### PR TITLE
Fix Issue #56: Javadocs updated to SE 8

### DIFF
--- a/share/java/data.url
+++ b/share/java/data.url
@@ -1,1 +1,1 @@
-http://download.oracle.com/otn-pub/java/jdk/6u30-b12/jdk-6u30-apidocs.zip
+http://download.oracle.com/otn-pub/java/jdk/8-b132/jdk-8-apidocs.zip

--- a/share/java/fetch.sh
+++ b/share/java/fetch.sh
@@ -1,3 +1,3 @@
-# Probably best to go to the below and accept otherwise this probably will not work
+# Probably best to go to the below and accept otherwise this probably will not work (old method from SE 6)
 # http://www.oracle.com/technetwork/java/javase/downloads/jdk-6u25-doc-download-355137.html
-wget http://download.oracle.com/otn-pub/java/jdk/6u30-b12/jdk-6u30-apidocs.zip
+wget http://download.oracle.com/otn-pub/java/jdk/8-b132/jdk-8-apidocs.zip

--- a/share/java/meta.txt
+++ b/share/java/meta.txt
@@ -1,4 +1,4 @@
-Name: JDK 1.6
+Name: JDK 1.8
 Domain: docs.oracle.com
 Type: Java
 MediaWiki: 0

--- a/share/java/parse.py
+++ b/share/java/parse.py
@@ -105,7 +105,7 @@ for fname in dirList:
     # print the object
 
     name = fname.split('/')[-1].replace('.html', '')
-    url = "http://download.oracle.com/javase/6/docs/%s" \
+    url = "http://download.oracle.com/javase/8/docs/%s" \
         % (fname.replace('./docs/java/en/', ''))
     description = spaces.sub(' ', findopenclosetags.sub('', desc).strip())
 
@@ -125,7 +125,7 @@ for fname in dirList:
         #synopsis = j.strip().replace('</A','</A>').replace('>>','>')
         synopsis = ''
         methodname =  r1.sub('', j).replace('</A', '').strip()
-        url = 'http://download.oracle.com/javase/6/docs/%s#%s' % ( fname.replace('./docs/java/en/',''), methodname)
+        url = 'http://download.oracle.com/javase/8/docs/%s#%s' % ( fname.replace('./docs/java/en/',''), methodname)
         namespaceinherited = "%s.%s" % (namespace, name)
 
         print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (methodname,
@@ -140,7 +140,7 @@ for fname in dirList:
         methodname = r1.sub('', findh3.findall(meth)[0]).strip()
         methodurl = finda.findall(meth)[0]
         methodurl = methodurl.replace('<A NAME="', '').replace('">', '')
-        url = 'http://download.oracle.com/javase/6/docs/%s#%s'%(fname.replace('./docs/java/en/', ''),methodurl)
+        url = 'http://download.oracle.com/javase/8/docs/%s#%s'%(fname.replace('./docs/java/en/', ''),methodurl)
         synopsis = findopenclosetags.sub('',findpre.findall(meth)[0].replace('<PRE>', '').replace('</PRE>', '').replace("\r\n", '').strip())
         description = spaces.sub(' ',findopenclosetags.sub('', findddtop.findall(meth)[0].replace('<DD>', '').replace('<P>', '')))
         namespaceinherited = "%s.%s" % (namespace, name)


### PR DESCRIPTION
Updated Java fathead files to use JavaDocs SE 8 URLs and reflect Java 1.8. Light testing without errors.
