### PR TITLE
Add redirects for raw numbers.

### DIFF
--- a/xep/output.txt
+++ b/xep/output.txt
@@ -1,313 +1,626 @@
-XEP-0170	A										This document specifies a recommended order for negotiation of XMPP stream features.	http://xmpp.org/extensions/xep-0170.html
-XEP-0226	A										This document specifies best practices for generating and handling extended content in XMPP message stanzas.	http://xmpp.org/extensions/xep-0226.html
-XEP-0125	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0125.html
-XEP-0229	A										This document specifies how to use the LZW algorithm in XML stream compression.	http://xmpp.org/extensions/xep-0229.html
-XEP-0285	A										This document provides a technical specification for Encapsulating Digital Signatures       in the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0285.html
-XEP-0286	A										This document provides background information for XMPP implementors concerned with mobile devices operating in a cellular network such as 3G.	http://xmpp.org/extensions/xep-0286.html
-XEP-0259	A									[[Image:http://xmpp.org/images/xmpp.png]]	In servers that deliver messages intended for the bare JID to   all resources, the resource that claims a conversation notifies all   of the other resources of that claim.	http://xmpp.org/extensions/xep-0259.html
-XEP-0174	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines how to communicate over local or wide-area networks using the principles of zero-configuration networking for endpoint discovery and the syntax of XML streams and XMPP messaging for real-time communication. This method uses DNS-based Service Discovery and Multicast DNS to discover entities that support the protocol, including their IP addresses and preferred ports. Any two entities can then negotiate a serverless connection using XML streams in order to exchange XMPP message and IQ stanzas.	http://xmpp.org/extensions/xep-0174.html
-XEP-0057	A										This document defines a way to handle extended roster items.	http://xmpp.org/extensions/xep-0057.html
-XEP-0217	A										This document specifies a minimal subset of the Encrypted Session Negotiation protocol sufficent for negotiating an end-to-end encrypted session.	http://xmpp.org/extensions/xep-0217.html
-XEP-0030	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for discovering information about other XMPP entities. Two kinds of information can be discovered: (1) the identity and capabilities of an entity, including the protocols and features it supports; and (2) the items associated with an entity, such as the list of rooms hosted at a multi-user chat service.	http://xmpp.org/extensions/xep-0030.html
-XEP-0220	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines the Server Dialback protocol, which is used between XMPP servers to provide identity verification. Server Dialback uses the Domain Name System (DNS) as the basis for verifying identity; the basic approach is that when a receiving server accepts a server-to-server connection from an originating server, it does not process traffic over the connection until it has verified a key with an authoritative server for the domain asserted by the originating server. Although Server Dialback does not provide strong authentication or trusted federation and although it is subject to DNS poisoning attacks, it has effectively prevented most instances of address spoofing on the XMPP network since its development in the year 2000.	http://xmpp.org/extensions/xep-0220.html
-XEP-0242	A										This document defines XMPP client compliance levels for 2009.	http://xmpp.org/extensions/xep-0242.html
-XEP-0293	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP extension to negotiate   the use of the Extended RTP Profile for Real-time Transport Control   Protocol (RTCP)-Based Feedback (RTP/AVPF) with Jingle RTP   sessions	http://xmpp.org/extensions/xep-0293.html
-XEP-0313	A										This document defines a protocol to query and control and archive of messages stored on a server.	http://xmpp.org/extensions/xep-0313.html
-XEP-0042	A										A protocol for enabling uni-directional multicast data transfers out of band.	http://xmpp.org/extensions/xep-0042.html
-XEP-0188	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document describes the cryptographic design that underpins the XMPP protocol extensions Encrypted Session Negotiation, Offline Encrypted Sessions and Stanza Encryption.	http://xmpp.org/extensions/xep-0188.html
-XEP-0206	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines how the Bidirectional-streams Over Synchronous HTTP (BOSH) technology can be used to transport XMPP stanzas. The result is an HTTP binding for XMPP communications that is useful in situations where a device or client is unable to maintain a long-lived TCP connection to an XMPP server.	http://xmpp.org/extensions/xep-0206.html
-XEP-0141	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a backwards-compatible extension to the XMPP Data Forms protocol that enables an application to specify form layouts, including the layout of form fields, sections within pages, and subsections within sections.	http://xmpp.org/extensions/xep-0141.html
-XEP-0264	A										This specification defines a way for a client supply a preview image for a file transfer.	http://xmpp.org/extensions/xep-0264.html
-XEP-0055	A										This specification provides canonical documentation of the jabber:iq:search namespace currently in use within the Jabber community.	http://xmpp.org/extensions/xep-0055.html
-XEP-0238	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides detailed protocol flows for the establishment of communication between domains that provide XMPP services, including permutations for a wide variety of possible federation policies.	http://xmpp.org/extensions/xep-0238.html
-XEP-0081	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies a MIME type for launching a Jabber client as a helper application from most modern web browsers, and for completing basic use cases once the client is launched.	http://xmpp.org/extensions/xep-0081.html
-XEP-0269	A										This specification describes methods for exchanging early media in the context of Jingle RTP sessions.	http://xmpp.org/extensions/xep-0269.html
-XEP-0200	A										This document specifies an XMPP protocol extension for session-based stanza encryption.	http://xmpp.org/extensions/xep-0200.html
-XEP-0087	A										A common method to initiate a stream with meta information	http://xmpp.org/extensions/xep-0087.html
-XEP-0218	A										This document provides guidelines to client and library developers for bootstrapping implementation of the encrypted sessions technology.	http://xmpp.org/extensions/xep-0218.html
-XEP-0098	A										Standardizes "private" XML data storage.	http://xmpp.org/extensions/xep-0098.html
-XEP-0189	A										This specification defines a method by which an entity can publish its public keys over XMPP.	http://xmpp.org/extensions/xep-0189.html
-XEP-0005	A										This is the official list and summary information of the Jabber Interest Groups.	http://xmpp.org/extensions/xep-0005.html
-XEP-0157	A										This document defines a method for specifying contact addresses related to an XMPP service.	http://xmpp.org/extensions/xep-0157.html
-XEP-0093	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides canonical documentation of the jabber:x:roster namespace historically used within the Jabber community. NOTE WELL: This specification has been superseded by XEP-0144.	http://xmpp.org/extensions/xep-0093.html
-XEP-0065	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for establishing an out-of-band bytestream between any two XMPP users, mainly for the purpose of file transfer. The bytestream can be either direct (peer-to-peer) or mediated (though a special-purpose proxy server). The typical transport protocol used is TCP, although UDP can optionally be supported as well.	http://xmpp.org/extensions/xep-0065.html
-XEP-0298	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP extension for tightly coupled       conference calls. It allows users who participate in multiparty Jingle       calls via a focus agent (mixer) to retrieve information and receive       notifications about the state of the call and the other participants.       This extension is also meant to provide a straightforward way of       connecting SIP and XMPP clients to the same conference room.     	http://xmpp.org/extensions/xep-0298.html
-XEP-0256	A										This specification defines a way to use the Last Activity extension in XMPP presence notifications.	http://xmpp.org/extensions/xep-0256.html
-XEP-0248	A										This specification defines the nature and handling of collection nodes in the XMPP publish-subscribe extension.	http://xmpp.org/extensions/xep-0248.html
-XEP-0303	A										This specification defines a method for commenting.	http://xmpp.org/extensions/xep-0303.html
-XEP-0205	A										This document recommends a number of practices that can help discourage denial of service attacks on XMPP-based networks.	http://xmpp.org/extensions/xep-0205.html
-XEP-0029	A										This document defines the exact nature of a Jabber Identifier (JID). 	http://xmpp.org/extensions/xep-0029.html
-XEP-0299	A										This document describes implementation considerations related to video codecs for use in Jingle RTP sessions.	http://xmpp.org/extensions/xep-0299.html
-XEP-0076	A										This document defines an XMPP protocol extension for flagging malicious stanzas.	http://xmpp.org/extensions/xep-0076.html
-XEP-0163	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines semantics for using the XMPP publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account. This profile of pubsub therefore enables a standard XMPP user account to function as a virtual pubsub service, easing the discovery of syndicated data and event notifications associated with such an account.	http://xmpp.org/extensions/xep-0163.html
-XEP-0187	A										This document specifies an end-to-end encryption protocol for offline XMPP communication sessions.	http://xmpp.org/extensions/xep-0187.html
-XEP-0061	A										A simplistic mechanism for shared notes, modeled after common stickie note applications.	http://xmpp.org/extensions/xep-0061.html
-XEP-0023	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification documents an historical protocol that was used to specify expiration dates for messages; this protocol has been deprecated in favor of XEP-0079: Advanced Message Processing.	http://xmpp.org/extensions/xep-0023.html
 XEP-0001	A										This document defines the standards process followed by the XMPP Standards Foundation.	http://xmpp.org/extensions/xep-0001.html
-XEP-0301	A										This is a specification for real-time text transmitted in-band over an XMPP session.	http://xmpp.org/extensions/xep-0301.html
-XEP-0101	A										This document defines a protocol for authenticating HTTP requests using Jabber Tickets.	http://xmpp.org/extensions/xep-0101.html
-XEP-0179	A										This document defines a Jingle transport method that results in using the Inter-Asterisk eXchange protocol (IAX) for the final communication.	http://xmpp.org/extensions/xep-0179.html
-XEP-0075	A									[[Image:http://xmpp.org/images/xmpp.png]]	The Jabber Object Access Protocol, or JOAP, defines a       mechanism for creating Jabber-accessible object servers, and       manipulating objects provided by those servers. It is intended       for development of business applications with Jabber.	http://xmpp.org/extensions/xep-0075.html
-XEP-0277	A										This specification defines a method for microblogging over XMPP.	http://xmpp.org/extensions/xep-0277.html
-XEP-0004	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for data forms that can be used in workflows such as service configuration as well as for application-specific data description and reporting. The protocol includes lightweight semantics for forms processing (such as request, response, submit, and cancel), defines several common field types (boolean, list options with single or multiple choice, text with single line or multiple lines, single or multiple JabberIDs, hidden fields, etc.), provides extensibility for future data types, and can be embedded in a wide range of applications. The protocol is not intended to provide complete forms-processing functionality as is provided in the W3C XForms technology, but instead provides a basic subset of such functionality for use by XMPP entities.	http://xmpp.org/extensions/xep-0004.html
-XEP-0139	A										This document proposes the formation of a Special Interest Group devoted to the analysis of security threats related to Jabber technologies.	http://xmpp.org/extensions/xep-0139.html
-XEP-0235	A										This specification defines an XMPP extension for delegating access to protected resources over XMPP, using the OAuth protocol.	http://xmpp.org/extensions/xep-0235.html
-XEP-0090	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides historical documentation of the legacy jabber:iq:time namespace, which has been deprecated in favor the urn:xmpp:time namespace defined in XEP-0202.	http://xmpp.org/extensions/xep-0090.html
-XEP-0233	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a method by a connecting client can learn the domain-based service name of a Kerberos acceptor principal for SASL authentication using the GSSAPI mechanism.	http://xmpp.org/extensions/xep-0233.html
-XEP-0181	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XML format for encapsulating Dual Tone Multi-Frequency (DTMF) events in informational messages sent within the context of Jingle audio sessions, e.g. to be used in the context of Interactive Voice Response (IVR) systems. Note well that this format is not to be used in the context of RTP sessions, where native RTP methods are to be used instead.	http://xmpp.org/extensions/xep-0181.html
-XEP-0135	A										This document specifies a simple extension to existing protocols for file sharing over Jabber/XMPP.	http://xmpp.org/extensions/xep-0135.html
-XEP-0079	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables entities to request, and servers to perform, advanced processing of XMPP message stanzas, including reliable data transport, time-sensitive delivery, and expiration of transient messages.	http://xmpp.org/extensions/xep-0079.html
-XEP-0176	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending media data using raw datagram associations via the User Datagram Protocol (UDP). This transport method is negotiated via the Interactive Connectivity Establishment (ICE) methodology, which provides robust NAT traversal for media traffic.	http://xmpp.org/extensions/xep-0176.html
-XEP-0191	A										This document specifies an XMPP protocol extension for communications blocking that is intended to be simpler than privacy lists (XEP-0016).	http://xmpp.org/extensions/xep-0191.html
-XEP-0302	A										This document defines XMPP protocol compliance levels for 2012.	http://xmpp.org/extensions/xep-0302.html
-XEP-0282	A										Multi-User Chats, distributed over several nodes in the XMPP network, using a master/slave architecture	http://xmpp.org/extensions/xep-0282.html
-XEP-0103	A										This document defines a structure for providing information about an Uniform Resource Locator (URL), and a protocol signaling retrieval states.	http://xmpp.org/extensions/xep-0103.html
-XEP-0199	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for sending application-level pings over XML streams. Such pings can be sent from a client to a server, from one server to another, or end-to-end.	http://xmpp.org/extensions/xep-0199.html
-XEP-0146	A										This document specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.	http://xmpp.org/extensions/xep-0146.html
-XEP-0224	A										This document defines an XMPP protocol extension for getting the attention of another user.	http://xmpp.org/extensions/xep-0224.html
-XEP-0267	A										This specification defines a convention for presence subscriptions between XMPP servers.	http://xmpp.org/extensions/xep-0267.html
-XEP-0294	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP extension to negotiate   the use of the use of RTP Header Extension as defined by RFC 5285   with Jingle RTP sessions	http://xmpp.org/extensions/xep-0294.html
-XEP-0122	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a backwards-compatible extension to the XMPP Data Forms protocol that enables applications to specify additional validation guidelines related to a form, such as validation of standard XML datatypes, application-specific datatypes, value ranges, and regular expressions.	http://xmpp.org/extensions/xep-0122.html
-XEP-0060	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for generic publish-subscribe functionality. The protocol enables XMPP entities to create nodes (topics) at a pubsub service and publish information at those nodes; an event notification (with or without payload) is then broadcasted to all entities that have subscribed to the node. Pubsub therefore adheres to the classic Observer design pattern and can serve as the foundation for a wide variety of applications, including news feeds, content syndication, rich presence, geolocation, workflow systems, network management systems, and any other application that requires event notifications.	http://xmpp.org/extensions/xep-0060.html
-XEP-0231	A										This specification defines an XMPP protocol extension for including or referring to small bits of binary data in an XML stanza.	http://xmpp.org/extensions/xep-0231.html
-XEP-0106	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a mechanism that enables the display in Jabber Identifiers (JIDs) of characters disallowed by the Nodeprep profile of stringprep. Although these characters -- space, double quote, ampersand, single quote, forward slash, colon, less than, greater than, and at-sign -- cannot be included in XMPP node identifiers, JID Escaping provides a native XMPP escaping mechanism for these characters so that the displayed version of a Jabber Identifier can appear to include these characters. This mechanism can also be used to translate non-XMPP addreses into XMPP syntax, for example when gatewaying between XMPP and a non-XMPP communications technology such as email.	http://xmpp.org/extensions/xep-0106.html
-XEP-0069	A										A proposal to form a SIG devoted to issues related to protocol compliance.	http://xmpp.org/extensions/xep-0069.html
-XEP-0162	A										This document specifies best practices for roster and subscription management in Jabber/XMPP clients.	http://xmpp.org/extensions/xep-0162.html
-XEP-0007	A										A proposal for a Jabber Interest Group that will discuss the protocol for implementing many-to-many communications.	http://xmpp.org/extensions/xep-0007.html
-XEP-0283	A										This document defines an XMPP protocol extension that enables a user to inform its contacts about a change in JID.	http://xmpp.org/extensions/xep-0283.html
-XEP-0297	A										This document defines a protocol to forward a message from one entity to another.	http://xmpp.org/extensions/xep-0297.html
-XEP-0016	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for enabling or disabling communication with other entities on a network. The protocol, which was first standardized in Section 10 of RFC 3921, can be used to block communication with unknown or undesirable entities. Blocking can be based on Jabber Identifier, subscription state, or roster group. The blocked stanzas can be messages, IQs, inbound or outbound presence stanzas, or all stanzas. The protocol also enables an entity to create, modify, or delete its privacy lists, apply different lists to different connected resources, define a default list, and decline the use of any privacy list during a particular communications session.	http://xmpp.org/extensions/xep-0016.html
-XEP-0045	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for multi-user text chat, whereby multiple XMPP users can exchange messages in the context of a room or channel, similar to Internet Relay Chat (IRC). In addition to standard chatroom features such as room topics and invitations, the protocol defines a strong room control model, including the ability to kick and ban users, to name room moderators and administrators, to require membership or passwords in order to join the room, etc.	http://xmpp.org/extensions/xep-0045.html
-XEP-0068	A										This document specifies how to standardize field variables used in the context of jabber:x:data forms.	http://xmpp.org/extensions/xep-0068.html
-XEP-0070	A										This specification defines an XMPP protocol extension that enables verification of an HTTP request via XMPP.	http://xmpp.org/extensions/xep-0070.html
-XEP-0272	A									[[Image:http://xmpp.org/images/xmpp.png]]	     This specification defines an XMPP protocol extension for initiating and     managing multiparty voice and video conferences within an XMPP MUC   	http://xmpp.org/extensions/xep-0272.html
-XEP-0295	A										This specification defines an alternative JSON encoding for XMPP stanzas and other elements.	http://xmpp.org/extensions/xep-0295.html
-XEP-0138	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for negotiating compression of XML streams, especially in situations where standard TLS compression cannot be negotiated. The protocol provides a modular framework that can accommodate a wide range of compression algorithms; the ZLIB compression algorithm is mandatory-to-implement, but implementations may support other algorithms in addition.	http://xmpp.org/extensions/xep-0138.html
-XEP-0137	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables an XMPP entity to advertise the fact that it is willing accept a particular Stream Initiation request. The protocol is used mainly to inform other entities that a particular file is available for transfer via the File Transfer protocol defined in XEP-0096.	http://xmpp.org/extensions/xep-0137.html
-XEP-0132	A										This document defines an XMPP protocol extension that enables probing for presence via physical rather than electronic means.	http://xmpp.org/extensions/xep-0132.html
-XEP-0180	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for negotiating a video chat or other video session. The application type uses the Real-time Transport Protocol (RTP) for the underlying media exchange and provides a straightforward mapping to Session Description Protocol (SDP) for interworking with SIP media endpoints. 	http://xmpp.org/extensions/xep-0180.html
-XEP-0243	A										This document defines XMPP server compliance levels for 2009.	http://xmpp.org/extensions/xep-0243.html
-XEP-0072	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines methods for transporting SOAP messages over XMPP. Although the protocol supports only the request-response message exchange pattern, the protocol is formally defined as a SOAP Protocol Binding in accordance with version 1.2 of the W3C SOAP specification. In addition, a WSDL definition is defined for the purpose of advertising the availability of this protocol binding.	http://xmpp.org/extensions/xep-0072.html
-XEP-0147	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.	http://xmpp.org/extensions/xep-0147.html
-XEP-0145	A										This document defines a protocol for making annotations about roster items and other entities.	http://xmpp.org/extensions/xep-0145.html
-XEP-0062	A										A framework for packet filtering rules.	http://xmpp.org/extensions/xep-0062.html
-XEP-0223	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines best practices for using the XMPP publish-subscribe extension to persistently store private information such as bookmarks and client configuration options.	http://xmpp.org/extensions/xep-0223.html
-XEP-0112	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a protocol for communicating information about the current physical location of a Jabber entity. NOTE WELL: The protocol defined herein has been folded into XEP-0080.	http://xmpp.org/extensions/xep-0112.html
-XEP-0136	A										This document defines mechanisms and preferences for the server-side archiving and retrieval of XMPP messages.	http://xmpp.org/extensions/xep-0136.html
-XEP-0306	A										This document defines an extensible format for status conditions in Multi-User Chat, similar to the error format used in the core of XMPP.	http://xmpp.org/extensions/xep-0306.html
-XEP-0012	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for communicating information about the last activity associated with an XMPP entity. It is typically used by an IM client to retrieve the most recent presence information from an offline contact by sending a last activity request to the server that hosts the account controlled by the contact.	http://xmpp.org/extensions/xep-0012.html
-XEP-0230	A										This specification defines a method for requesting and receiving notifications regarding XMPP service discovery items.	http://xmpp.org/extensions/xep-0230.html
-XEP-0214	A									[[Image:http://xmpp.org/images/xmpp.png]]	While a protocol has been described for initiating a file transfer from one user to another, there is not yet a defined way for users to designate a set of files as available for retrieval by other users of their choosing. This extension defines a common syntax for this purpose which is based on PubSub Collections.	http://xmpp.org/extensions/xep-0214.html
-XEP-0257	A										This specification defines a method to manage client certificates that can be used with SASL External to allow clients to log in without a password.	http://xmpp.org/extensions/xep-0257.html
-XEP-0153	A										This document provides historical documentation of a vCard-based protocol for exchanging user avatars.	http://xmpp.org/extensions/xep-0153.html
-XEP-0161	A										This document specifies an XMPP protocol extension for reporting abusive XMPP stanzas. NOTE: This specification has been superseded by XEP-0268.	http://xmpp.org/extensions/xep-0161.html
-XEP-0222	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines best practices for using the XMPP publish-subscribe extension to persistently store semi-public data objects such as public keys and personal profiles.	http://xmpp.org/extensions/xep-0222.html
-XEP-0310	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document provides a protocol using which a server is able to provide information to clients indicating that previously received presence data may be stale.	http://xmpp.org/extensions/xep-0310.html
-XEP-0133	A										This document defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.	http://xmpp.org/extensions/xep-0133.html
-XEP-0184	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for message delivery receipts, whereby the sender of a message can request notification that the message has been delivered to a client controlled by the intended recipient.	http://xmpp.org/extensions/xep-0184.html
-XEP-0177	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending media data using raw datagram associations via the User Datagram Protocol (UDP). This simple transport method does not provide NAT traversal, and the ICE-UDP transport method should be used if NAT traversal is required.	http://xmpp.org/extensions/xep-0177.html
-XEP-0018	A										Documentation of invisible presence.	http://xmpp.org/extensions/xep-0018.html
-XEP-0151	A										This document proposes extensions to the Jabber groupchat protocol for virtual presence on Web pages.	http://xmpp.org/extensions/xep-0151.html
-XEP-0043	A										Expose RDBM systems directly to the jabber network	http://xmpp.org/extensions/xep-0043.html
-XEP-0054	A										This specification provides canonical documentation of the vCard-XML format currently in use within the Jabber community.	http://xmpp.org/extensions/xep-0054.html
-XEP-0198	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for active management of an XML stream between two XMPP entities, including features for stanza acknowledgements and stream resumption.	http://xmpp.org/extensions/xep-0198.html
-XEP-0149	A										This document defines a method to specify the valid time periods for states, events, and activities communicated via Jabber/XMPP protocols.	http://xmpp.org/extensions/xep-0149.html
-XEP-0240	A										This specification defines a recommended best practice for linking to JabberIDs from documents hosted on the World Wide Web.	http://xmpp.org/extensions/xep-0240.html
-XEP-0091	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides historical documentation of the legacy jabber:x:delay namespace, which has been deprecated in favor the urn:xmpp:delay namespace defined in XEP-0203.	http://xmpp.org/extensions/xep-0091.html
-XEP-0309	A										This specification shows how to combine and extend a number of existing XMPP protocols for improved sharing of information about XMPP servers.	http://xmpp.org/extensions/xep-0309.html
-XEP-0232	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies an extended data format whereby XMPP service discovery responses can include detailed information about the software application that powers a given XMPP entity for includion in service discovery responses.	http://xmpp.org/extensions/xep-0232.html
-XEP-0274	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document discusses considerations for the design of Digital Signatures in XMPP,       including use cases and requirements. The document also discusses various ways XML Digital       Signatures could be used in XMPP.	http://xmpp.org/extensions/xep-0274.html
-XEP-0049	A										This specification provides canonical documentation of the 'jabber:iq:private' namespace currently in common usage.	http://xmpp.org/extensions/xep-0049.html
-XEP-0102	A										Security extensions for Jabber/XMPP.	http://xmpp.org/extensions/xep-0102.html
-XEP-0159	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables clients to control how their servers may block spim that is addressed to them. It specifies a default privacy list fall-through action.	http://xmpp.org/extensions/xep-0159.html
-XEP-0304	A										This specification defines a method for negotiating how to send keepalives in XMPP.	http://xmpp.org/extensions/xep-0304.html
-XEP-0092	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for retrieving information about the software application associated with an XMPP entity. The protocol enables one entity to explicitly query another entity, where the response can include the name of the software application, the version of the software application, and the operating system on which the application is running.	http://xmpp.org/extensions/xep-0092.html
-XEP-0028	A										This document was removed from the XSF website and source control at the request of the author.	http://xmpp.org/extensions/xep-0028.html
-XEP-0011	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a way to describe information about Jabber entities and the relationships between entities. Note: This document is superseded by XEP-0030: Service Discovery.	http://xmpp.org/extensions/xep-0011.html
-XEP-0165	A										This document recommends best practices to discourage mimicking of Jabber IDs.	http://xmpp.org/extensions/xep-0165.html
-XEP-0190	A										This document specifies a best practice for closing an XML stream that is perceived to be idle.	http://xmpp.org/extensions/xep-0190.html
-XEP-0115	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for broadcasting and dynamically discovering client, device, or generic entity capabilities. In order to minimize network impact, the transport mechanism is standard XMPP presence broadcast (thus forestalling the need for polling related to service discovery data), the capabilities information can be cached either within a session or across sessions, and the format has been kept as small as possible.	http://xmpp.org/extensions/xep-0115.html
-XEP-0300	A										This document provides recommendations for the use of cryptographic hash functions in XMPP protocol extensions.	http://xmpp.org/extensions/xep-0300.html
-XEP-0168	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension to indicate the presence priority of XMPP resources for applications other than standard XMPP messaging.	http://xmpp.org/extensions/xep-0168.html
-XEP-0144	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for exchanging contact list items, including the ability to suggest whether the item is to be added, deleted, or modified in the contact list of the recipient, as well as the suggested roster group for the item.	http://xmpp.org/extensions/xep-0144.html
-XEP-0041	A										Protocol for linking a bytestream between two Jabber entities.	http://xmpp.org/extensions/xep-0041.html
-XEP-0120	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0120.html
-XEP-0019	A										This document proposes to streamline the existing Special Interest Groups (SIGs).	http://xmpp.org/extensions/xep-0019.html
-XEP-0270	A										This document defines XMPP protocol compliance levels for 2010.	http://xmpp.org/extensions/xep-0270.html
-XEP-0234	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for transferring files between two entities. The protocol provides a modular framework that enables the exchange of information about the file to be transferred as well as the negotiation of parameters such as the transport to be used.	http://xmpp.org/extensions/xep-0234.html
-XEP-0239	A										This specification defines Binary XMPP, an obviously superior representation of the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0239.html
-XEP-0074	A										A simple protocol for querying information for permissions.	http://xmpp.org/extensions/xep-0074.html
-XEP-0263	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines best practices and protocol modifications that will reduce the energy consumption of XMPP systems and thereby help to save the planet.	http://xmpp.org/extensions/xep-0263.html
-XEP-0100	A										This document specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.	http://xmpp.org/extensions/xep-0100.html
-XEP-0126	A										This specification defines best practices regarding implementation of invisible presence by means of XMPP privacy lists.	http://xmpp.org/extensions/xep-0126.html
-XEP-0117	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications. Note: This protocol suite has been obsoleted by XEP-0213 and XEP-0216.	http://xmpp.org/extensions/xep-0117.html
-XEP-0024	A										A publish-subscribe protocol for Jabber.	http://xmpp.org/extensions/xep-0024.html
-XEP-0209	A										This document specifies an XMPP protocol extension for defining metacontacts and grouping member JIDs.	http://xmpp.org/extensions/xep-0209.html
-XEP-0036	A										A proposal for the subscribe half of a publish-subscribe protocol within Jabber.	http://xmpp.org/extensions/xep-0036.html
-XEP-0013	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for flexible, POP3-like handling of offline messages. The protocol enables a connecting client to retrieve its offline messages on login in a controlled fashion, without receiving a flood of messages. Messages can also be left on the server for later retrieval.	http://xmpp.org/extensions/xep-0013.html
-XEP-0006	A										A proposal for a more powerful and extensible protocol for the management of personal information within Jabber.	http://xmpp.org/extensions/xep-0006.html
-XEP-0037	A										A proposal for proxy support in Jabber.	http://xmpp.org/extensions/xep-0037.html
-XEP-0215	A										This document specifies an XMPP protocol extension for discovering services external to the XMPP network.	http://xmpp.org/extensions/xep-0215.html
-XEP-0111	A										This document defined a SIP-compatible transport for initiating and negotiating sessions using SDP over XMPP.	http://xmpp.org/extensions/xep-0111.html
-XEP-0084	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for exchanging user avatars, which are small images or icons associated with human users. The protocol specifies payload formats for both avatar metadata and the image data itself. The payload formats are typically transported using the personal eventing profile of XMPP publish-subscribe as specified in XEP-0163.	http://xmpp.org/extensions/xep-0084.html
-XEP-0048	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XML data format for use by XMPP clients in storing bookmarks to mult-user chatrooms and web pages. The chatroom bookmarking function includes the ability to auto-join rooms on login.	http://xmpp.org/extensions/xep-0048.html
-XEP-0025	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables access to a Jabber server from behind firewalls which do not allow outgoing sockets on port 5222, via HTTP requests.	http://xmpp.org/extensions/xep-0025.html
-XEP-0143	A										This document provides information intended to assist authors of XMPP Extension Protocols.	http://xmpp.org/extensions/xep-0143.html
-XEP-0193	A										This document proposes improvements to the definition of resource binding for inclusion in the specification that supersedes RFC 3920.	http://xmpp.org/extensions/xep-0193.html
-XEP-0225	A										This document specifies a standards-track XMPP protocol extension that enables server components to connect to XMPP servers.	http://xmpp.org/extensions/xep-0225.html
-XEP-0307	A										This specification defines an XMPP protocol extension for requesting a unique room ID from a multi-user chat service.	http://xmpp.org/extensions/xep-0307.html
-XEP-0311	A										This document provides a protocol that can be used for limiting the amount of presence history needed when rejoining a MUC room.	http://xmpp.org/extensions/xep-0311.html
-XEP-0284	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a protocol that enables two or more endpoints to collaboratively edit an XML object. The protocol is intended for use mainly over the Extensible Messaging and Presence Protocol (XMPP), either by existing instant messaging clients or by specialized editing clients. However, the protocol could also be used over a direct TCP connection rather than over XMPP.	http://xmpp.org/extensions/xep-0284.html
-XEP-0046	A										Direct TCP connection between two Jabber entities.	http://xmpp.org/extensions/xep-0046.html
-XEP-0108	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a payload format for communicating information about user activities, such as whether a person is currently working, travelling, or relaxing. The payload format is typically transported using the personal eventing protocol, a profile of XMPP publish-subscribe specified in XEP-0163.	http://xmpp.org/extensions/xep-0108.html
-XEP-0171	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for providing language translation facilities over XMPP. It supports human, machine, client-based, and server-based translations.	http://xmpp.org/extensions/xep-0171.html
-XEP-0201	A										This specification defines recommended handling of XMPP message threads.	http://xmpp.org/extensions/xep-0201.html
-XEP-0280	A										In order to keep all IM clients for a user engaged in a conversation, outbound messages are carbon-copied to all interested resources.	http://xmpp.org/extensions/xep-0280.html
-XEP-0097	A										A simple mechanism to transport iCal data over the jabber protocol	http://xmpp.org/extensions/xep-0097.html
-XEP-0095	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for initiating a data stream between any two XMPP entities. The protocol includes the ability to include metadata about the stream and provides a pluggable framework so that various profiles of stream initiation can be defined for particular use cases (such as file transfer).	http://xmpp.org/extensions/xep-0095.html
-XEP-0085	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for communicating the status of a user in a chat session, thus indicating whether a chat partner is actively engaged in the chat, composing a message, temporarily paused, inactive, or gone. The protocol can be used in the context of a one-to-one chat session or a multi-user chat room.	http://xmpp.org/extensions/xep-0085.html
-XEP-0276	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables a user to send directed presence with a request for the target to also share presence information for the duration of a communications session.	http://xmpp.org/extensions/xep-0276.html
-XEP-0150	A										This document defines best practices for the use of Entity Tags in XMPP extensions.	http://xmpp.org/extensions/xep-0150.html
-XEP-0066	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines two XMPP protocol extensions for communicating URIs, one for use in XMPP message stanzas and the other for use in a structured request-response interaction via XMPP IQ stanzas. Among other things, this enables one entity to inform another entity about a file that is available at an HTTP URL.	http://xmpp.org/extensions/xep-0066.html
-XEP-0212	A										This document defines the XMPP Basic Server 2008 compliance level.	http://xmpp.org/extensions/xep-0212.html
-XEP-0010	A										A proposal to form a SIG to develop a protocol for whiteboarding over Jabber.	http://xmpp.org/extensions/xep-0010.html
-XEP-0213	A										This document defines the XMPP Intermediate IM Client 2008 compliance level.	http://xmpp.org/extensions/xep-0213.html
-XEP-0251	A										This specification defines an extension to XMPP Jingle for transferring a session (such as a voice call) from one person to another.	http://xmpp.org/extensions/xep-0251.html
-XEP-0246	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines methods for communicating via end-to-end XML streams over a logical or physical connection that provides a reliable transport between two endpoints.	http://xmpp.org/extensions/xep-0246.html
-XEP-0033	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables entities to include RFC822-style address headers within XMPP stanzas in order to specify multiple recipients or sub-addresses.	http://xmpp.org/extensions/xep-0033.html
-XEP-0265	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines how to send parts of an XML stream over a direct connection between peers. This allows to send large stanzas or binary data without blocking the XML stream for other stanzas.	http://xmpp.org/extensions/xep-0265.html
-XEP-0080	A										This specification defines an XMPP protocol extension for communicating information about the current geographical or physical location of an entity.	http://xmpp.org/extensions/xep-0080.html
-XEP-0123	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0123.html
-XEP-0287	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables XMPP entities to interact with spim filters by marking unsolicited or suspicious XMPP stanzas.	http://xmpp.org/extensions/xep-0287.html
-XEP-0128	A										This document specifies best practices for including extended information in Service Discovery results.	http://xmpp.org/extensions/xep-0128.html
-XEP-0040	A										Note: This proposal has been superseded by XEP-0060; please refer to that document for the successor protocol.	http://xmpp.org/extensions/xep-0040.html
-XEP-0127	A										This document specifies a method for sending Common Alerting Protocol (CAP) data over XMPP.	http://xmpp.org/extensions/xep-0127.html
-XEP-0052	A										A protocol for transferring a file between two Jabber IDs.	http://xmpp.org/extensions/xep-0052.html
-XEP-0296	A										This document specifies best practices to be followed by Jabber/XMPP clients about when to lock into, and unlock away from, resources.	http://xmpp.org/extensions/xep-0296.html
-XEP-0249	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a method for inviting a contact to a multi-user chat room directly, instead of sending the invitation through the chat room.	http://xmpp.org/extensions/xep-0249.html
-XEP-0022	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension used to request and respond to events relating to the delivery, display, and composition of messages. Note: This specification has been obsoleted in favor of XEP-0085 and XEP-0184.	http://xmpp.org/extensions/xep-0022.html
-XEP-0291	A										This specification defines an approach for users to delegate certain services (e.g. pubsub) to alternative JIDs.	http://xmpp.org/extensions/xep-0291.html
-XEP-0195	A										This document defines an XMPP protocol extension for communicating information about the web pages a user visits.	http://xmpp.org/extensions/xep-0195.html
-XEP-0134	A										This document defines best practices for the intelligent design of Jabber protocols and other XMPP extensions.	http://xmpp.org/extensions/xep-0134.html
-XEP-0275	A										This specification defines an XMPP protocol extension for communicating the reputation of any entity on the network.	http://xmpp.org/extensions/xep-0275.html
-XEP-0077	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for in-band registration with XMPP-based instant messaging servers and other services hosted on an XMPP network (such as groupchat rooms and gateways to non-XMPP IM services). The protocol is extensible via use of data forms, thus enabling services to gather a wide range of information during the registration process. The protocol also supports in-band password changes and cancellation of an existing registration.	http://xmpp.org/extensions/xep-0077.html
-XEP-0110	A										A protocol for transport of generic maps (graphical displays of specific subsets of buddies).	http://xmpp.org/extensions/xep-0110.html
-XEP-0305	A										This document defines methods for speeding the process of connecting or reconnecting to an XMPP.	http://xmpp.org/extensions/xep-0305.html
-XEP-0281	A										This document defines methods for distributing Multi-User Chat (MUC) rooms across multiple chat services.	http://xmpp.org/extensions/xep-0281.html
-XEP-0178	A										This document specifies best practices for XMPP usage of the SASL EXTERNAL mechanism in the context of PKIX certificates.	http://xmpp.org/extensions/xep-0178.html
-XEP-0086	A										A mapping to enable legacy entities to correctly handle errors from XMPP-aware entities.	http://xmpp.org/extensions/xep-0086.html
-XEP-0003	A										This document defines a method for relaying media via proxies on the Jabber/XMPP network.	http://xmpp.org/extensions/xep-0003.html
-XEP-0156	A										This document defines a DNS TXT Resource Record format for use in discovering alternative methods of connecting to an XMPP server.	http://xmpp.org/extensions/xep-0156.html
-XEP-0083	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables nested sub-groups to exist within the Jabber roster, while retaining backwards compatibility and ensuring that the roster remains usable by all clients.	http://xmpp.org/extensions/xep-0083.html
-XEP-0288	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a protocol for using server-to-server connections in a bidirectional way such that stanzas are sent and received on the same TCP connection.	http://xmpp.org/extensions/xep-0288.html
-XEP-0020	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables two entities to mutually negotiate feature options, such as parameters related to a file transfer or a communications session.	http://xmpp.org/extensions/xep-0020.html
-XEP-0172	A										This specification defines a protocol for communicating user nicknames, either in XMPP presence subscription requests or in XMPP messages.	http://xmpp.org/extensions/xep-0172.html
-XEP-0258	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document describes the use of security labels in XMPP. The document specifies             how security label meta-data is carried in XMPP, when this meta-data should or should             not be provided, and how the meta-data is to be processed.	http://xmpp.org/extensions/xep-0258.html
-XEP-0194	A										This specification defines an XMPP protocol extension for communicating information about the chatrooms a user visits.	http://xmpp.org/extensions/xep-0194.html
-XEP-0063	A										A module that provides basic conditions and actions for packet filtering.	http://xmpp.org/extensions/xep-0063.html
-XEP-0021	A										A generic publish-and-subscribe service for Jabber.	http://xmpp.org/extensions/xep-0021.html
-XEP-0273	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables a client to exercise control over the XML stanzas it will receive from the server by instructing the server to intercept and filter inbound stanzas.	http://xmpp.org/extensions/xep-0273.html
-XEP-0118	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a payload format for communicating information about music to which a user is listening, including the title, track number, collection, performer, composer, length, and user rating. The payload format is typically transported using the personal eventing protocol, a profile of XMPP publish-subscribe specified in XEP-0163.	http://xmpp.org/extensions/xep-0118.html
-XEP-0121	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0121.html
-XEP-0290	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document provides a technical specification for Encapsulated Digital             Signatures in the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0290.html
-XEP-0129	A										This document specifies a method for completing file transfers between XMPP entities using WebDAV.	http://xmpp.org/extensions/xep-0129.html
-XEP-0116	A										This document specifies an XMPP protocol extension for negotiating an end-to-end encrypted session.	http://xmpp.org/extensions/xep-0116.html
-XEP-0089	A										A protocol for generic alerts (similar to .NET Alerts service).	http://xmpp.org/extensions/xep-0089.html
-XEP-0053	A										This document defines the roles and processes of the XMPP Registrar function within the XMPP Standards Foundation.	http://xmpp.org/extensions/xep-0053.html
-XEP-0279	A										This specification defines a simple XMPP extension that enables a client to discover its external IP address.	http://xmpp.org/extensions/xep-0279.html
-XEP-0312	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a publish-subscribe feature that enables a subscriber to automatically receive pubsub and PEP notifications since the last logout time of a specific resource.	http://xmpp.org/extensions/xep-0312.html
-XEP-0208	A										This document provides guidelines to XMPP client developers for bootstrapping implementation of Jingle technologies.	http://xmpp.org/extensions/xep-0208.html
-XEP-0167	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for negotiating one or more sessions that use the Real-time Transport Protocol (RTP) to exchange media such as voice or video. The application type includes a straightforward mapping to Session Description Protocol (SDP) for interworking with SIP media endpoints.	http://xmpp.org/extensions/xep-0167.html
-XEP-0255	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for querying a compliant server or service for information about the geographical or physical location of an entity.	http://xmpp.org/extensions/xep-0255.html
-XEP-0073	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications. Note: This protocol suite has been obsoleted by XEP-0211 and XEP-0212.	http://xmpp.org/extensions/xep-0073.html
-XEP-0278	A									[[Image:http://xmpp.org/images/xmpp.png]]	This documents specifies how Jingle Clients can interact with Jingle Relay Nodes Services and how XMPP entities can provide, search and list available Jingle Relay Nodes.	http://xmpp.org/extensions/xep-0278.html
-XEP-0247	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for establishing direct or mediated XML streams between two entities over any streaming transport. This technology thus enables two entities to establish a trusted connection for end-to-end encryption or for bypassing server limits on large volumes of XMPP traffic.	http://xmpp.org/extensions/xep-0247.html
-XEP-0015	A										A proposal for enabling the ability to transfer an account from one Jabber server to another.	http://xmpp.org/extensions/xep-0015.html
-XEP-0078	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies a protocol for authentication with Jabber servers and services using the jabber:iq:auth namespace. Note Well: The protocol specified herein has been superseded in favor of SASL authentication as specified in RFC 3920 / RFC 6120, and is now obsolete.	http://xmpp.org/extensions/xep-0078.html
-XEP-0241	A										This specification defines methods for encrypting messages that are archived at an XMPP server.	http://xmpp.org/extensions/xep-0241.html
-XEP-0152	A										This document defines an XMPP protocol extension for communicating reachability information related to non-XMPP devices.	http://xmpp.org/extensions/xep-0152.html
-XEP-0026	A									[[Image:http://xmpp.org/images/xmpp.png]]	NOTE WELL: this document was retracted on 2003-11-05 since the topic is addressed definitively in XMPP Core. Please refer to XMPP Core for further information.	http://xmpp.org/extensions/xep-0026.html
-XEP-0017	A										An intermediate method for more efficient framing of the Jabber XML Stream.	http://xmpp.org/extensions/xep-0017.html
-XEP-0166	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for initiating and managing peer-to-peer media sessions between two XMPP entities in a way that is interoperable with existing Internet standards. The protocol provides a pluggable model that enables the core session management semantics (compatible with SIP) to be used for a wide variety of application types (e.g., voice chat, video chat, file transfer) and with a wide variety of transport methods (e.g., TCP, UDP, ICE, application-specific transports).	http://xmpp.org/extensions/xep-0166.html
-XEP-0014	A										A proposal for including the sender's tone in messages.	http://xmpp.org/extensions/xep-0014.html
-XEP-0183	A										This document defines a telepathic transport method for establishing Extra-Sensory Perception (ESP) streams.	http://xmpp.org/extensions/xep-0183.html
-XEP-0253	A										This specification defines a method for chaining pubsub nodes together, resulting in lightweight repeaters for pubsub notifications.	http://xmpp.org/extensions/xep-0253.html
-XEP-0109	A										This document defines an XMPP protocol extension for communicating out-of-office status.	http://xmpp.org/extensions/xep-0109.html
-XEP-0039	A										A protocol to enable gathering statistics from Jabber servers and components.	http://xmpp.org/extensions/xep-0039.html
-XEP-0203	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for communicating the fact that an XML stanza has been delivered with a delay, for example because a message has been stored on a server while the intended recipient was offline or because a message is contained in the history of a multi-user chat room.	http://xmpp.org/extensions/xep-0203.html
-XEP-0008	A										This specification provides historical documentation of an IQ-based protocol for exchanging user avatars.	http://xmpp.org/extensions/xep-0008.html
-XEP-0169	A										The classic Christmas poem annotated with XMPP protocols.	http://xmpp.org/extensions/xep-0169.html
-XEP-0027	A										This document outlines the current usage of OpenPGP for messaging and presence.	http://xmpp.org/extensions/xep-0027.html
-XEP-0260	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending data via the SOCKS5 Bytestreams (S5B) protocol defined in XEP-0065. Essentially this transport method reuses XEP-0065 semantics for sending the data and defines native Jingle methods for starting and ending an S5B session.	http://xmpp.org/extensions/xep-0260.html
-XEP-0034	A									[[Image:http://xmpp.org/images/xmpp.png]]	NOTE WELL: this specification was retracted on 2003-11-05 since the topic is addressed definitively in XMPP Core. Please refer to XMPP Core for further information.	http://xmpp.org/extensions/xep-0034.html
-XEP-0051	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables a server to redirect connections from one connection manager or server node to another.	http://xmpp.org/extensions/xep-0051.html
-XEP-0244	A										This specification defines an XMPP protocol extension for handling the input to and output from a remote entity.	http://xmpp.org/extensions/xep-0244.html
-XEP-0113	A										A proposal for an extremely simple whiteboarding protocol over Jabber.	http://xmpp.org/extensions/xep-0113.html
-XEP-0266	A										This document describes implementation considerations related to audio codecs for use in Jingle RTP sessions.	http://xmpp.org/extensions/xep-0266.html
-XEP-0236	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for reporting abusive traffic sent over an XMPP network. Note: This specification has been retracted in favor of XEP-0161, which now contains the content originally published in this specification.	http://xmpp.org/extensions/xep-0236.html
-XEP-0131	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for representing non-address-related headers in an XML format that is appropriate for use in XMPP. While the protocol provides a flexible mechanism for representing many kinds of standard Internet metadata, a registry of values is defined to structure the possible range of headers, and the inital registration includes headers from email, HTTP, MIME, and SIP.	http://xmpp.org/extensions/xep-0131.html
-XEP-0140	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a protocol profile for centrally defined and administered roster groups; the protocol described herein has been retracted in favor of XEP-0144: Roster Item Exchange.	http://xmpp.org/extensions/xep-0140.html
-XEP-0261	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending data via the In-Band Bytestreams (IBB) protocol defined in XEP-0047. Essentially this transport method reuses XEP-0047 semantics for sending the data and defines native Jingle methods for starting and ending an IBB session.	http://xmpp.org/extensions/xep-0261.html
-XEP-0059	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables an entity to page through and otherwise manage the receipt of large result sets. The protocol can be used in the context of any XMPP protocol that might send large result sets (such as service discovery, multi-user chat, and publish-subscribe). While the requesting entity in such an interaction can explicitly request the use of result set management, an indication that result set management is in use can also be proactively included by the responding entity when returning a limited result set in response to a query.	http://xmpp.org/extensions/xep-0059.html
-XEP-0067	A										This document specifies a data format for stock data distribution in the Jabber community.	http://xmpp.org/extensions/xep-0067.html
-XEP-0104	A										This document provides a schema description for detailed information about HTTP URLs.	http://xmpp.org/extensions/xep-0104.html
-XEP-0185	A										This document provides a recommended method for generating and validating the keys used in the XMPP server dialback protocol.	http://xmpp.org/extensions/xep-0185.html
-XEP-0142	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables a user to communicate with a representative of an organization, department, or workgroup.	http://xmpp.org/extensions/xep-0142.html
-XEP-0292	A										This document specifies an XMPP extension for use of the vCard4 XML format in XMPP systems, with the intent of obsoleting the vcard-temp format.	http://xmpp.org/extensions/xep-0292.html
-XEP-0192	A										This document proposes improvements to the XML stream features definition for inclusion in the specification that supersedes RFC 3920.	http://xmpp.org/extensions/xep-0192.html
-XEP-0148	A										This specification provides canonical documentation of the jabber:iq:iq namespace.	http://xmpp.org/extensions/xep-0148.html
-XEP-0216	A										This document defines the XMPP Intermedate IM Server 2008 compliance level.	http://xmpp.org/extensions/xep-0216.html
-XEP-0047	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables any two entities to establish a one-to-one bytestream between themselves, where the data is broken down into smaller chunks and transported in-band over XMPP.	http://xmpp.org/extensions/xep-0047.html
-XEP-0308	A										This specification defines a method for marking a message as a correction of the last sent message.	http://xmpp.org/extensions/xep-0308.html
-XEP-0228	A										This document defines requirements for the design of XMPP-based shared editing protocols.	http://xmpp.org/extensions/xep-0228.html
-XEP-0186	A										This document specifies an XMPP-compatible protocol for user invisibility.	http://xmpp.org/extensions/xep-0186.html
-XEP-0058	A										This document defines how several people may simultaneously edit text.	http://xmpp.org/extensions/xep-0058.html
-XEP-0237	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a proposed modification to the XMPP roster protocol that enables versioning of rosters such that the server will not send the roster to the client if the roster has not been modified, thus saving bandwidth during session establishment.	http://xmpp.org/extensions/xep-0237.html
-XEP-0211	A										This document defines the XMPP Basic Client 2008 compliance level.	http://xmpp.org/extensions/xep-0211.html
-XEP-0210	A										This document describes the requirements for an XMPP end-to-end encrypted session protocol.	http://xmpp.org/extensions/xep-0210.html
-XEP-0094	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides canonical documentation of the obsolete Agent Information namespace. Note: This document has been superseded by XEP-0030: Service Discovery.	http://xmpp.org/extensions/xep-0094.html
-XEP-0182	A										This document defines a registry of application-specific error conditions.	http://xmpp.org/extensions/xep-0182.html
-XEP-0268	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines methods for incident reporting among XMPP server deployments using the IODEF format produced by the IETF's INCH Working Group.	http://xmpp.org/extensions/xep-0268.html
+XEP-1	R	XEP-0001										
 XEP-0002	A										A definition of Special Interest Groups within the XMPP Standards Foundation.	http://xmpp.org/extensions/xep-0002.html
-XEP-0032	A										A URI scheme for Jabber communications.	http://xmpp.org/extensions/xep-0032.html
-XEP-0250	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document describes how to negotiate TLS extensions when using TLS for end-to-end XML streams between two clients. It covers X.509 certificates with an without CA, the use of OpenPGP, Shared Remote Passwords (SRP) and how to use one extension to bootstrap a trust relationship.	http://xmpp.org/extensions/xep-0250.html
-XEP-0099	A										Standardizes behavior of <iq/> <query/> actions for generic query behavior.	http://xmpp.org/extensions/xep-0099.html
-XEP-0227	A										This document specifies a file format for importing and exporting user data to and from XMPP-IM servers.	http://xmpp.org/extensions/xep-0227.html
-XEP-0207	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies semantics for using the XMPP publish-subscribe protocol to handle generic XMPP events (including presence, one-to-one messaging, and groupchat).	http://xmpp.org/extensions/xep-0207.html
-XEP-0035	A									[[Image:http://xmpp.org/images/xmpp.png]]	NOTE WELL: this specification was retracted on 2003-11-05 since the topic is addressed definitively in XMPP Core. Please refer to XMPP Core for further information.	http://xmpp.org/extensions/xep-0035.html
-XEP-0114	A										This specification documents the existing protocol used for communication between servers and "external" components over the Jabber network.	http://xmpp.org/extensions/xep-0114.html
-XEP-0262	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for negotiating one or more sessions that use the Real-time Transport Protocol (RTP) to exchange media such as voice or video. The application type includes a straightforward mapping to Session Description Protocol (SDP) for interworking with SIP media endpoints.	http://xmpp.org/extensions/xep-0262.html
-XEP-0056	A										This document defines a way to transmit ebXML messages, ANSI X.11, EDIFACT/UN, and SAP iDoc over Jabber/XMPP.	http://xmpp.org/extensions/xep-0056.html
-XEP-0173	A										This document defines an XMPP protocol extension for storing subscriptions to Pubsub nodes.	http://xmpp.org/extensions/xep-0173.html
-XEP-0071	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XHTML 1.0 Integration Set for use in exchanging instant messages that contain lightweight text markup. The protocol enables an XMPP entity to format a message using a small range of commonly-used HTML elements, attributes, and style properties that are suitable for use in instant messaging. The protocol also excludes HTML constructs that may introduce malware and other vulnerabilities (such as scripts and objects) for improved security.	http://xmpp.org/extensions/xep-0071.html
-XEP-0031	A									[[Image:http://xmpp.org/images/xmpp.png]]	 Although the value and utility of contemporary instant messaging  systems, like Jabber, are now indisputable, current security  features to protect message data are generally inadequate for  many deployments; this is particularly true in security conscious  environments like large, commercial enterprises and government  agencies. These current features suffer from issues of  scalability, usability, and supported features. Furthermore, there is a  lack of standardization.  We present a protocol to allow communities of Jabber users to  apply cryptographic protection to selected conversation data. 	http://xmpp.org/extensions/xep-0031.html
-XEP-0164	A										This document specifies a mechanism for requesting specific sections of a vCard.	http://xmpp.org/extensions/xep-0164.html
-XEP-0154	A										This document specifies how to represent and manage profile data about IM users and other XMPP entities using the XMPP Data Forms extension.	http://xmpp.org/extensions/xep-0154.html
+XEP-2	R	XEP-0002										
+XEP-0003	A										This document defines a method for relaying media via proxies on the Jabber/XMPP network.	http://xmpp.org/extensions/xep-0003.html
+XEP-3	R	XEP-0003										
+XEP-0004	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for data forms that can be used in workflows such as service configuration as well as for application-specific data description and reporting. The protocol includes lightweight semantics for forms processing (such as request, response, submit, and cancel), defines several common field types (boolean, list options with single or multiple choice, text with single line or multiple lines, single or multiple JabberIDs, hidden fields, etc.), provides extensibility for future data types, and can be embedded in a wide range of applications. The protocol is not intended to provide complete forms-processing functionality as is provided in the W3C XForms technology, but instead provides a basic subset of such functionality for use by XMPP entities.	http://xmpp.org/extensions/xep-0004.html
+XEP-4	R	XEP-0004										
+XEP-0005	A										This is the official list and summary information of the Jabber Interest Groups.	http://xmpp.org/extensions/xep-0005.html
+XEP-5	R	XEP-0005										
+XEP-0006	A										A proposal for a more powerful and extensible protocol for the management of personal information within Jabber.	http://xmpp.org/extensions/xep-0006.html
+XEP-6	R	XEP-0006										
+XEP-0007	A										A proposal for a Jabber Interest Group that will discuss the protocol for implementing many-to-many communications.	http://xmpp.org/extensions/xep-0007.html
+XEP-7	R	XEP-0007										
+XEP-0008	A										This specification provides historical documentation of an IQ-based protocol for exchanging user avatars.	http://xmpp.org/extensions/xep-0008.html
+XEP-8	R	XEP-0008										
 XEP-0009	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for transporting XML-RPC encoded requests and responses between two XMPP entities. The protocol supports all syntax and semantics of XML-RPC except that it uses XMPP instead of HTTP as the underlying transport.	http://xmpp.org/extensions/xep-0009.html
-XEP-0271	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification more clearly defines the nature of nodes as used in the Service Discovery and Publish-Subscribe extensions to the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0271.html
-XEP-0254	A										This specification defines an extension to XMPP publish-subscribe for queueing information at a node.	http://xmpp.org/extensions/xep-0254.html
-XEP-0088	A										A protocol for displaying web-based tabs in clients.	http://xmpp.org/extensions/xep-0088.html
-XEP-0064	A										A module that provides an XPath matching condition for packet filtering.	http://xmpp.org/extensions/xep-0064.html
-XEP-0245	A										This specification defines recommended handling of the /me command in XMPP instant messaging clients.	http://xmpp.org/extensions/xep-0245.html
-XEP-0050	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for advertising and executing application-specific commands, such as those related to a configuration workflow. Typically the commands contain data forms (XEP-0004) in order to structure the information exchange.	http://xmpp.org/extensions/xep-0050.html
+XEP-9	R	XEP-0009										
+XEP-0010	A										A proposal to form a SIG to develop a protocol for whiteboarding over Jabber.	http://xmpp.org/extensions/xep-0010.html
+XEP-10	R	XEP-0010										
+XEP-0011	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a way to describe information about Jabber entities and the relationships between entities. Note: This document is superseded by XEP-0030: Service Discovery.	http://xmpp.org/extensions/xep-0011.html
+XEP-11	R	XEP-0011										
+XEP-0012	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for communicating information about the last activity associated with an XMPP entity. It is typically used by an IM client to retrieve the most recent presence information from an offline contact by sending a last activity request to the server that hosts the account controlled by the contact.	http://xmpp.org/extensions/xep-0012.html
+XEP-12	R	XEP-0012										
+XEP-0013	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for flexible, POP3-like handling of offline messages. The protocol enables a connecting client to retrieve its offline messages on login in a controlled fashion, without receiving a flood of messages. Messages can also be left on the server for later retrieval.	http://xmpp.org/extensions/xep-0013.html
+XEP-13	R	XEP-0013										
+XEP-0014	A										A proposal for including the sender's tone in messages.	http://xmpp.org/extensions/xep-0014.html
+XEP-14	R	XEP-0014										
+XEP-0015	A										A proposal for enabling the ability to transfer an account from one Jabber server to another.	http://xmpp.org/extensions/xep-0015.html
+XEP-15	R	XEP-0015										
+XEP-0016	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for enabling or disabling communication with other entities on a network. The protocol, which was first standardized in Section 10 of RFC 3921, can be used to block communication with unknown or undesirable entities. Blocking can be based on Jabber Identifier, subscription state, or roster group. The blocked stanzas can be messages, IQs, inbound or outbound presence stanzas, or all stanzas. The protocol also enables an entity to create, modify, or delete its privacy lists, apply different lists to different connected resources, define a default list, and decline the use of any privacy list during a particular communications session.	http://xmpp.org/extensions/xep-0016.html
+XEP-16	R	XEP-0016										
+XEP-0017	A										An intermediate method for more efficient framing of the Jabber XML Stream.	http://xmpp.org/extensions/xep-0017.html
+XEP-17	R	XEP-0017										
+XEP-0018	A										Documentation of invisible presence.	http://xmpp.org/extensions/xep-0018.html
+XEP-18	R	XEP-0018										
+XEP-0019	A										This document proposes to streamline the existing Special Interest Groups (SIGs).	http://xmpp.org/extensions/xep-0019.html
+XEP-19	R	XEP-0019										
+XEP-0020	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables two entities to mutually negotiate feature options, such as parameters related to a file transfer or a communications session.	http://xmpp.org/extensions/xep-0020.html
+XEP-20	R	XEP-0020										
+XEP-0021	A										A generic publish-and-subscribe service for Jabber.	http://xmpp.org/extensions/xep-0021.html
+XEP-21	R	XEP-0021										
+XEP-0022	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension used to request and respond to events relating to the delivery, display, and composition of messages. Note: This specification has been obsoleted in favor of XEP-0085 and XEP-0184.	http://xmpp.org/extensions/xep-0022.html
+XEP-22	R	XEP-0022										
+XEP-0023	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification documents an historical protocol that was used to specify expiration dates for messages; this protocol has been deprecated in favor of XEP-0079: Advanced Message Processing.	http://xmpp.org/extensions/xep-0023.html
+XEP-23	R	XEP-0023										
+XEP-0024	A										A publish-subscribe protocol for Jabber.	http://xmpp.org/extensions/xep-0024.html
+XEP-24	R	XEP-0024										
+XEP-0025	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables access to a Jabber server from behind firewalls which do not allow outgoing sockets on port 5222, via HTTP requests.	http://xmpp.org/extensions/xep-0025.html
+XEP-25	R	XEP-0025										
+XEP-0026	A									[[Image:http://xmpp.org/images/xmpp.png]]	NOTE WELL: this document was retracted on 2003-11-05 since the topic is addressed definitively in XMPP Core. Please refer to XMPP Core for further information.	http://xmpp.org/extensions/xep-0026.html
+XEP-26	R	XEP-0026										
+XEP-0027	A										This document outlines the current usage of OpenPGP for messaging and presence.	http://xmpp.org/extensions/xep-0027.html
+XEP-27	R	XEP-0027										
+XEP-0028	A										This document was removed from the XSF website and source control at the request of the author.	http://xmpp.org/extensions/xep-0028.html
+XEP-28	R	XEP-0028										
+XEP-0029	A										This document defines the exact nature of a Jabber Identifier (JID). 	http://xmpp.org/extensions/xep-0029.html
+XEP-29	R	XEP-0029										
+XEP-0030	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for discovering information about other XMPP entities. Two kinds of information can be discovered: (1) the identity and capabilities of an entity, including the protocols and features it supports; and (2) the items associated with an entity, such as the list of rooms hosted at a multi-user chat service.	http://xmpp.org/extensions/xep-0030.html
+XEP-30	R	XEP-0030										
+XEP-0031	A									[[Image:http://xmpp.org/images/xmpp.png]]	 Although the value and utility of contemporary instant messaging  systems, like Jabber, are now indisputable, current security  features to protect message data are generally inadequate for  many deployments; this is particularly true in security conscious  environments like large, commercial enterprises and government  agencies. These current features suffer from issues of  scalability, usability, and supported features. Furthermore, there is a  lack of standardization.  We present a protocol to allow communities of Jabber users to  apply cryptographic protection to selected conversation data. 	http://xmpp.org/extensions/xep-0031.html
+XEP-31	R	XEP-0031										
+XEP-0032	A										A URI scheme for Jabber communications.	http://xmpp.org/extensions/xep-0032.html
+XEP-32	R	XEP-0032										
+XEP-0033	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables entities to include RFC822-style address headers within XMPP stanzas in order to specify multiple recipients or sub-addresses.	http://xmpp.org/extensions/xep-0033.html
+XEP-33	R	XEP-0033										
+XEP-0034	A									[[Image:http://xmpp.org/images/xmpp.png]]	NOTE WELL: this specification was retracted on 2003-11-05 since the topic is addressed definitively in XMPP Core. Please refer to XMPP Core for further information.	http://xmpp.org/extensions/xep-0034.html
+XEP-34	R	XEP-0034										
+XEP-0035	A									[[Image:http://xmpp.org/images/xmpp.png]]	NOTE WELL: this specification was retracted on 2003-11-05 since the topic is addressed definitively in XMPP Core. Please refer to XMPP Core for further information.	http://xmpp.org/extensions/xep-0035.html
+XEP-35	R	XEP-0035										
+XEP-0036	A										A proposal for the subscribe half of a publish-subscribe protocol within Jabber.	http://xmpp.org/extensions/xep-0036.html
+XEP-36	R	XEP-0036										
+XEP-0037	A										A proposal for proxy support in Jabber.	http://xmpp.org/extensions/xep-0037.html
+XEP-37	R	XEP-0037										
 XEP-0038	A										A protocol for specifying exchangeable styles of emoticons and genicons within Jabber IM clients.	http://xmpp.org/extensions/xep-0038.html
-XEP-0155	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a method for formally negotiating the exchange of XML stanzas between two XMPP entities. The method uses feature negotiation forms sent via XMPP message stanzas to enable session initiation between entities that do not share presence information or have knowledge of full JabberIDs and therefore is also suitable for use across gateways to SIP-based systems. A wide range of session parameters can be negotiated, including the use of end-to-end encryption, chat state notifications, XHTML-IM formatting, and message archiving.	http://xmpp.org/extensions/xep-0155.html
-XEP-0105	A										A profile describing meta-data for transferring trees of files using stream inititation.	http://xmpp.org/extensions/xep-0105.html
-XEP-0130	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.	http://xmpp.org/extensions/xep-0130.html
-XEP-0158	A										This document specifies an XMPP protocol extension that entities may use to discover whether the sender of an XML stanza is a human user or a robot.	http://xmpp.org/extensions/xep-0158.html
-XEP-0160	A										This document specifies best practices to be followed by Jabber/XMPP servers in handling messages sent to recipients who are offline.	http://xmpp.org/extensions/xep-0160.html
-XEP-0252	A										This specification provides historical documentation regarding the "alternative script syntax" first defined in Version 1.6 of XEP-0124.	http://xmpp.org/extensions/xep-0252.html
-XEP-0219	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables an entity to check the security of client-to-server and server-to-server hops between it and another entity. Note: This specification has been retracted by the author because the problem is not compelling and a real solution would be too complicated.	http://xmpp.org/extensions/xep-0219.html
-XEP-0221	A										This specification defines an XMPP protocol extension for including media data in XEP-0004 data forms.	http://xmpp.org/extensions/xep-0221.html
-XEP-0107	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a payload format for communicating information about user moods, such as whether a person is currently happy, sad, angy, or annoyed. The payload format is typically transported using the personal eventing protocol, a profile of XMPP publish-subscribe specified in XEP-0163.	http://xmpp.org/extensions/xep-0107.html
-XEP-0202	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for communicating the local time of an entity, including the time in UTC according to the entity as well as the offset from UTC. The time format itself conforms to the dateTime profile of ISO 8601 defined in XEP-0082.	http://xmpp.org/extensions/xep-0202.html
-XEP-0197	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for communicating information about the television shows, movies, or other videos that a user watches.	http://xmpp.org/extensions/xep-0197.html
-XEP-0124	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a transport protocol that emulates the semantics of a long-lived, bidirectional TCP connection between two entities (such as a client and a server) by efficiently using multiple synchronous HTTP request/response pairs without requiring the use of frequent polling or chunked responses.	http://xmpp.org/extensions/xep-0124.html
-XEP-0119	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies a set of XMPP extensions that provide support for extended presence information. Note: This document has been retracted since its functionality is handled by XEP-0163.	http://xmpp.org/extensions/xep-0119.html
-XEP-0082	A										This document specifies a standardization of ISO 8601 profiles and their lexical representation for use in XMPP protocol extensions.	http://xmpp.org/extensions/xep-0082.html
-XEP-0289	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document provides a protocol for federating MUC rooms together in order to reduce the effects of constrained network (e.g. unreliability, severely limited bandwidth) on the room occupants.	http://xmpp.org/extensions/xep-0289.html
-XEP-0204	A										This document specifies an XMPP protocol extension that supports the exchange of structured data objects.	http://xmpp.org/extensions/xep-0204.html
-XEP-0096	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a profile of the XMPP stream initiation extension for transferring files between two entities. The protocol provides a modular framework that enables the exchange of information about the file to be transferred as well as the negotiation of parameters such as the transport to be used.	http://xmpp.org/extensions/xep-0096.html
-XEP-0175	A										This document specifies best practices for use of the SASL ANONYMOUS mechanism in the context of client authentication with an XMPP server.	http://xmpp.org/extensions/xep-0175.html
-XEP-0196	A										This document defines an XMPP protocol extension for communicating information about the games a user plays.	http://xmpp.org/extensions/xep-0196.html
+XEP-38	R	XEP-0038										
+XEP-0039	A										A protocol to enable gathering statistics from Jabber servers and components.	http://xmpp.org/extensions/xep-0039.html
+XEP-39	R	XEP-0039										
+XEP-0040	A										Note: This proposal has been superseded by XEP-0060; please refer to that document for the successor protocol.	http://xmpp.org/extensions/xep-0040.html
+XEP-40	R	XEP-0040										
+XEP-0041	A										Protocol for linking a bytestream between two Jabber entities.	http://xmpp.org/extensions/xep-0041.html
+XEP-41	R	XEP-0041										
+XEP-0042	A										A protocol for enabling uni-directional multicast data transfers out of band.	http://xmpp.org/extensions/xep-0042.html
+XEP-42	R	XEP-0042										
+XEP-0043	A										Expose RDBM systems directly to the jabber network	http://xmpp.org/extensions/xep-0043.html
+XEP-43	R	XEP-0043										
 XEP-0044	A										A description of the use of namespaces within Jabber.	http://xmpp.org/extensions/xep-0044.html
+XEP-44	R	XEP-0044										
+XEP-0045	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for multi-user text chat, whereby multiple XMPP users can exchange messages in the context of a room or channel, similar to Internet Relay Chat (IRC). In addition to standard chatroom features such as room topics and invitations, the protocol defines a strong room control model, including the ability to kick and ban users, to name room moderators and administrators, to require membership or passwords in order to join the room, etc.	http://xmpp.org/extensions/xep-0045.html
+XEP-45	R	XEP-0045										
+XEP-0046	A										Direct TCP connection between two Jabber entities.	http://xmpp.org/extensions/xep-0046.html
+XEP-46	R	XEP-0046										
+XEP-0047	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables any two entities to establish a one-to-one bytestream between themselves, where the data is broken down into smaller chunks and transported in-band over XMPP.	http://xmpp.org/extensions/xep-0047.html
+XEP-47	R	XEP-0047										
+XEP-0048	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XML data format for use by XMPP clients in storing bookmarks to mult-user chatrooms and web pages. The chatroom bookmarking function includes the ability to auto-join rooms on login.	http://xmpp.org/extensions/xep-0048.html
+XEP-48	R	XEP-0048										
+XEP-0049	A										This specification provides canonical documentation of the 'jabber:iq:private' namespace currently in common usage.	http://xmpp.org/extensions/xep-0049.html
+XEP-49	R	XEP-0049										
+XEP-0050	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for advertising and executing application-specific commands, such as those related to a configuration workflow. Typically the commands contain data forms (XEP-0004) in order to structure the information exchange.	http://xmpp.org/extensions/xep-0050.html
+XEP-50	R	XEP-0050										
+XEP-0051	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables a server to redirect connections from one connection manager or server node to another.	http://xmpp.org/extensions/xep-0051.html
+XEP-51	R	XEP-0051										
+XEP-0052	A										A protocol for transferring a file between two Jabber IDs.	http://xmpp.org/extensions/xep-0052.html
+XEP-52	R	XEP-0052										
+XEP-0053	A										This document defines the roles and processes of the XMPP Registrar function within the XMPP Standards Foundation.	http://xmpp.org/extensions/xep-0053.html
+XEP-53	R	XEP-0053										
+XEP-0054	A										This specification provides canonical documentation of the vCard-XML format currently in use within the Jabber community.	http://xmpp.org/extensions/xep-0054.html
+XEP-54	R	XEP-0054										
+XEP-0055	A										This specification provides canonical documentation of the jabber:iq:search namespace currently in use within the Jabber community.	http://xmpp.org/extensions/xep-0055.html
+XEP-55	R	XEP-0055										
+XEP-0056	A										This document defines a way to transmit ebXML messages, ANSI X.11, EDIFACT/UN, and SAP iDoc over Jabber/XMPP.	http://xmpp.org/extensions/xep-0056.html
+XEP-56	R	XEP-0056										
+XEP-0057	A										This document defines a way to handle extended roster items.	http://xmpp.org/extensions/xep-0057.html
+XEP-57	R	XEP-0057										
+XEP-0058	A										This document defines how several people may simultaneously edit text.	http://xmpp.org/extensions/xep-0058.html
+XEP-58	R	XEP-0058										
+XEP-0059	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables an entity to page through and otherwise manage the receipt of large result sets. The protocol can be used in the context of any XMPP protocol that might send large result sets (such as service discovery, multi-user chat, and publish-subscribe). While the requesting entity in such an interaction can explicitly request the use of result set management, an indication that result set management is in use can also be proactively included by the responding entity when returning a limited result set in response to a query.	http://xmpp.org/extensions/xep-0059.html
+XEP-59	R	XEP-0059										
+XEP-0060	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for generic publish-subscribe functionality. The protocol enables XMPP entities to create nodes (topics) at a pubsub service and publish information at those nodes; an event notification (with or without payload) is then broadcasted to all entities that have subscribed to the node. Pubsub therefore adheres to the classic Observer design pattern and can serve as the foundation for a wide variety of applications, including news feeds, content syndication, rich presence, geolocation, workflow systems, network management systems, and any other application that requires event notifications.	http://xmpp.org/extensions/xep-0060.html
+XEP-60	R	XEP-0060										
+XEP-0061	A										A simplistic mechanism for shared notes, modeled after common stickie note applications.	http://xmpp.org/extensions/xep-0061.html
+XEP-61	R	XEP-0061										
+XEP-0062	A										A framework for packet filtering rules.	http://xmpp.org/extensions/xep-0062.html
+XEP-62	R	XEP-0062										
+XEP-0063	A										A module that provides basic conditions and actions for packet filtering.	http://xmpp.org/extensions/xep-0063.html
+XEP-63	R	XEP-0063										
+XEP-0064	A										A module that provides an XPath matching condition for packet filtering.	http://xmpp.org/extensions/xep-0064.html
+XEP-64	R	XEP-0064										
+XEP-0065	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for establishing an out-of-band bytestream between any two XMPP users, mainly for the purpose of file transfer. The bytestream can be either direct (peer-to-peer) or mediated (though a special-purpose proxy server). The typical transport protocol used is TCP, although UDP can optionally be supported as well.	http://xmpp.org/extensions/xep-0065.html
+XEP-65	R	XEP-0065										
+XEP-0066	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines two XMPP protocol extensions for communicating URIs, one for use in XMPP message stanzas and the other for use in a structured request-response interaction via XMPP IQ stanzas. Among other things, this enables one entity to inform another entity about a file that is available at an HTTP URL.	http://xmpp.org/extensions/xep-0066.html
+XEP-66	R	XEP-0066										
+XEP-0067	A										This document specifies a data format for stock data distribution in the Jabber community.	http://xmpp.org/extensions/xep-0067.html
+XEP-67	R	XEP-0067										
+XEP-0068	A										This document specifies how to standardize field variables used in the context of jabber:x:data forms.	http://xmpp.org/extensions/xep-0068.html
+XEP-68	R	XEP-0068										
+XEP-0069	A										A proposal to form a SIG devoted to issues related to protocol compliance.	http://xmpp.org/extensions/xep-0069.html
+XEP-69	R	XEP-0069										
+XEP-0070	A										This specification defines an XMPP protocol extension that enables verification of an HTTP request via XMPP.	http://xmpp.org/extensions/xep-0070.html
+XEP-70	R	XEP-0070										
+XEP-0071	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XHTML 1.0 Integration Set for use in exchanging instant messages that contain lightweight text markup. The protocol enables an XMPP entity to format a message using a small range of commonly-used HTML elements, attributes, and style properties that are suitable for use in instant messaging. The protocol also excludes HTML constructs that may introduce malware and other vulnerabilities (such as scripts and objects) for improved security.	http://xmpp.org/extensions/xep-0071.html
+XEP-71	R	XEP-0071										
+XEP-0072	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines methods for transporting SOAP messages over XMPP. Although the protocol supports only the request-response message exchange pattern, the protocol is formally defined as a SOAP Protocol Binding in accordance with version 1.2 of the W3C SOAP specification. In addition, a WSDL definition is defined for the purpose of advertising the availability of this protocol binding.	http://xmpp.org/extensions/xep-0072.html
+XEP-72	R	XEP-0072										
+XEP-0073	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications. Note: This protocol suite has been obsoleted by XEP-0211 and XEP-0212.	http://xmpp.org/extensions/xep-0073.html
+XEP-73	R	XEP-0073										
+XEP-0074	A										A simple protocol for querying information for permissions.	http://xmpp.org/extensions/xep-0074.html
+XEP-74	R	XEP-0074										
+XEP-0075	A									[[Image:http://xmpp.org/images/xmpp.png]]	The Jabber Object Access Protocol, or JOAP, defines a       mechanism for creating Jabber-accessible object servers, and       manipulating objects provided by those servers. It is intended       for development of business applications with Jabber.	http://xmpp.org/extensions/xep-0075.html
+XEP-75	R	XEP-0075										
+XEP-0076	A										This document defines an XMPP protocol extension for flagging malicious stanzas.	http://xmpp.org/extensions/xep-0076.html
+XEP-76	R	XEP-0076										
+XEP-0077	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for in-band registration with XMPP-based instant messaging servers and other services hosted on an XMPP network (such as groupchat rooms and gateways to non-XMPP IM services). The protocol is extensible via use of data forms, thus enabling services to gather a wide range of information during the registration process. The protocol also supports in-band password changes and cancellation of an existing registration.	http://xmpp.org/extensions/xep-0077.html
+XEP-77	R	XEP-0077										
+XEP-0078	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies a protocol for authentication with Jabber servers and services using the jabber:iq:auth namespace. Note Well: The protocol specified herein has been superseded in favor of SASL authentication as specified in RFC 3920 / RFC 6120, and is now obsolete.	http://xmpp.org/extensions/xep-0078.html
+XEP-78	R	XEP-0078										
+XEP-0079	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables entities to request, and servers to perform, advanced processing of XMPP message stanzas, including reliable data transport, time-sensitive delivery, and expiration of transient messages.	http://xmpp.org/extensions/xep-0079.html
+XEP-79	R	XEP-0079										
+XEP-0080	A										This specification defines an XMPP protocol extension for communicating information about the current geographical or physical location of an entity.	http://xmpp.org/extensions/xep-0080.html
+XEP-80	R	XEP-0080										
+XEP-0081	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies a MIME type for launching a Jabber client as a helper application from most modern web browsers, and for completing basic use cases once the client is launched.	http://xmpp.org/extensions/xep-0081.html
+XEP-81	R	XEP-0081										
+XEP-0082	A										This document specifies a standardization of ISO 8601 profiles and their lexical representation for use in XMPP protocol extensions.	http://xmpp.org/extensions/xep-0082.html
+XEP-82	R	XEP-0082										
+XEP-0083	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables nested sub-groups to exist within the Jabber roster, while retaining backwards compatibility and ensuring that the roster remains usable by all clients.	http://xmpp.org/extensions/xep-0083.html
+XEP-83	R	XEP-0083										
+XEP-0084	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for exchanging user avatars, which are small images or icons associated with human users. The protocol specifies payload formats for both avatar metadata and the image data itself. The payload formats are typically transported using the personal eventing profile of XMPP publish-subscribe as specified in XEP-0163.	http://xmpp.org/extensions/xep-0084.html
+XEP-84	R	XEP-0084										
+XEP-0085	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for communicating the status of a user in a chat session, thus indicating whether a chat partner is actively engaged in the chat, composing a message, temporarily paused, inactive, or gone. The protocol can be used in the context of a one-to-one chat session or a multi-user chat room.	http://xmpp.org/extensions/xep-0085.html
+XEP-85	R	XEP-0085										
+XEP-0086	A										A mapping to enable legacy entities to correctly handle errors from XMPP-aware entities.	http://xmpp.org/extensions/xep-0086.html
+XEP-86	R	XEP-0086										
+XEP-0087	A										A common method to initiate a stream with meta information	http://xmpp.org/extensions/xep-0087.html
+XEP-87	R	XEP-0087										
+XEP-0088	A										A protocol for displaying web-based tabs in clients.	http://xmpp.org/extensions/xep-0088.html
+XEP-88	R	XEP-0088										
+XEP-0089	A										A protocol for generic alerts (similar to .NET Alerts service).	http://xmpp.org/extensions/xep-0089.html
+XEP-89	R	XEP-0089										
+XEP-0090	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides historical documentation of the legacy jabber:iq:time namespace, which has been deprecated in favor the urn:xmpp:time namespace defined in XEP-0202.	http://xmpp.org/extensions/xep-0090.html
+XEP-90	R	XEP-0090										
+XEP-0091	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides historical documentation of the legacy jabber:x:delay namespace, which has been deprecated in favor the urn:xmpp:delay namespace defined in XEP-0203.	http://xmpp.org/extensions/xep-0091.html
+XEP-91	R	XEP-0091										
+XEP-0092	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for retrieving information about the software application associated with an XMPP entity. The protocol enables one entity to explicitly query another entity, where the response can include the name of the software application, the version of the software application, and the operating system on which the application is running.	http://xmpp.org/extensions/xep-0092.html
+XEP-92	R	XEP-0092										
+XEP-0093	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides canonical documentation of the jabber:x:roster namespace historically used within the Jabber community. NOTE WELL: This specification has been superseded by XEP-0144.	http://xmpp.org/extensions/xep-0093.html
+XEP-93	R	XEP-0093										
+XEP-0094	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides canonical documentation of the obsolete Agent Information namespace. Note: This document has been superseded by XEP-0030: Service Discovery.	http://xmpp.org/extensions/xep-0094.html
+XEP-94	R	XEP-0094										
+XEP-0095	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for initiating a data stream between any two XMPP entities. The protocol includes the ability to include metadata about the stream and provides a pluggable framework so that various profiles of stream initiation can be defined for particular use cases (such as file transfer).	http://xmpp.org/extensions/xep-0095.html
+XEP-95	R	XEP-0095										
+XEP-0096	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a profile of the XMPP stream initiation extension for transferring files between two entities. The protocol provides a modular framework that enables the exchange of information about the file to be transferred as well as the negotiation of parameters such as the transport to be used.	http://xmpp.org/extensions/xep-0096.html
+XEP-96	R	XEP-0096										
+XEP-0097	A										A simple mechanism to transport iCal data over the jabber protocol	http://xmpp.org/extensions/xep-0097.html
+XEP-97	R	XEP-0097										
+XEP-0098	A										Standardizes "private" XML data storage.	http://xmpp.org/extensions/xep-0098.html
+XEP-98	R	XEP-0098										
+XEP-0099	A										Standardizes behavior of <iq/> <query/> actions for generic query behavior.	http://xmpp.org/extensions/xep-0099.html
+XEP-99	R	XEP-0099										
+XEP-0100	A										This document specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.	http://xmpp.org/extensions/xep-0100.html
+XEP-100	R	XEP-0100										
+XEP-0101	A										This document defines a protocol for authenticating HTTP requests using Jabber Tickets.	http://xmpp.org/extensions/xep-0101.html
+XEP-101	R	XEP-0101										
+XEP-0102	A										Security extensions for Jabber/XMPP.	http://xmpp.org/extensions/xep-0102.html
+XEP-102	R	XEP-0102										
+XEP-0103	A										This document defines a structure for providing information about an Uniform Resource Locator (URL), and a protocol signaling retrieval states.	http://xmpp.org/extensions/xep-0103.html
+XEP-103	R	XEP-0103										
+XEP-0104	A										This document provides a schema description for detailed information about HTTP URLs.	http://xmpp.org/extensions/xep-0104.html
+XEP-104	R	XEP-0104										
+XEP-0105	A										A profile describing meta-data for transferring trees of files using stream inititation.	http://xmpp.org/extensions/xep-0105.html
+XEP-105	R	XEP-0105										
+XEP-0106	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a mechanism that enables the display in Jabber Identifiers (JIDs) of characters disallowed by the Nodeprep profile of stringprep. Although these characters -- space, double quote, ampersand, single quote, forward slash, colon, less than, greater than, and at-sign -- cannot be included in XMPP node identifiers, JID Escaping provides a native XMPP escaping mechanism for these characters so that the displayed version of a Jabber Identifier can appear to include these characters. This mechanism can also be used to translate non-XMPP addreses into XMPP syntax, for example when gatewaying between XMPP and a non-XMPP communications technology such as email.	http://xmpp.org/extensions/xep-0106.html
+XEP-106	R	XEP-0106										
+XEP-0107	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a payload format for communicating information about user moods, such as whether a person is currently happy, sad, angy, or annoyed. The payload format is typically transported using the personal eventing protocol, a profile of XMPP publish-subscribe specified in XEP-0163.	http://xmpp.org/extensions/xep-0107.html
+XEP-107	R	XEP-0107										
+XEP-0108	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a payload format for communicating information about user activities, such as whether a person is currently working, travelling, or relaxing. The payload format is typically transported using the personal eventing protocol, a profile of XMPP publish-subscribe specified in XEP-0163.	http://xmpp.org/extensions/xep-0108.html
+XEP-108	R	XEP-0108										
+XEP-0109	A										This document defines an XMPP protocol extension for communicating out-of-office status.	http://xmpp.org/extensions/xep-0109.html
+XEP-109	R	XEP-0109										
+XEP-0110	A										A protocol for transport of generic maps (graphical displays of specific subsets of buddies).	http://xmpp.org/extensions/xep-0110.html
+XEP-110	R	XEP-0110										
+XEP-0111	A										This document defined a SIP-compatible transport for initiating and negotiating sessions using SDP over XMPP.	http://xmpp.org/extensions/xep-0111.html
+XEP-111	R	XEP-0111										
+XEP-0112	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a protocol for communicating information about the current physical location of a Jabber entity. NOTE WELL: The protocol defined herein has been folded into XEP-0080.	http://xmpp.org/extensions/xep-0112.html
+XEP-112	R	XEP-0112										
+XEP-0113	A										A proposal for an extremely simple whiteboarding protocol over Jabber.	http://xmpp.org/extensions/xep-0113.html
+XEP-113	R	XEP-0113										
+XEP-0114	A										This specification documents the existing protocol used for communication between servers and "external" components over the Jabber network.	http://xmpp.org/extensions/xep-0114.html
+XEP-114	R	XEP-0114										
+XEP-0115	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for broadcasting and dynamically discovering client, device, or generic entity capabilities. In order to minimize network impact, the transport mechanism is standard XMPP presence broadcast (thus forestalling the need for polling related to service discovery data), the capabilities information can be cached either within a session or across sessions, and the format has been kept as small as possible.	http://xmpp.org/extensions/xep-0115.html
+XEP-115	R	XEP-0115										
+XEP-0116	A										This document specifies an XMPP protocol extension for negotiating an end-to-end encrypted session.	http://xmpp.org/extensions/xep-0116.html
+XEP-116	R	XEP-0116										
+XEP-0117	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications. Note: This protocol suite has been obsoleted by XEP-0213 and XEP-0216.	http://xmpp.org/extensions/xep-0117.html
+XEP-117	R	XEP-0117										
+XEP-0118	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a payload format for communicating information about music to which a user is listening, including the title, track number, collection, performer, composer, length, and user rating. The payload format is typically transported using the personal eventing protocol, a profile of XMPP publish-subscribe specified in XEP-0163.	http://xmpp.org/extensions/xep-0118.html
+XEP-118	R	XEP-0118										
+XEP-0119	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies a set of XMPP extensions that provide support for extended presence information. Note: This document has been retracted since its functionality is handled by XEP-0163.	http://xmpp.org/extensions/xep-0119.html
+XEP-119	R	XEP-0119										
+XEP-0120	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0120.html
+XEP-120	R	XEP-0120										
+XEP-0121	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0121.html
+XEP-121	R	XEP-0121										
+XEP-0122	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a backwards-compatible extension to the XMPP Data Forms protocol that enables applications to specify additional validation guidelines related to a form, such as validation of standard XML datatypes, application-specific datatypes, value ranges, and regular expressions.	http://xmpp.org/extensions/xep-0122.html
+XEP-122	R	XEP-0122										
+XEP-0123	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0123.html
+XEP-123	R	XEP-0123										
+XEP-0124	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a transport protocol that emulates the semantics of a long-lived, bidirectional TCP connection between two entities (such as a client and a server) by efficiently using multiple synchronous HTTP request/response pairs without requiring the use of frequent polling or chunked responses.	http://xmpp.org/extensions/xep-0124.html
+XEP-124	R	XEP-0124										
+XEP-0125	A										NOTE: This proposal was retracted by the author on 2004-02-19.	http://xmpp.org/extensions/xep-0125.html
+XEP-125	R	XEP-0125										
+XEP-0126	A										This specification defines best practices regarding implementation of invisible presence by means of XMPP privacy lists.	http://xmpp.org/extensions/xep-0126.html
+XEP-126	R	XEP-0126										
+XEP-0127	A										This document specifies a method for sending Common Alerting Protocol (CAP) data over XMPP.	http://xmpp.org/extensions/xep-0127.html
+XEP-127	R	XEP-0127										
+XEP-0128	A										This document specifies best practices for including extended information in Service Discovery results.	http://xmpp.org/extensions/xep-0128.html
+XEP-128	R	XEP-0128										
+XEP-0129	A										This document specifies a method for completing file transfers between XMPP entities using WebDAV.	http://xmpp.org/extensions/xep-0129.html
+XEP-129	R	XEP-0129										
+XEP-0130	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.	http://xmpp.org/extensions/xep-0130.html
+XEP-130	R	XEP-0130										
+XEP-0131	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for representing non-address-related headers in an XML format that is appropriate for use in XMPP. While the protocol provides a flexible mechanism for representing many kinds of standard Internet metadata, a registry of values is defined to structure the possible range of headers, and the inital registration includes headers from email, HTTP, MIME, and SIP.	http://xmpp.org/extensions/xep-0131.html
+XEP-131	R	XEP-0131										
+XEP-0132	A										This document defines an XMPP protocol extension that enables probing for presence via physical rather than electronic means.	http://xmpp.org/extensions/xep-0132.html
+XEP-132	R	XEP-0132										
+XEP-0133	A										This document defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.	http://xmpp.org/extensions/xep-0133.html
+XEP-133	R	XEP-0133										
+XEP-0134	A										This document defines best practices for the intelligent design of Jabber protocols and other XMPP extensions.	http://xmpp.org/extensions/xep-0134.html
+XEP-134	R	XEP-0134										
+XEP-0135	A										This document specifies a simple extension to existing protocols for file sharing over Jabber/XMPP.	http://xmpp.org/extensions/xep-0135.html
+XEP-135	R	XEP-0135										
+XEP-0136	A										This document defines mechanisms and preferences for the server-side archiving and retrieval of XMPP messages.	http://xmpp.org/extensions/xep-0136.html
+XEP-136	R	XEP-0136										
+XEP-0137	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables an XMPP entity to advertise the fact that it is willing accept a particular Stream Initiation request. The protocol is used mainly to inform other entities that a particular file is available for transfer via the File Transfer protocol defined in XEP-0096.	http://xmpp.org/extensions/xep-0137.html
+XEP-137	R	XEP-0137										
+XEP-0138	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for negotiating compression of XML streams, especially in situations where standard TLS compression cannot be negotiated. The protocol provides a modular framework that can accommodate a wide range of compression algorithms; the ZLIB compression algorithm is mandatory-to-implement, but implementations may support other algorithms in addition.	http://xmpp.org/extensions/xep-0138.html
+XEP-138	R	XEP-0138										
+XEP-0139	A										This document proposes the formation of a Special Interest Group devoted to the analysis of security threats related to Jabber technologies.	http://xmpp.org/extensions/xep-0139.html
+XEP-139	R	XEP-0139										
+XEP-0140	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a protocol profile for centrally defined and administered roster groups; the protocol described herein has been retracted in favor of XEP-0144: Roster Item Exchange.	http://xmpp.org/extensions/xep-0140.html
+XEP-140	R	XEP-0140										
+XEP-0141	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a backwards-compatible extension to the XMPP Data Forms protocol that enables an application to specify form layouts, including the layout of form fields, sections within pages, and subsections within sections.	http://xmpp.org/extensions/xep-0141.html
+XEP-141	R	XEP-0141										
+XEP-0142	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables a user to communicate with a representative of an organization, department, or workgroup.	http://xmpp.org/extensions/xep-0142.html
+XEP-142	R	XEP-0142										
+XEP-0143	A										This document provides information intended to assist authors of XMPP Extension Protocols.	http://xmpp.org/extensions/xep-0143.html
+XEP-143	R	XEP-0143										
+XEP-0144	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for exchanging contact list items, including the ability to suggest whether the item is to be added, deleted, or modified in the contact list of the recipient, as well as the suggested roster group for the item.	http://xmpp.org/extensions/xep-0144.html
+XEP-144	R	XEP-0144										
+XEP-0145	A										This document defines a protocol for making annotations about roster items and other entities.	http://xmpp.org/extensions/xep-0145.html
+XEP-145	R	XEP-0145										
+XEP-0146	A										This document specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.	http://xmpp.org/extensions/xep-0146.html
+XEP-146	R	XEP-0146										
+XEP-0147	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.	http://xmpp.org/extensions/xep-0147.html
+XEP-147	R	XEP-0147										
+XEP-0148	A										This specification provides canonical documentation of the jabber:iq:iq namespace.	http://xmpp.org/extensions/xep-0148.html
+XEP-148	R	XEP-0148										
+XEP-0149	A										This document defines a method to specify the valid time periods for states, events, and activities communicated via Jabber/XMPP protocols.	http://xmpp.org/extensions/xep-0149.html
+XEP-149	R	XEP-0149										
+XEP-0150	A										This document defines best practices for the use of Entity Tags in XMPP extensions.	http://xmpp.org/extensions/xep-0150.html
+XEP-150	R	XEP-0150										
+XEP-0151	A										This document proposes extensions to the Jabber groupchat protocol for virtual presence on Web pages.	http://xmpp.org/extensions/xep-0151.html
+XEP-151	R	XEP-0151										
+XEP-0152	A										This document defines an XMPP protocol extension for communicating reachability information related to non-XMPP devices.	http://xmpp.org/extensions/xep-0152.html
+XEP-152	R	XEP-0152										
+XEP-0153	A										This document provides historical documentation of a vCard-based protocol for exchanging user avatars.	http://xmpp.org/extensions/xep-0153.html
+XEP-153	R	XEP-0153										
+XEP-0154	A										This document specifies how to represent and manage profile data about IM users and other XMPP entities using the XMPP Data Forms extension.	http://xmpp.org/extensions/xep-0154.html
+XEP-154	R	XEP-0154										
+XEP-0155	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a method for formally negotiating the exchange of XML stanzas between two XMPP entities. The method uses feature negotiation forms sent via XMPP message stanzas to enable session initiation between entities that do not share presence information or have knowledge of full JabberIDs and therefore is also suitable for use across gateways to SIP-based systems. A wide range of session parameters can be negotiated, including the use of end-to-end encryption, chat state notifications, XHTML-IM formatting, and message archiving.	http://xmpp.org/extensions/xep-0155.html
+XEP-155	R	XEP-0155										
+XEP-0156	A										This document defines a DNS TXT Resource Record format for use in discovering alternative methods of connecting to an XMPP server.	http://xmpp.org/extensions/xep-0156.html
+XEP-156	R	XEP-0156										
+XEP-0157	A										This document defines a method for specifying contact addresses related to an XMPP service.	http://xmpp.org/extensions/xep-0157.html
+XEP-157	R	XEP-0157										
+XEP-0158	A										This document specifies an XMPP protocol extension that entities may use to discover whether the sender of an XML stanza is a human user or a robot.	http://xmpp.org/extensions/xep-0158.html
+XEP-158	R	XEP-0158										
+XEP-0159	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables clients to control how their servers may block spim that is addressed to them. It specifies a default privacy list fall-through action.	http://xmpp.org/extensions/xep-0159.html
+XEP-159	R	XEP-0159										
+XEP-0160	A										This document specifies best practices to be followed by Jabber/XMPP servers in handling messages sent to recipients who are offline.	http://xmpp.org/extensions/xep-0160.html
+XEP-160	R	XEP-0160										
+XEP-0161	A										This document specifies an XMPP protocol extension for reporting abusive XMPP stanzas. NOTE: This specification has been superseded by XEP-0268.	http://xmpp.org/extensions/xep-0161.html
+XEP-161	R	XEP-0161										
+XEP-0162	A										This document specifies best practices for roster and subscription management in Jabber/XMPP clients.	http://xmpp.org/extensions/xep-0162.html
+XEP-162	R	XEP-0162										
+XEP-0163	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines semantics for using the XMPP publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account. This profile of pubsub therefore enables a standard XMPP user account to function as a virtual pubsub service, easing the discovery of syndicated data and event notifications associated with such an account.	http://xmpp.org/extensions/xep-0163.html
+XEP-163	R	XEP-0163										
+XEP-0164	A										This document specifies a mechanism for requesting specific sections of a vCard.	http://xmpp.org/extensions/xep-0164.html
+XEP-164	R	XEP-0164										
+XEP-0165	A										This document recommends best practices to discourage mimicking of Jabber IDs.	http://xmpp.org/extensions/xep-0165.html
+XEP-165	R	XEP-0165										
+XEP-0166	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for initiating and managing peer-to-peer media sessions between two XMPP entities in a way that is interoperable with existing Internet standards. The protocol provides a pluggable model that enables the core session management semantics (compatible with SIP) to be used for a wide variety of application types (e.g., voice chat, video chat, file transfer) and with a wide variety of transport methods (e.g., TCP, UDP, ICE, application-specific transports).	http://xmpp.org/extensions/xep-0166.html
+XEP-166	R	XEP-0166										
+XEP-0167	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for negotiating one or more sessions that use the Real-time Transport Protocol (RTP) to exchange media such as voice or video. The application type includes a straightforward mapping to Session Description Protocol (SDP) for interworking with SIP media endpoints.	http://xmpp.org/extensions/xep-0167.html
+XEP-167	R	XEP-0167										
+XEP-0168	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension to indicate the presence priority of XMPP resources for applications other than standard XMPP messaging.	http://xmpp.org/extensions/xep-0168.html
+XEP-168	R	XEP-0168										
+XEP-0169	A										The classic Christmas poem annotated with XMPP protocols.	http://xmpp.org/extensions/xep-0169.html
+XEP-169	R	XEP-0169										
+XEP-0170	A										This document specifies a recommended order for negotiation of XMPP stream features.	http://xmpp.org/extensions/xep-0170.html
+XEP-170	R	XEP-0170										
+XEP-0171	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for providing language translation facilities over XMPP. It supports human, machine, client-based, and server-based translations.	http://xmpp.org/extensions/xep-0171.html
+XEP-171	R	XEP-0171										
+XEP-0172	A										This specification defines a protocol for communicating user nicknames, either in XMPP presence subscription requests or in XMPP messages.	http://xmpp.org/extensions/xep-0172.html
+XEP-172	R	XEP-0172										
+XEP-0173	A										This document defines an XMPP protocol extension for storing subscriptions to Pubsub nodes.	http://xmpp.org/extensions/xep-0173.html
+XEP-173	R	XEP-0173										
+XEP-0174	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines how to communicate over local or wide-area networks using the principles of zero-configuration networking for endpoint discovery and the syntax of XML streams and XMPP messaging for real-time communication. This method uses DNS-based Service Discovery and Multicast DNS to discover entities that support the protocol, including their IP addresses and preferred ports. Any two entities can then negotiate a serverless connection using XML streams in order to exchange XMPP message and IQ stanzas.	http://xmpp.org/extensions/xep-0174.html
+XEP-174	R	XEP-0174										
+XEP-0175	A										This document specifies best practices for use of the SASL ANONYMOUS mechanism in the context of client authentication with an XMPP server.	http://xmpp.org/extensions/xep-0175.html
+XEP-175	R	XEP-0175										
+XEP-0176	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending media data using raw datagram associations via the User Datagram Protocol (UDP). This transport method is negotiated via the Interactive Connectivity Establishment (ICE) methodology, which provides robust NAT traversal for media traffic.	http://xmpp.org/extensions/xep-0176.html
+XEP-176	R	XEP-0176										
+XEP-0177	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending media data using raw datagram associations via the User Datagram Protocol (UDP). This simple transport method does not provide NAT traversal, and the ICE-UDP transport method should be used if NAT traversal is required.	http://xmpp.org/extensions/xep-0177.html
+XEP-177	R	XEP-0177										
+XEP-0178	A										This document specifies best practices for XMPP usage of the SASL EXTERNAL mechanism in the context of PKIX certificates.	http://xmpp.org/extensions/xep-0178.html
+XEP-178	R	XEP-0178										
+XEP-0179	A										This document defines a Jingle transport method that results in using the Inter-Asterisk eXchange protocol (IAX) for the final communication.	http://xmpp.org/extensions/xep-0179.html
+XEP-179	R	XEP-0179										
+XEP-0180	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for negotiating a video chat or other video session. The application type uses the Real-time Transport Protocol (RTP) for the underlying media exchange and provides a straightforward mapping to Session Description Protocol (SDP) for interworking with SIP media endpoints. 	http://xmpp.org/extensions/xep-0180.html
+XEP-180	R	XEP-0180										
+XEP-0181	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XML format for encapsulating Dual Tone Multi-Frequency (DTMF) events in informational messages sent within the context of Jingle audio sessions, e.g. to be used in the context of Interactive Voice Response (IVR) systems. Note well that this format is not to be used in the context of RTP sessions, where native RTP methods are to be used instead.	http://xmpp.org/extensions/xep-0181.html
+XEP-181	R	XEP-0181										
+XEP-0182	A										This document defines a registry of application-specific error conditions.	http://xmpp.org/extensions/xep-0182.html
+XEP-182	R	XEP-0182										
+XEP-0183	A										This document defines a telepathic transport method for establishing Extra-Sensory Perception (ESP) streams.	http://xmpp.org/extensions/xep-0183.html
+XEP-183	R	XEP-0183										
+XEP-0184	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for message delivery receipts, whereby the sender of a message can request notification that the message has been delivered to a client controlled by the intended recipient.	http://xmpp.org/extensions/xep-0184.html
+XEP-184	R	XEP-0184										
+XEP-0185	A										This document provides a recommended method for generating and validating the keys used in the XMPP server dialback protocol.	http://xmpp.org/extensions/xep-0185.html
+XEP-185	R	XEP-0185										
+XEP-0186	A										This document specifies an XMPP-compatible protocol for user invisibility.	http://xmpp.org/extensions/xep-0186.html
+XEP-186	R	XEP-0186										
+XEP-0187	A										This document specifies an end-to-end encryption protocol for offline XMPP communication sessions.	http://xmpp.org/extensions/xep-0187.html
+XEP-187	R	XEP-0187										
+XEP-0188	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document describes the cryptographic design that underpins the XMPP protocol extensions Encrypted Session Negotiation, Offline Encrypted Sessions and Stanza Encryption.	http://xmpp.org/extensions/xep-0188.html
+XEP-188	R	XEP-0188										
+XEP-0189	A										This specification defines a method by which an entity can publish its public keys over XMPP.	http://xmpp.org/extensions/xep-0189.html
+XEP-189	R	XEP-0189										
+XEP-0190	A										This document specifies a best practice for closing an XML stream that is perceived to be idle.	http://xmpp.org/extensions/xep-0190.html
+XEP-190	R	XEP-0190										
+XEP-0191	A										This document specifies an XMPP protocol extension for simple communications blocking.	http://xmpp.org/extensions/xep-0191.html
+XEP-191	R	XEP-0191										
+XEP-0192	A										This document proposes improvements to the XML stream features definition for inclusion in the specification that supersedes RFC 3920.	http://xmpp.org/extensions/xep-0192.html
+XEP-192	R	XEP-0192										
+XEP-0193	A										This document proposes improvements to the definition of resource binding for inclusion in the specification that supersedes RFC 3920.	http://xmpp.org/extensions/xep-0193.html
+XEP-193	R	XEP-0193										
+XEP-0194	A										This specification defines an XMPP protocol extension for communicating information about the chatrooms a user visits.	http://xmpp.org/extensions/xep-0194.html
+XEP-194	R	XEP-0194										
+XEP-0195	A										This document defines an XMPP protocol extension for communicating information about the web pages a user visits.	http://xmpp.org/extensions/xep-0195.html
+XEP-195	R	XEP-0195										
+XEP-0196	A										This document defines an XMPP protocol extension for communicating information about the games a user plays.	http://xmpp.org/extensions/xep-0196.html
+XEP-196	R	XEP-0196										
+XEP-0197	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension for communicating information about the television shows, movies, or other videos that a user watches.	http://xmpp.org/extensions/xep-0197.html
+XEP-197	R	XEP-0197										
+XEP-0198	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for active management of an XML stream between two XMPP entities, including features for stanza acknowledgements and stream resumption.	http://xmpp.org/extensions/xep-0198.html
+XEP-198	R	XEP-0198										
+XEP-0199	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for sending application-level pings over XML streams. Such pings can be sent from a client to a server, from one server to another, or end-to-end.	http://xmpp.org/extensions/xep-0199.html
+XEP-199	R	XEP-0199										
+XEP-0200	A										This document specifies an XMPP protocol extension for session-based stanza encryption.	http://xmpp.org/extensions/xep-0200.html
+XEP-200	R	XEP-0200										
+XEP-0201	A										This specification defines recommended handling of XMPP message threads.	http://xmpp.org/extensions/xep-0201.html
+XEP-201	R	XEP-0201										
+XEP-0202	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for communicating the local time of an entity, including the time in UTC according to the entity as well as the offset from UTC. The time format itself conforms to the dateTime profile of ISO 8601 defined in XEP-0082.	http://xmpp.org/extensions/xep-0202.html
+XEP-202	R	XEP-0202										
+XEP-0203	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for communicating the fact that an XML stanza has been delivered with a delay, for example because a message has been stored on a server while the intended recipient was offline or because a message is contained in the history of a multi-user chat room.	http://xmpp.org/extensions/xep-0203.html
+XEP-203	R	XEP-0203										
+XEP-0204	A										This document specifies an XMPP protocol extension that supports the exchange of structured data objects.	http://xmpp.org/extensions/xep-0204.html
+XEP-204	R	XEP-0204										
+XEP-0205	A										This document recommends a number of practices that can help discourage denial of service attacks on XMPP-based networks.	http://xmpp.org/extensions/xep-0205.html
+XEP-205	R	XEP-0205										
+XEP-0206	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines how the Bidirectional-streams Over Synchronous HTTP (BOSH) technology can be used to transport XMPP stanzas. The result is an HTTP binding for XMPP communications that is useful in situations where a device or client is unable to maintain a long-lived TCP connection to an XMPP server.	http://xmpp.org/extensions/xep-0206.html
+XEP-206	R	XEP-0206										
+XEP-0207	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies semantics for using the XMPP publish-subscribe protocol to handle generic XMPP events (including presence, one-to-one messaging, and groupchat).	http://xmpp.org/extensions/xep-0207.html
+XEP-207	R	XEP-0207										
+XEP-0208	A										This document provides guidelines to XMPP client developers for bootstrapping implementation of Jingle technologies.	http://xmpp.org/extensions/xep-0208.html
+XEP-208	R	XEP-0208										
+XEP-0209	A										This document specifies an XMPP protocol extension for defining metacontacts and grouping member JIDs.	http://xmpp.org/extensions/xep-0209.html
+XEP-209	R	XEP-0209										
+XEP-0210	A										This document describes the requirements for an XMPP end-to-end encrypted session protocol.	http://xmpp.org/extensions/xep-0210.html
+XEP-210	R	XEP-0210										
+XEP-0211	A										This document defines the XMPP Basic Client 2008 compliance level.	http://xmpp.org/extensions/xep-0211.html
+XEP-211	R	XEP-0211										
+XEP-0212	A										This document defines the XMPP Basic Server 2008 compliance level.	http://xmpp.org/extensions/xep-0212.html
+XEP-212	R	XEP-0212										
+XEP-0213	A										This document defines the XMPP Intermediate IM Client 2008 compliance level.	http://xmpp.org/extensions/xep-0213.html
+XEP-213	R	XEP-0213										
+XEP-0214	A									[[Image:http://xmpp.org/images/xmpp.png]]	While a protocol has been described for initiating a file transfer from one user to another, there is not yet a defined way for users to designate a set of files as available for retrieval by other users of their choosing. This extension defines a common syntax for this purpose which is based on PubSub Collections.	http://xmpp.org/extensions/xep-0214.html
+XEP-214	R	XEP-0214										
+XEP-0215	A										This document specifies an XMPP protocol extension for discovering services external to the XMPP network.	http://xmpp.org/extensions/xep-0215.html
+XEP-215	R	XEP-0215										
+XEP-0216	A										This document defines the XMPP Intermedate IM Server 2008 compliance level.	http://xmpp.org/extensions/xep-0216.html
+XEP-216	R	XEP-0216										
+XEP-0217	A										This document specifies a minimal subset of the Encrypted Session Negotiation protocol sufficent for negotiating an end-to-end encrypted session.	http://xmpp.org/extensions/xep-0217.html
+XEP-217	R	XEP-0217										
+XEP-0218	A										This document provides guidelines to client and library developers for bootstrapping implementation of the encrypted sessions technology.	http://xmpp.org/extensions/xep-0218.html
+XEP-218	R	XEP-0218										
+XEP-0219	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables an entity to check the security of client-to-server and server-to-server hops between it and another entity. Note: This specification has been retracted by the author because the problem is not compelling and a real solution would be too complicated.	http://xmpp.org/extensions/xep-0219.html
+XEP-219	R	XEP-0219										
+XEP-0220	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines the Server Dialback protocol, which is used between XMPP servers to provide identity verification. Server Dialback uses the Domain Name System (DNS) as the basis for verifying identity; the basic approach is that when a receiving server accepts a server-to-server connection from an originating server, it does not process traffic over the connection until it has verified a key with an authoritative server for the domain asserted by the originating server. Although Server Dialback does not provide strong authentication or trusted federation and although it is subject to DNS poisoning attacks, it has effectively prevented most instances of address spoofing on the XMPP network since its development in the year 2000.	http://xmpp.org/extensions/xep-0220.html
+XEP-220	R	XEP-0220										
+XEP-0221	A										This specification defines an XMPP protocol extension for including media data in XEP-0004 data forms.	http://xmpp.org/extensions/xep-0221.html
+XEP-221	R	XEP-0221										
+XEP-0222	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines best practices for using the XMPP publish-subscribe extension to persistently store semi-public data objects such as public keys and personal profiles.	http://xmpp.org/extensions/xep-0222.html
+XEP-222	R	XEP-0222										
+XEP-0223	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines best practices for using the XMPP publish-subscribe extension to persistently store private information such as bookmarks and client configuration options.	http://xmpp.org/extensions/xep-0223.html
+XEP-223	R	XEP-0223										
+XEP-0224	A										This document defines an XMPP protocol extension for getting the attention of another user.	http://xmpp.org/extensions/xep-0224.html
+XEP-224	R	XEP-0224										
+XEP-0225	A										This document specifies a standards-track XMPP protocol extension that enables server components to connect to XMPP servers.	http://xmpp.org/extensions/xep-0225.html
+XEP-225	R	XEP-0225										
+XEP-0226	A										This document specifies best practices for generating and handling extended content in XMPP message stanzas.	http://xmpp.org/extensions/xep-0226.html
+XEP-226	R	XEP-0226										
+XEP-0227	A										This document specifies a file format for importing and exporting user data to and from XMPP-IM servers.	http://xmpp.org/extensions/xep-0227.html
+XEP-227	R	XEP-0227										
+XEP-0228	A										This document defines requirements for the design of XMPP-based shared editing protocols.	http://xmpp.org/extensions/xep-0228.html
+XEP-228	R	XEP-0228										
+XEP-0229	A										This document specifies how to use the LZW algorithm in XML stream compression.	http://xmpp.org/extensions/xep-0229.html
+XEP-229	R	XEP-0229										
+XEP-0230	A										This specification defines a method for requesting and receiving notifications regarding XMPP service discovery items.	http://xmpp.org/extensions/xep-0230.html
+XEP-230	R	XEP-0230										
+XEP-0231	A										This specification defines an XMPP protocol extension for including or referring to small bits of binary data in an XML stanza.	http://xmpp.org/extensions/xep-0231.html
+XEP-231	R	XEP-0231										
+XEP-0232	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document specifies an extended data format whereby XMPP service discovery responses can include detailed information about the software application that powers a given XMPP entity for includion in service discovery responses.	http://xmpp.org/extensions/xep-0232.html
+XEP-232	R	XEP-0232										
+XEP-0233	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a method by a connecting client can learn the domain-based service name of a Kerberos acceptor principal for SASL authentication using the GSSAPI mechanism.	http://xmpp.org/extensions/xep-0233.html
+XEP-233	R	XEP-0233										
+XEP-0234	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for transferring files between two entities. The protocol provides a modular framework that enables the exchange of information about the file to be transferred as well as the negotiation of parameters such as the transport to be used.	http://xmpp.org/extensions/xep-0234.html
+XEP-234	R	XEP-0234										
+XEP-0235	A										This specification defines an XMPP extension for delegating access to protected resources over XMPP, using the OAuth protocol.	http://xmpp.org/extensions/xep-0235.html
+XEP-235	R	XEP-0235										
+XEP-0236	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for reporting abusive traffic sent over an XMPP network. Note: This specification has been retracted in favor of XEP-0161, which now contains the content originally published in this specification.	http://xmpp.org/extensions/xep-0236.html
+XEP-236	R	XEP-0236										
+XEP-0237	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a proposed modification to the XMPP roster protocol that enables versioning of rosters such that the server will not send the roster to the client if the roster has not been modified, thus saving bandwidth during session establishment.	http://xmpp.org/extensions/xep-0237.html
+XEP-237	R	XEP-0237										
+XEP-0238	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification provides detailed protocol flows for the establishment of communication between domains that provide XMPP services, including permutations for a wide variety of possible federation policies.	http://xmpp.org/extensions/xep-0238.html
+XEP-238	R	XEP-0238										
+XEP-0239	A										This specification defines Binary XMPP, an obviously superior representation of the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0239.html
+XEP-239	R	XEP-0239										
+XEP-0240	A										This specification defines a recommended best practice for linking to JabberIDs from documents hosted on the World Wide Web.	http://xmpp.org/extensions/xep-0240.html
+XEP-240	R	XEP-0240										
+XEP-0241	A										This specification defines methods for encrypting messages that are archived at an XMPP server.	http://xmpp.org/extensions/xep-0241.html
+XEP-241	R	XEP-0241										
+XEP-0242	A										This document defines XMPP client compliance levels for 2009.	http://xmpp.org/extensions/xep-0242.html
+XEP-242	R	XEP-0242										
+XEP-0243	A										This document defines XMPP server compliance levels for 2009.	http://xmpp.org/extensions/xep-0243.html
+XEP-243	R	XEP-0243										
+XEP-0244	A										This specification defines an XMPP protocol extension for handling the input to and output from a remote entity.	http://xmpp.org/extensions/xep-0244.html
+XEP-244	R	XEP-0244										
+XEP-0245	A										This specification defines recommended handling of the /me command in XMPP instant messaging clients.	http://xmpp.org/extensions/xep-0245.html
+XEP-245	R	XEP-0245										
+XEP-0246	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines methods for communicating via end-to-end XML streams over a logical or physical connection that provides a reliable transport between two endpoints.	http://xmpp.org/extensions/xep-0246.html
+XEP-246	R	XEP-0246										
+XEP-0247	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for establishing direct or mediated XML streams between two entities over any streaming transport. This technology thus enables two entities to establish a trusted connection for end-to-end encryption or for bypassing server limits on large volumes of XMPP traffic.	http://xmpp.org/extensions/xep-0247.html
+XEP-247	R	XEP-0247										
+XEP-0248	A										This specification defines the nature and handling of collection nodes in the XMPP publish-subscribe extension.	http://xmpp.org/extensions/xep-0248.html
+XEP-248	R	XEP-0248										
+XEP-0249	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a method for inviting a contact to a multi-user chat room directly, instead of sending the invitation through the chat room.	http://xmpp.org/extensions/xep-0249.html
+XEP-249	R	XEP-0249										
+XEP-0250	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document describes how to negotiate TLS extensions when using TLS for end-to-end XML streams between two clients. It covers X.509 certificates with an without CA, the use of OpenPGP, Shared Remote Passwords (SRP) and how to use one extension to bootstrap a trust relationship.	http://xmpp.org/extensions/xep-0250.html
+XEP-250	R	XEP-0250										
+XEP-0251	A										This specification defines an extension to XMPP Jingle for transferring a session (such as a voice call) from one person to another.	http://xmpp.org/extensions/xep-0251.html
+XEP-251	R	XEP-0251										
+XEP-0252	A										This specification provides historical documentation regarding the "alternative script syntax" first defined in Version 1.6 of XEP-0124.	http://xmpp.org/extensions/xep-0252.html
+XEP-252	R	XEP-0252										
+XEP-0253	A										This specification defines a method for chaining pubsub nodes together, resulting in lightweight repeaters for pubsub notifications.	http://xmpp.org/extensions/xep-0253.html
+XEP-253	R	XEP-0253										
+XEP-0254	A										This specification defines an extension to XMPP publish-subscribe for queueing information at a node.	http://xmpp.org/extensions/xep-0254.html
+XEP-254	R	XEP-0254										
+XEP-0255	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension for querying a compliant server or service for information about the geographical or physical location of an entity.	http://xmpp.org/extensions/xep-0255.html
+XEP-255	R	XEP-0255										
+XEP-0256	A										This specification defines a way to use the Last Activity extension in XMPP presence notifications.	http://xmpp.org/extensions/xep-0256.html
+XEP-256	R	XEP-0256										
+XEP-0257	A										This specification defines a method to manage client certificates that can be used with SASL External to allow clients to log in without a password.	http://xmpp.org/extensions/xep-0257.html
+XEP-257	R	XEP-0257										
+XEP-0258	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document describes the use of security labels in XMPP. The document specifies             how security label meta-data is carried in XMPP, when this meta-data should or should             not be provided, and how the meta-data is to be processed.	http://xmpp.org/extensions/xep-0258.html
+XEP-258	R	XEP-0258										
+XEP-0259	A									[[Image:http://xmpp.org/images/xmpp.png]]	In servers that deliver messages intended for the bare JID to   all resources, the resource that claims a conversation notifies all   of the other resources of that claim.	http://xmpp.org/extensions/xep-0259.html
+XEP-259	R	XEP-0259										
+XEP-0260	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending data via the SOCKS5 Bytestreams (S5B) protocol defined in XEP-0065. Essentially this transport method reuses XEP-0065 semantics for sending the data and defines native Jingle methods for starting and ending an S5B session.	http://xmpp.org/extensions/xep-0260.html
+XEP-260	R	XEP-0260										
+XEP-0261	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle transport method that results in sending data via the In-Band Bytestreams (IBB) protocol defined in XEP-0047. Essentially this transport method reuses XEP-0047 semantics for sending the data and defines native Jingle methods for starting and ending an IBB session.	http://xmpp.org/extensions/xep-0261.html
+XEP-261	R	XEP-0261										
+XEP-0262	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a Jingle application type for negotiating one or more sessions that use the Real-time Transport Protocol (RTP) to exchange media such as voice or video. The application type includes a straightforward mapping to Session Description Protocol (SDP) for interworking with SIP media endpoints.	http://xmpp.org/extensions/xep-0262.html
+XEP-262	R	XEP-0262										
+XEP-0263	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines best practices and protocol modifications that will reduce the energy consumption of XMPP systems and thereby help to save the planet.	http://xmpp.org/extensions/xep-0263.html
+XEP-263	R	XEP-0263										
+XEP-0264	A										This specification defines a way for a client supply a preview image for a file transfer.	http://xmpp.org/extensions/xep-0264.html
+XEP-264	R	XEP-0264										
+XEP-0265	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines how to send parts of an XML stream over a direct connection between peers. This allows to send large stanzas or binary data without blocking the XML stream for other stanzas.	http://xmpp.org/extensions/xep-0265.html
+XEP-265	R	XEP-0265										
+XEP-0266	A										This document describes implementation considerations related to audio codecs for use in Jingle RTP sessions.	http://xmpp.org/extensions/xep-0266.html
+XEP-266	R	XEP-0266										
+XEP-0267	A										This specification defines a convention for presence subscriptions between XMPP servers.	http://xmpp.org/extensions/xep-0267.html
+XEP-267	R	XEP-0267										
+XEP-0268	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines methods for incident reporting among XMPP server deployments using the IODEF format produced by the IETF's INCH Working Group.	http://xmpp.org/extensions/xep-0268.html
+XEP-268	R	XEP-0268										
+XEP-0269	A										This specification describes methods for exchanging early media in the context of Jingle RTP sessions.	http://xmpp.org/extensions/xep-0269.html
+XEP-269	R	XEP-0269										
+XEP-0270	A										This document defines XMPP protocol compliance levels for 2010.	http://xmpp.org/extensions/xep-0270.html
+XEP-270	R	XEP-0270										
+XEP-0271	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification more clearly defines the nature of nodes as used in the Service Discovery and Publish-Subscribe extensions to the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0271.html
+XEP-271	R	XEP-0271										
+XEP-0272	A									[[Image:http://xmpp.org/images/xmpp.png]]	     This specification defines an XMPP protocol extension for initiating and     managing multiparty voice and video conferences within an XMPP MUC   	http://xmpp.org/extensions/xep-0272.html
+XEP-272	R	XEP-0272										
+XEP-0273	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables a client to exercise control over the XML stanzas it will receive from the server by instructing the server to intercept and filter inbound stanzas.	http://xmpp.org/extensions/xep-0273.html
+XEP-273	R	XEP-0273										
+XEP-0274	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document discusses considerations for the design of Digital Signatures in XMPP,       including use cases and requirements. The document also discusses various ways XML Digital       Signatures could be used in XMPP.	http://xmpp.org/extensions/xep-0274.html
+XEP-274	R	XEP-0274										
+XEP-0275	A										This specification defines an XMPP protocol extension for communicating the reputation of any entity on the network.	http://xmpp.org/extensions/xep-0275.html
+XEP-275	R	XEP-0275										
+XEP-0276	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP protocol extension that enables a user to send directed presence with a request for the target to also share presence information for the duration of a communications session.	http://xmpp.org/extensions/xep-0276.html
+XEP-276	R	XEP-0276										
+XEP-0277	A										This specification defines a method for microblogging over XMPP.	http://xmpp.org/extensions/xep-0277.html
+XEP-277	R	XEP-0277										
+XEP-0278	A									[[Image:http://xmpp.org/images/xmpp.png]]	This documents specifies how Jingle Clients can interact with Jingle Relay Nodes Services and how XMPP entities can provide, search and list available Jingle Relay Nodes.	http://xmpp.org/extensions/xep-0278.html
+XEP-278	R	XEP-0278										
+XEP-0279	A										This specification defines a simple XMPP extension that enables a client to discover its external IP address.	http://xmpp.org/extensions/xep-0279.html
+XEP-279	R	XEP-0279										
+XEP-0280	A										In order to keep all IM clients for a user engaged in a conversation, outbound messages are carbon-copied to all interested resources.	http://xmpp.org/extensions/xep-0280.html
+XEP-280	R	XEP-0280										
+XEP-0281	A										This document defines methods for distributing Multi-User Chat (MUC) rooms across multiple chat services.	http://xmpp.org/extensions/xep-0281.html
+XEP-281	R	XEP-0281										
+XEP-0282	A										Multi-User Chats, distributed over several nodes in the XMPP network, using a master/slave architecture	http://xmpp.org/extensions/xep-0282.html
+XEP-282	R	XEP-0282										
+XEP-0283	A										This document defines an XMPP protocol extension that enables a user to inform its contacts about a change in JID.	http://xmpp.org/extensions/xep-0283.html
+XEP-283	R	XEP-0283										
+XEP-0284	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a protocol that enables two or more endpoints to collaboratively edit an XML object. The protocol is intended for use mainly over the Extensible Messaging and Presence Protocol (XMPP), either by existing instant messaging clients or by specialized editing clients. However, the protocol could also be used over a direct TCP connection rather than over XMPP.	http://xmpp.org/extensions/xep-0284.html
+XEP-284	R	XEP-0284										
+XEP-0285	A										This document provides a technical specification for Encapsulating Digital Signatures       in the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0285.html
+XEP-285	R	XEP-0285										
+XEP-0286	A										This document provides background information for XMPP implementors concerned with mobile devices operating in a cellular network such as 3G.	http://xmpp.org/extensions/xep-0286.html
+XEP-286	R	XEP-0286										
+XEP-0287	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document defines an XMPP protocol extension that enables XMPP entities to interact with spim filters by marking unsolicited or suspicious XMPP stanzas.	http://xmpp.org/extensions/xep-0287.html
+XEP-287	R	XEP-0287										
+XEP-0288	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a protocol for using server-to-server connections in a bidirectional way such that stanzas are sent and received on the same TCP connection.	http://xmpp.org/extensions/xep-0288.html
+XEP-288	R	XEP-0288										
+XEP-0289	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document provides a protocol for reducing the bandwidth cost of local users contributing to a remote MUC over a constrained link through local proxying of the MUC room.	http://xmpp.org/extensions/xep-0289.html
+XEP-289	R	XEP-0289										
+XEP-0290	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document provides a technical specification for Encapsulated Digital             Signatures in the Extensible Messaging and Presence Protocol (XMPP).	http://xmpp.org/extensions/xep-0290.html
+XEP-290	R	XEP-0290										
+XEP-0291	A										This specification defines an approach for users to delegate certain services (e.g. pubsub) to alternative JIDs.	http://xmpp.org/extensions/xep-0291.html
+XEP-291	R	XEP-0291										
+XEP-0292	A										This document specifies an XMPP extension for use of the vCard4 XML format in XMPP systems, with the intent of obsoleting the vcard-temp format.	http://xmpp.org/extensions/xep-0292.html
+XEP-292	R	XEP-0292										
+XEP-0293	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP extension to negotiate   the use of the Extended RTP Profile for Real-time Transport Control   Protocol (RTCP)-Based Feedback (RTP/AVPF) with Jingle RTP   sessions	http://xmpp.org/extensions/xep-0293.html
+XEP-293	R	XEP-0293										
+XEP-0294	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP extension to negotiate   the use of the use of RTP Header Extension as defined by RFC 5285   with Jingle RTP sessions	http://xmpp.org/extensions/xep-0294.html
+XEP-294	R	XEP-0294										
+XEP-0295	A										This specification defines an alternative JSON encoding for XMPP stanzas and other elements.	http://xmpp.org/extensions/xep-0295.html
+XEP-295	R	XEP-0295										
+XEP-0296	A										This document specifies best practices to be followed by Jabber/XMPP clients about when to lock into, and unlock away from, resources.	http://xmpp.org/extensions/xep-0296.html
+XEP-296	R	XEP-0296										
+XEP-0297	A										This document defines a protocol to forward a message from one entity to another.	http://xmpp.org/extensions/xep-0297.html
+XEP-297	R	XEP-0297										
+XEP-0298	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines an XMPP extension for tightly coupled       conference calls. It allows users who participate in multiparty Jingle       calls via a focus agent (mixer) to retrieve information and receive       notifications about the state of the call and the other participants.       This extension is also meant to provide a straightforward way of       connecting SIP and XMPP clients to the same conference room.     	http://xmpp.org/extensions/xep-0298.html
+XEP-298	R	XEP-0298										
+XEP-0299	A										This document describes implementation considerations related to video codecs for use in Jingle RTP sessions.	http://xmpp.org/extensions/xep-0299.html
+XEP-299	R	XEP-0299										
+XEP-0300	A										This document provides recommendations for the use of cryptographic hash functions in XMPP protocol extensions.	http://xmpp.org/extensions/xep-0300.html
+XEP-300	R	XEP-0300										
+XEP-0301	A										This is a specification for real-time text transmitted in-band over an XMPP session.	http://xmpp.org/extensions/xep-0301.html
+XEP-301	R	XEP-0301										
+XEP-0302	A										This document defines XMPP protocol compliance levels for 2012.	http://xmpp.org/extensions/xep-0302.html
+XEP-302	R	XEP-0302										
+XEP-0303	A										This specification defines a method for commenting.	http://xmpp.org/extensions/xep-0303.html
+XEP-303	R	XEP-0303										
+XEP-0304	A										This specification defines a method for negotiating how to send keepalives in XMPP.	http://xmpp.org/extensions/xep-0304.html
+XEP-304	R	XEP-0304										
+XEP-0305	A										This document defines methods for speeding the process of connecting or reconnecting to an XMPP.	http://xmpp.org/extensions/xep-0305.html
+XEP-305	R	XEP-0305										
+XEP-0306	A										This document defines an extensible format for status conditions in Multi-User Chat, similar to the error format used in the core of XMPP.	http://xmpp.org/extensions/xep-0306.html
+XEP-306	R	XEP-0306										
+XEP-0307	A										This specification defines an XMPP protocol extension for requesting a unique room ID from a multi-user chat service.	http://xmpp.org/extensions/xep-0307.html
+XEP-307	R	XEP-0307										
+XEP-0308	A										This specification defines a method for marking a message as a correction of the last sent message.	http://xmpp.org/extensions/xep-0308.html
+XEP-308	R	XEP-0308										
+XEP-0309	A										This specification shows how to combine and extend a number of existing XMPP protocols for improved sharing of information about XMPP servers.	http://xmpp.org/extensions/xep-0309.html
+XEP-309	R	XEP-0309										
+XEP-0310	A									[[Image:http://xmpp.org/images/xmpp.png]]	This document provides a protocol using which a server is able to provide information to clients indicating that previously received presence data may be stale.	http://xmpp.org/extensions/xep-0310.html
+XEP-310	R	XEP-0310										
+XEP-0311	A										This document provides a protocol that can be used for limiting the amount of presence history needed when rejoining a MUC room.	http://xmpp.org/extensions/xep-0311.html
+XEP-311	R	XEP-0311										
+XEP-0312	A									[[Image:http://xmpp.org/images/xmpp.png]]	This specification defines a publish-subscribe feature that enables a subscriber to automatically receive pubsub and PEP notifications since the last logout time of a specific resource.	http://xmpp.org/extensions/xep-0312.html
+XEP-312	R	XEP-0312										
+XEP-0313	A										This document defines a protocol to query and control and archive of messages stored on a server.	http://xmpp.org/extensions/xep-0313.html
+XEP-313	R	XEP-0313										

--- a/xep/parse.py
+++ b/xep/parse.py
@@ -18,8 +18,10 @@ for f in files:
     tree = etree.parse(f)
 
     title = tree.xpath('/xep/header/title')[0].text
-    number = 'XEP-' + tree.xpath('/xep/header/number')[0].text
-    url = 'http://xmpp.org/extensions/' + number.lower() + '.html'
+    number = tree.xpath('/xep/header/number')[0].text
+    long_name = 'XEP-%s' % number
+    short_name = 'XEP-%d' % int(number)
+    url = 'http://xmpp.org/extensions/' + long_name.lower() + '.html'
     abstract = tree.xpath('/xep/header/abstract')[0].text
     image = '';
     
@@ -30,7 +32,9 @@ for f in files:
     abstract = abstract.replace('\n', ' ')
     abstract = abstract.replace('\t', ' ')
     
-    out.write('\t'.join([number, "A", "", "", "", "", "", "", "", "",
+    out.write('\t'.join([long_name, "A", "", "", "", "", "", "", "", "",
                          image,
                          abstract,
                          url]) + '\n')
+    out.write('\t'.join([short_name, "R", long_name,
+                         "", "", "", "", "", "", "", "", "", ""]) + '\n')


### PR DESCRIPTION
This allows "xep 45" to return the same thing as "xep 0045".
