### PR TITLE
Initial implementation of Expatistan's Fathead

### DIFF
--- a/expatistan/fetch.sh
+++ b/expatistan/fetch.sh
@@ -1,0 +1,3 @@
+mkdir -p data
+cd data
+curl -sO http://www.expatistan.com/api/zeroclickinfo.dump

--- a/expatistan/meta.txt
+++ b/expatistan/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Expatistan
+
+# This is the base domain where the source pages are located.
+Domain: www.expatistan.com
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: Cost of Living
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: cost of living, prices in, price comparison

--- a/expatistan/parse.rb
+++ b/expatistan/parse.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/ruby
+
+def single_city(tokens)
+	[
+    tokens[1], # title ; name of the city, in English. tokens[2] contains the name of the city, in the local language.
+    'A', # type
+    nil, # redirect
+    nil, # otheruses
+    nil, # categories
+    nil, # references
+    nil, # see also
+    nil, # further reading
+    nil, # external links
+    nil, # disambiguation
+    "[[Image:http://www.expatistan.com/images/expatistan_icon_97x97.png]]", # images
+    "#{tokens[1]} has a cost of living index of #{tokens[3]} in Expatistan's scale (Prague, Czech Republic = 100)", # abstract
+    tokens[4], # source url
+  ].join("\t")
+end
+
+def comparison_abstract(city_1,city_2,difference)
+	if difference > 0.96 && difference < 1.04
+		readable_difference = "about the same as"
+  else
+		rounded_difference = ((1 - difference).abs * 100).round
+		readable_difference = "#{rounded_difference}% #{difference > 1 ? 'more expensive' : 'cheaper'} than"
+  end
+	"Cost of living in #{city_1} is #{readable_difference} in #{city_2}."
+end
+
+def comparison(tokens)
+	[
+    "#{tokens[1]} ; #{tokens[3]}", # title ; names of the cities whose cost of living is compared. tokens[2] and tokens[4] contain the local name of the cities.
+    'A', # type
+    nil, # redirect
+    nil, # otheruses
+    nil, # categories
+    nil, # references
+    nil, # see also
+    nil, # further reading
+    nil, # external links
+    nil, # disambiguation
+    "[[Image:http://www.expatistan.com/images/expatistan_icon_97x97.png]]", # images
+    comparison_abstract(tokens[1],tokens[3],tokens[5].to_f), # abstract
+    tokens[6], # source url
+  ].join("\t")
+end
+
+File.open("./data/zeroclickinfo.dump", "r") do |dump|
+	while (line = dump.gets)
+		tokens = line.split("\t")
+		puts case tokens[0]
+		  when "single_city" then single_city(tokens)
+		  when "comparison" then comparison(tokens)
+			else raise "Unkown entry - [#{tokens[0]}] : #{line}"
+		end
+  end
+end

--- a/expatistan/parse.sh
+++ b/expatistan/parse.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ruby parse.rb


### PR DESCRIPTION
I've asked using open@duckduckgo.com how to include Expatistan's cost of living data into your zero-click results. Following the indications of Torsten Raudssus here is a pull request for it. Just to give a bit of context, expatistan.com is a crowdsourced cost of living index that I've created and that I run. It currently holds reliable information for 143 different cities around the world (and not so reliable info for 700 more). I think it would be great to have this information accumulated on cost of living show up in duckduckgo 0-click results for queries like "cost of living in Paris" or "how expensive is London" or "cost of living in New York compared to San Francisco". The dump I'm creating for Fathead will contain data only for the cities with reliable information.

I've used ruby to implement the parser, since that's what I am most familiar with. The parser is very simple, though, so I could port it easily to python or node.js is necessary.

I am not sure how the fetcher should work. I've based this initial one in some other one available in the repo (the c++ one, I think). I'll be happy to change it too if necessary (if I get indications from you guys on how it should actually behave, and where it should save the fetched dump).

The output of the parser may also not be totally correct, specially the first field ("title"). I assumed that this field would be the 'keyword' that would be used to match a search query with one of the entries in the parsed dump. Therefore, I've placed there the name of the city (or cities) for each entry, in English. In the case of comparisons of two cities, I've put in that first field the name of both cities, separated by semicolon. I don't know what convention do you have for multi-term "title". Again, I'll be happy to change it to whatever you guys use.
