### PR TITLE
Add USLaw module.

### DIFF
--- a/lib/DDG/Fathead/USLaw.pm
+++ b/lib/DDG/Fathead/USLaw.pm
@@ -1,0 +1,14 @@
+package DDG::Fathead::USLaw;
+use DDG::Fathead;
+
+primary_example_queries "20 USC 76d";
+secondary_example_queries
+    "20 U.S.C. 76d",
+    "US Code Title 20, Section 76d";
+description "Sections of the United States Code";
+name "USLaw";
+source "United States House of Representatives";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/us_law";
+topics "";
+category "";
+1;

--- a/share/us_law/README.txt
+++ b/share/us_law/README.txt
@@ -1,0 +1,11 @@
+The US Code is (inconsistently) divided into titles, chapters, subchapters, parts, subparts, sections, subsections, paragraphs, and perhaps even further. However, the "primary key" used in the legal profession is (title, section), so the first two fields of the output file are title and section. All further fields are merely human-readable content.
+
+The output file contains some duplicate information. For example, every section in a given chapter contains the heading of the chapter. I figured it was worth the loss of 2 or 3 megabytes for the convenience of needing only to look up one record for every query.
+
+Some of the section numbers are ranges (eg Title 15, Section "79 to 79z–6"). All of the sections in the range have the same content. This can be handled by generating the interior of the range, or simply using string > or < during lookup.
+
+The output contains generated links to www.law.cornell.edu. I chose that site because it is more user-friendly than the gpo.gov one, and it has a much more convenient URL interface: The text of any section can be reached by navigating to www.law.cornell.edu/uscode/text/$title/$section. The government site uses a more cumbersome scheme.
+
+Dependencies:
+	python3
+	bs4	(beautiful soup 4)

--- a/share/us_law/fetch.sh
+++ b/share/us_law/fetch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+wget http://uscode.house.gov/download/releasepoints/us/pl/113/120/xml_uscAll@113-120.zip
+
+mkdir download
+unzip xml_uscAll@113-120.zip -d download/
+
+rm xml_uscAll@113-120.zip

--- a/share/us_law/parse.py
+++ b/share/us_law/parse.py
@@ -6,6 +6,7 @@ import os
 def find_parents(n, parents):
     parents.insert(0, (n.parent.name, n.parent.num, n.parent.heading))
 
+    #if n.parent.name in ["title", "appendix"]:    #top level
     if n.parent.name == "title":    #top level
         return parents
     else:
@@ -13,8 +14,17 @@ def find_parents(n, parents):
 
 for title in os.listdir("download/xml/"):
     soup = BeautifulSoup(open("download/xml/%s" % title))
-    if soup.appendix:   #Appendices don't conform to the pattern
+
+    if soup.appendix:   #Appendices aren't part of the code
         continue
+
+
+    """
+    if soup.appendix and soup.appendix.num.value in ["11a", "28a"]:
+        leaf_element = "courtRule"  #Appendices don't conform to the pattern
+    else:
+        leaf_element = "section"
+    """
 
     for section in soup.find_all("section"):
         if section.get("id") == None:

--- a/share/us_law/parse.py
+++ b/share/us_law/parse.py
@@ -36,7 +36,7 @@ for title in os.listdir("download/xml/"):
         num_title = chain[0][1].get("value")    #One end of the chain is the title...
         num_sec = chain[-1][1].get("value")     #...and the other end is the section
 
-        context = " ".join([x[1].get_text() + " " + x[2].get_text() for x in chain])    #Combine the headings of every level of the chain
+        context = "<br>".join([x[1].get_text() + " " + x[2].get_text() for x in chain])    #Combine the headings of every level of the chain
         url = "http://www.law.cornell.edu/uscode/text/%s/%s" % (num_title, num_sec)
 
         out = "%s USC %s\t" % (num_title, num_sec)        #0

--- a/share/us_law/parse.py
+++ b/share/us_law/parse.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from bs4 import BeautifulSoup
+import os
+
+def find_parents(n, parents):
+	parents.insert(0, (n.parent.name, n.parent.num, n.parent.heading))
+
+	if n.parent.name == "title":	#top level
+		return parents
+	else:
+		return find_parents(n.parent, parents)
+
+for title in os.listdir("download/"):
+	soup = BeautifulSoup(open("download/%s" % title))
+	if soup.appendix:
+		continue
+
+	for section in soup.find_all("section"):
+		if section.get("id") == None:
+			continue	#not a leaf node
+
+		chain = find_parents(section, []) + [(section.name, section.num, section.heading)]
+
+		num_title = chain[0][1].get("value")
+		num_sec = chain[-1][1].get("value")
+
+		out = "\t".join([x[1].get_text() + " " + x[2].get_text() for x in chain])
+		url = "http://www.law.cornell.edu/uscode/text/%s/%s" % (num_title, num_sec)
+		print("%s\t%s\t%s\t%s" % (num_title, num_sec, out, url))

--- a/share/us_law/parse.py
+++ b/share/us_law/parse.py
@@ -4,42 +4,42 @@ from bs4 import BeautifulSoup
 import os
 
 def find_parents(n, parents):
-	parents.insert(0, (n.parent.name, n.parent.num, n.parent.heading))
+    parents.insert(0, (n.parent.name, n.parent.num, n.parent.heading))
 
-	if n.parent.name == "title":	#top level
-		return parents
-	else:
-		return find_parents(n.parent, parents)
+    if n.parent.name == "title":    #top level
+        return parents
+    else:
+        return find_parents(n.parent, parents)
 
 for title in os.listdir("download/xml/"):
-	soup = BeautifulSoup(open("download/xml/%s" % title))
-	if soup.appendix:
-		continue
+    soup = BeautifulSoup(open("download/xml/%s" % title))
+    if soup.appendix:
+        continue
 
-	for section in soup.find_all("section"):
-		if section.get("id") == None:
-			continue	#not a leaf node
+    for section in soup.find_all("section"):
+        if section.get("id") == None:
+            continue    #not a leaf node
 
-		chain = find_parents(section, []) + [(section.name, section.num, section.heading)]
+        chain = find_parents(section, []) + [(section.name, section.num, section.heading)]
 
-		num_title = chain[0][1].get("value")
-		num_sec = chain[-1][1].get("value")
+        num_title = chain[0][1].get("value")
+        num_sec = chain[-1][1].get("value")
 
-		context = " ".join([x[1].get_text() + " " + x[2].get_text() for x in chain])
-		url = "http://www.law.cornell.edu/uscode/text/%s/%s" % (num_title, num_sec)
+        context = " ".join([x[1].get_text() + " " + x[2].get_text() for x in chain])
+        url = "http://www.law.cornell.edu/uscode/text/%s/%s" % (num_title, num_sec)
 
-		out = "%s USC %s\t" % (num_title, num_sec)		#0
-		out += "A\t"		#1
-		out += "\t"		#2
-		out += "\t"		#3
-		out += "\t"		#4
-		out += "\t"		#5
-		out += "\t"		#6
-		out += "\t"		#7
-		out += "\t"		#8
-		out += "\t"		#9
-		out += "\t"		#10
-		out += context + "\t"		#11
-		out += url		#12
+        out = "%s USC %s\t" % (num_title, num_sec)        #0
+        out += "A\t"        #1
+        out += "\t"        #2
+        out += "\t"        #3
+        out += "\t"        #4
+        out += "\t"        #5
+        out += "\t"        #6
+        out += "\t"        #7
+        out += "\t"        #8
+        out += "\t"        #9
+        out += "\t"        #10
+        out += context + "\t"        #11
+        out += url        #12
 
-		print(out)
+        print(out)

--- a/share/us_law/parse.py
+++ b/share/us_law/parse.py
@@ -13,19 +13,20 @@ def find_parents(n, parents):
 
 for title in os.listdir("download/xml/"):
     soup = BeautifulSoup(open("download/xml/%s" % title))
-    if soup.appendix:
+    if soup.appendix:   #Appendices don't conform to the pattern
         continue
 
     for section in soup.find_all("section"):
         if section.get("id") == None:
             continue    #not a leaf node
 
+        #build a chain from the section to the top level. We don't know how many intermediate links there will be.
         chain = find_parents(section, []) + [(section.name, section.num, section.heading)]
 
-        num_title = chain[0][1].get("value")
-        num_sec = chain[-1][1].get("value")
+        num_title = chain[0][1].get("value")    #One end of the chain is the title...
+        num_sec = chain[-1][1].get("value")     #...and the other end is the section
 
-        context = " ".join([x[1].get_text() + " " + x[2].get_text() for x in chain])
+        context = " ".join([x[1].get_text() + " " + x[2].get_text() for x in chain])    #Combine the headings of every level of the chain
         url = "http://www.law.cornell.edu/uscode/text/%s/%s" % (num_title, num_sec)
 
         out = "%s USC %s\t" % (num_title, num_sec)        #0

--- a/share/us_law/parse.py
+++ b/share/us_law/parse.py
@@ -11,8 +11,8 @@ def find_parents(n, parents):
 	else:
 		return find_parents(n.parent, parents)
 
-for title in os.listdir("download/"):
-	soup = BeautifulSoup(open("download/%s" % title))
+for title in os.listdir("download/xml/"):
+	soup = BeautifulSoup(open("download/xml/%s" % title))
 	if soup.appendix:
 		continue
 
@@ -25,6 +25,21 @@ for title in os.listdir("download/"):
 		num_title = chain[0][1].get("value")
 		num_sec = chain[-1][1].get("value")
 
-		out = "\t".join([x[1].get_text() + " " + x[2].get_text() for x in chain])
+		context = " ".join([x[1].get_text() + " " + x[2].get_text() for x in chain])
 		url = "http://www.law.cornell.edu/uscode/text/%s/%s" % (num_title, num_sec)
-		print("%s\t%s\t%s\t%s" % (num_title, num_sec, out, url))
+
+		out = "%s USC %s\t" % (num_title, num_sec)		#0
+		out += "A\t"		#1
+		out += "\t"		#2
+		out += "\t"		#3
+		out += "\t"		#4
+		out += "\t"		#5
+		out += "\t"		#6
+		out += "\t"		#7
+		out += "\t"		#8
+		out += "\t"		#9
+		out += "\t"		#10
+		out += context + "\t"		#11
+		out += url		#12
+
+		print(out)

--- a/share/us_law/parse.sh
+++ b/share/us_law/parse.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 parse.py > output.txt


### PR DESCRIPTION
# Fathead Pull Request


**What does your instant answer do?**
Returns the heading and context of a section of the US Code. For example, the query ``20 USC 76d`` returns the following

    Title 20— EDUCATION
    CHAPTER 3— SMITHSONIAN INSTITUTION, NATIONAL MUSEUMS AND ART GALLERIES
    SUBCHAPTER IV— SMITHSONIAN GALLERY OF ART
    § 76d.  Donations of works of art from Government agencies
    http://www.law.cornell.edu/uscode/text/20/76d

The full text of the law is not included in the answer, as it can vary greatly in length.


**What problem does your instant answer solve (Why is it better than organic links)?**
Since many legal citations to the USC include only title and section, it can be immensely helpful to also know the heading of the section, chapter, and any intermediate subdivisions. Organic links rarely provide the full context at a glance.


**What is the data source for your instant answer? (Provide a link if possible)**
http://uscode.house.gov/download/download.shtml


**Why did you choose this data source?**
The House of Representatives is the custodian of the document.


**Are there any other alternative (better) data sources?**
There are alternatives, but they are not likely to be better than the original source. All of the alternatives I examined appear to be generated from this source, anyway.


**What are some example queries that trigger this instant answer?**
``20 USC 76d``, ``20 US Code § 76d``, ``us code title 20 section 76d``


**Which communities will this instant answer be especially useful for? (gamers, book lovers, etc)**
Legal practitioners and scholars


**Is this instant answer connected to a DuckDuckHack [instant answer idea](https://duck.co/ideas)?**
https://duck.co/ideas/idea/355/law-lookup-by-code-citation
https://duck.co/ideas/idea/617/federal-statute-lookup


**Which existing instant answers will this one supercede/overlap with?**
None known.


**Are you having any problems? Do you need our help with anything?**
The output contains generated links to www.law.cornell.edu. I chose that site because it is more user-friendly than the official gpo.gov one, and it has a much more convenient URL interface: The text of any section can be reached by navigating to www.law.cornell.edu/uscode/text/$title/$section. The government site uses a more cumbersome scheme.