### PR TITLE
C++ standard library reference (cppreference.com)

### DIFF
--- a/lib/DDG/Fathead/CppreferenceDoc.pm
+++ b/lib/DDG/Fathead/CppreferenceDoc.pm
@@ -1,0 +1,31 @@
+package DDG::Fathead::CppreferenceDoc;
+
+use DDG::Fathead;
+
+primary_example_queries "c++ vector";
+
+secondary_example_queries
+    "std::multimap",
+    "std::vector constructor"
+    "std vector constructor"
+    "std vector begin"
+    "c++ vector begin";
+
+description "C++ reference";
+
+name "CppreferenceDoc";
+
+icon_url "";
+
+source "Cppreference";
+
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/cppreference_doc";
+
+topics "geek", "programming";
+
+category "reference";
+
+attribution
+    web => ['http://en.cppreference.com/w/', 'Cppreference contributors'];
+1;
+

--- a/share/cppreference_doc/README.md
+++ b/share/cppreference_doc/README.md
@@ -1,0 +1,18 @@
+Cppreference fathead plugin
+===========================
+
+This is a fathead plugin for C++ standard library reference manual hosted at
+http://en.cppreference.com.
+
+Data source
+-----------
+
+fetch.sh downloads and untars a snapshot of the website, which is available at
+http://en.cppreference.com/w/Cppreference:Archives. A new snapshot is released
+periodically. The script needs to be for the new location of the snapshot.
+
+Dependencies
+------------
+
+* python 3
+* python 3 lxml

--- a/share/cppreference_doc/data.url
+++ b/share/cppreference_doc/data.url
@@ -1,0 +1,1 @@
+http://en.cppreference.com/w/Cppreference:Archives

--- a/share/cppreference_doc/fetch.sh
+++ b/share/cppreference_doc/fetch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+rm -rf download
+mkdir -p download
+
+pushd download > /dev/null
+wget http://upload.cppreference.com/mwiki/images/e/e7/cppreference-doc-20130729-ddg.tar.gz
+tar -xzf cppreference-doc-20130729-ddg.tar.gz
+popd > /dev/null

--- a/share/cppreference_doc/parse.sh
+++ b/share/cppreference_doc/parse.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# we can use glob since the archive contains a single directory
+pushd download/*/ > /dev/null
+python3 index2ddg.py index-functions-cpp.xml ../../output.txt
+popd > /dev/null
+


### PR DESCRIPTION
This pull request is not intended to be applied, for now I just want to gather some feedback :-)

It implements [this idea](https://duckduckhack.uservoice.com/forums/5168-ideas-for-duckduckgo-instant-answer-plugins/suggestions/4119484-c-standard-library-reference).

The plugin works by analyzing the HTML content of the website. The website already [provides a periodically updated archive](http://en.cppreference.com/w/Cppreference:Archives) for offline viewing, so the instead of recursively downloading the live website (which, being wiki, may contain nonsense content at times), the script simply uses the released archive.

Since I'm the maintainer of the said archive, I've used a bit different approach to parse the content than is suggested in the documentation: the plugin calls scripts that (will) come with the archive, instead of invoking parse.xx. This was done because the archive already includes scripts ([github repository](https://github.com/p12tic/cppreference-doc)) that implement much of the functionality needed by the plugin. Additionally, since the HTML content is parsed, the parsing script is complex and strongly coupled with the internal structure of the website, which occasionally changes. If scripts were maintained separately, they would be usable only with specific versions of the archive, which would be harder to manage. I just thought that bundling the scripts would simplify everything a lot. Please let me know if this approach is acceptable, I can extract the required scripts and put them here if it's not.

Currently the abstracts use the absolute minimum space possible: 1-3 lines for the declaration code of the function/class and 1-2 lines for the description, the higher numbers being rare. That hurts usability a bit. What's the reasonable number of lines that the abstract can occupy? Something like 8-10 lines would be great. The additional lines would be used to display additional declarations - some C++ functions have 3-4 overloads with the same name.

All titles currently have the same format: 'c++ <identifier>', for example 'c++ std::vector::begin'. What variations (if any) of the title should I include as redirects? Maybe simple 'std::vector::begin' is also enough?

Finally, how to test Fathead plugins? The documentation only talks about Spice and Goodies.
