### PR TITLE
Add DebianPkgs module.

### DIFF
--- a/lib/DDG/Fathead/DebianPkgs.pm
+++ b/lib/DDG/Fathead/DebianPkgs.pm
@@ -1,0 +1,17 @@
+package DDG::Fathead::DebianPkgs;
+
+use DDG::Fathead;
+
+primary_example_queries "debian vim";
+secondary_example_queries
+    "debian package plink",
+    "netcat debian pkg";
+description "Debian packages";
+name "DebianPkgs";
+source "Debian.org";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/debian_pkgs";
+topics "linux", "sysadmin";
+category "software";
+
+1;
+

--- a/share/debian_pkgs/fetch.sh
+++ b/share/debian_pkgs/fetch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+mkdir download
+wget https://packages.debian.org/stable/allpackages?format=txt.gz -O download/stable.txt.gz
+wget https://packages.debian.org/testing/allpackages?format=txt.gz -O download/testing.txt.gz
+
+gunzip download/stable.txt.gz
+gunzip download/testing.txt.gz

--- a/share/debian_pkgs/fetch.sh
+++ b/share/debian_pkgs/fetch.sh
@@ -3,6 +3,8 @@
 mkdir download
 wget https://packages.debian.org/stable/allpackages?format=txt.gz -O download/stable.txt.gz
 wget https://packages.debian.org/testing/allpackages?format=txt.gz -O download/testing.txt.gz
+wget https://packages.debian.org/unstable/allpackages?format=txt.gz -O download/unstable.txt.gz
 
 gunzip download/stable.txt.gz
 gunzip download/testing.txt.gz
+gunzip download/unstable.txt.gz

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -10,7 +10,7 @@ for repo in repos:
     with open("download/%s.txt" % repo) as f:
         lines[repo] = f.readlines()
 
-    names[repo] = lines[repo][0].rsplit(" ", 1)[1].strip("\"\n")
+    names[repo] = lines[repo][0].rsplit(" ", 1)[1].strip("\"\n")    #the codename of each repo is in the first line
 
     lines[repo] = lines[repo][6:]   #omit the 6 lines of header
 
@@ -18,7 +18,7 @@ for repo in repos:
         (name, ver, desc) = p.split(" ", 2)
 
         if name not in pkgs.keys():
-            pkgs[name] = {} #this dict will hold the (ver, desc) from each of the three repos
+            pkgs[name] = {} #this dict will hold the package's (ver, desc) from each of the three repos. Some may not exist.
 
         if repo not in pkgs[name].keys():
             pkgs[name][repo] = {}
@@ -33,9 +33,9 @@ for (p, q) in pkgs.items():
     for repo in repos:
         if repo in q.keys():        #11
             abstract.append("%s (%s) %s https://packages.debian.org/%s/%s" % (repo, names[repo], q[repo]["ver"], names[repo], p))
-            if not desc:
+            if not desc:    #we only need to show one of the descriptions, since they're all very similar. We'll prefer them in the order listen in the repos array
                 desc = q[repo]["desc"]
-            if not ver:
+            if not ver:     #same for the screenshot
                 ver = q[repo]["ver"]
 
     out = p + "\t"        #0

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+with open("download/stable.txt") as f:
+	stable = f.readlines()
+
+with open("download/testing.txt") as f:
+	testing = f.readlines()
+
+stable_name = stable[0].rsplit(" ", 1)[1].strip("\"\n")
+testing_name = testing[0].rsplit(" ", 1)[1].strip("\"\n")
+
+stable = stable[6:]	#omit the 6 lines of header
+testing = testing[6:]
+
+pkgs = {}
+
+for p in stable:
+	q = p.split(" ", 2)
+	pkgs[q[0]] = {
+		"stable": {
+			"ver": q[1].strip("()"),
+			"desc": q[2].strip()
+		},
+		"testing": None
+	}
+
+for p in testing:
+	q = p.split(" ", 2)
+	try:
+		pkgs[q[0]]["testing"] = {
+			"ver": q[1].strip("()"),
+			"desc": q[2].strip()
+		}
+	except KeyError:
+		pkgs[q[0]] = {
+			"stable": None,
+			"testing": {
+				"ver": q[1].strip("()"),
+				"desc": q[2].strip()
+			}
+		}
+
+for (p, q) in pkgs.items():
+	if q["stable"] != None:
+		print("stable\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (stable_name, p, q["stable"]["ver"], q["stable"]["desc"], stable_name, p))
+	if q["testing"] != None:
+		print("testing\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (testing_name, p, q["testing"]["ver"], q["testing"]["desc"], testing_name, p))

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -1,103 +1,103 @@
 #!/usr/bin/python3
 
 with open("download/stable.txt") as f:
-	stable = f.readlines()
+    stable = f.readlines()
 
 with open("download/testing.txt") as f:
-	testing = f.readlines()
+    testing = f.readlines()
 
 with open("download/unstable.txt") as f:
-	unstable = f.readlines()
+    unstable = f.readlines()
 
 stable_name = stable[0].rsplit(" ", 1)[1].strip("\"\n")
 testing_name = testing[0].rsplit(" ", 1)[1].strip("\"\n")
 unstable_name = unstable[0].rsplit(" ", 1)[1].strip("\"\n")
 
-stable = stable[6:]	#omit the 6 lines of header
+stable = stable[6:]    #omit the 6 lines of header
 testing = testing[6:]
 unstable = unstable[6:]
 
 pkgs = {}
 
 for p in stable:
-	q = p.split(" ", 2)
-	pkgs[q[0]] = {
-		"stable": {
-			"ver": q[1].strip("()"),
-			"desc": q[2].strip()
-		},
-		"testing": None,
-		"unstable": None
-	}
+    q = p.split(" ", 2)
+    pkgs[q[0]] = {
+        "stable": {
+            "ver": q[1].strip("()"),
+            "desc": q[2].strip()
+        },
+        "testing": None,
+        "unstable": None
+    }
 
 for p in testing:
-	q = p.split(" ", 2)
-	try:
-		pkgs[q[0]]["testing"] = {
-			"ver": q[1].strip("()"),
-			"desc": q[2].strip()
-		}
-	except KeyError:
-		pkgs[q[0]] = {
-			"stable": None,
-			"testing": {
-				"ver": q[1].strip("()"),
-				"desc": q[2].strip()
-			},
-			"unstable": None
-		}
+    q = p.split(" ", 2)
+    try:
+        pkgs[q[0]]["testing"] = {
+            "ver": q[1].strip("()"),
+            "desc": q[2].strip()
+        }
+    except KeyError:
+        pkgs[q[0]] = {
+            "stable": None,
+            "testing": {
+                "ver": q[1].strip("()"),
+                "desc": q[2].strip()
+            },
+            "unstable": None
+        }
 
 for p in unstable:
-	q = p.split(" ", 2)
-	try:
-		pkgs[q[0]]["unstable"] = {
-			"ver": q[1].strip("()"),
-			"desc": q[2].strip()
-		}
-	except KeyError:
-		pkgs[q[0]] = {
-			"stable": None,
-			"testing": None,
-			"unstable": {
-				"ver": q[1].strip("()"),
-				"desc": q[2].strip()
-			}
-		}
+    q = p.split(" ", 2)
+    try:
+        pkgs[q[0]]["unstable"] = {
+            "ver": q[1].strip("()"),
+            "desc": q[2].strip()
+        }
+    except KeyError:
+        pkgs[q[0]] = {
+            "stable": None,
+            "testing": None,
+            "unstable": {
+                "ver": q[1].strip("()"),
+                "desc": q[2].strip()
+            }
+        }
 
 for (p, q) in pkgs.items():
-	desc = None
-	ver = None
-	abstract = []
-	if q["stable"] != None:		#11
-		abstract.append("stable (%s) %s https://packages.debian.org/%s/%s" % (stable_name, q["stable"]["ver"], stable_name, p))
-		if not desc:
-			desc = q["stable"]["desc"]
-		if not ver:
-			ver = q["stable"]["ver"]
-	if q["testing"] != None:
-		abstract.append("testing (%s) %s https://packages.debian.org/%s/%s" % (testing_name, q["testing"]["ver"], testing_name, p))
-		if not desc:
-			desc = q["testing"]["desc"]
-		if not ver:
-			ver = q["testing"]["ver"]
-	if q["unstable"] != None:
-		abstract.append("unstable (%s) %s https://packages.debian.org/%s/%s" % (unstable_name, q["unstable"]["ver"], unstable_name, p))
-		if not desc:
-			desc = q["unstable"]["desc"]
-		if not ver:
-			ver = q["unstable"]["ver"]
+    desc = None
+    ver = None
+    abstract = []
+    if q["stable"] != None:        #11
+        abstract.append("stable (%s) %s https://packages.debian.org/%s/%s" % (stable_name, q["stable"]["ver"], stable_name, p))
+        if not desc:
+            desc = q["stable"]["desc"]
+        if not ver:
+            ver = q["stable"]["ver"]
+    if q["testing"] != None:
+        abstract.append("testing (%s) %s https://packages.debian.org/%s/%s" % (testing_name, q["testing"]["ver"], testing_name, p))
+        if not desc:
+            desc = q["testing"]["desc"]
+        if not ver:
+            ver = q["testing"]["ver"]
+    if q["unstable"] != None:
+        abstract.append("unstable (%s) %s https://packages.debian.org/%s/%s" % (unstable_name, q["unstable"]["ver"], unstable_name, p))
+        if not desc:
+            desc = q["unstable"]["desc"]
+        if not ver:
+            ver = q["unstable"]["ver"]
 
-	out = p + "\t"		#0
-	out += "A\t"		#1
-	out += "\t"			#2
-	out += "\t"			#3
-	out += "\t"			#4
-	out += "\t"			#5
-	out += "\t"			#6
-	out += "\t"			#7
-	out += "\t"			#8
-	out += "\t"			#9
-	out += "[[Image:https://screenshots.debian.net/thumbnail-with-version/%s/%s]]\t" % (p, ver)		#10
-	out += desc + "<br>" + "<br>".join(abstract)	#11
-	out += "\t"			#12
-	print(out)
+    out = p + "\t"        #0
+    out += "A\t"        #1
+    out += "\t"            #2
+    out += "\t"            #3
+    out += "\t"            #4
+    out += "\t"            #5
+    out += "\t"            #6
+    out += "\t"            #7
+    out += "\t"            #8
+    out += "\t"            #9
+    out += "[[Image:https://screenshots.debian.net/thumbnail-with-version/%s/%s]]\t" % (p, ver)        #10
+    out += desc + "<br>" + "<br>".join(abstract)    #11
+    out += "\t"            #12
+    print(out)

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -65,9 +65,32 @@ for p in unstable:
 		}
 
 for (p, q) in pkgs.items():
-	if q["stable"] != None:
-		print("stable\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (stable_name, p, q["stable"]["ver"], q["stable"]["desc"], stable_name, p))
+	desc = None
+	abstract = []
+	if q["stable"] != None:		#11
+		abstract.append("stable (%s) %s https://packages.debian.org/%s/%s" % (stable_name, q["stable"]["ver"], stable_name, p))
+		if not desc:
+			desc = q["stable"]["desc"]
 	if q["testing"] != None:
-		print("testing\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (testing_name, p, q["testing"]["ver"], q["testing"]["desc"], testing_name, p))
+		abstract.append("testing (%s) %s https://packages.debian.org/%s/%s" % (testing_name, q["testing"]["ver"], testing_name, p))
+		if not desc:
+			desc = q["testing"]["desc"]
 	if q["unstable"] != None:
-		print("unstable\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (unstable_name, p, q["unstable"]["ver"], q["unstable"]["desc"], unstable_name, p))
+		abstract.append("unstable (%s) %s https://packages.debian.org/%s/%s" % (unstable_name, q["unstable"]["ver"], unstable_name, p))
+		if not desc:
+			desc = q["unstable"]["desc"]
+
+	out = p + "\t"		#0
+	out += "A\t"		#1
+	out += "\t"			#2
+	out += "\t"			#3
+	out += "\t"			#4
+	out += "\t"			#5
+	out += "\t"			#6
+	out += "\t"			#7
+	out += "\t"			#8
+	out += "\t"			#9
+	out += "\t"			#10
+	out += desc + "<br>" + "<br>".join(abstract)	#11
+	out += "\t"			#12
+	print(out)

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -6,11 +6,16 @@ with open("download/stable.txt") as f:
 with open("download/testing.txt") as f:
 	testing = f.readlines()
 
+with open("download/unstable.txt") as f:
+	unstable = f.readlines()
+
 stable_name = stable[0].rsplit(" ", 1)[1].strip("\"\n")
 testing_name = testing[0].rsplit(" ", 1)[1].strip("\"\n")
+unstable_name = unstable[0].rsplit(" ", 1)[1].strip("\"\n")
 
 stable = stable[6:]	#omit the 6 lines of header
 testing = testing[6:]
+unstable = unstable[6:]
 
 pkgs = {}
 
@@ -21,7 +26,8 @@ for p in stable:
 			"ver": q[1].strip("()"),
 			"desc": q[2].strip()
 		},
-		"testing": None
+		"testing": None,
+		"unstable": None
 	}
 
 for p in testing:
@@ -37,6 +43,24 @@ for p in testing:
 			"testing": {
 				"ver": q[1].strip("()"),
 				"desc": q[2].strip()
+			},
+			"unstable": None
+		}
+
+for p in unstable:
+	q = p.split(" ", 2)
+	try:
+		pkgs[q[0]]["unstable"] = {
+			"ver": q[1].strip("()"),
+			"desc": q[2].strip()
+		}
+	except KeyError:
+		pkgs[q[0]] = {
+			"stable": None,
+			"testing": None,
+			"unstable": {
+				"ver": q[1].strip("()"),
+				"desc": q[2].strip()
 			}
 		}
 
@@ -45,3 +69,5 @@ for (p, q) in pkgs.items():
 		print("stable\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (stable_name, p, q["stable"]["ver"], q["stable"]["desc"], stable_name, p))
 	if q["testing"] != None:
 		print("testing\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (testing_name, p, q["testing"]["ver"], q["testing"]["desc"], testing_name, p))
+	if q["unstable"] != None:
+		print("unstable\t%s\t%s\t%s\t%s\thttps://packages.debian.org/%s/%s" % (unstable_name, p, q["unstable"]["ver"], q["unstable"]["desc"], unstable_name, p))

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -33,7 +33,7 @@ for (p, q) in pkgs.items():
     for repo in repos:
         if repo in q.keys():        #11
             abstract.append("%s (%s) %s https://packages.debian.org/%s/%s" % (repo, names[repo], q[repo]["ver"], names[repo], p))
-            if not desc:    #we only need to show one of the descriptions, since they're all very similar. We'll prefer them in the order listen in the repos array
+            if not desc:    #we only need to show one of the descriptions, since they're all very similar. We'll prefer them in the order listed in the repos array
                 desc = q[repo]["desc"]
             if not ver:     #same for the screenshot
                 ver = q[repo]["ver"]

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -30,17 +30,19 @@ for (p, q) in pkgs.items():
     desc = None
     ver = None
     abstract = []
+    firstrepo = None  #the first repo that contains the package, for generating a link
     for repo in repos:
         if repo in q.keys():        #11
-            abstract.append("%s (%s) %s https://packages.debian.org/%s/%s" % (repo, names[repo], q[repo]["ver"], names[repo], p))
+            abstract.append("%s (%s) %s" % (repo, names[repo], q[repo]["ver"]))
             if not desc:    #we only need to show one of the descriptions, since they're all very similar. We'll prefer them in the order listed in the repos array
                 desc = q[repo]["desc"]
             if not ver:     #same for the screenshot
                 ver = q[repo]["ver"]
+            if not firstrepo:
+                firstrepo = names[repo]
 
-    out = p + "\t"        #0
-    out += "A\t"        #1
-    out += "\t"            #2
+    out = p + "\t"         #1
+    out += "A\t"           #2
     out += "\t"            #3
     out += "\t"            #4
     out += "\t"            #5
@@ -48,7 +50,9 @@ for (p, q) in pkgs.items():
     out += "\t"            #7
     out += "\t"            #8
     out += "\t"            #9
-    out += "[[Image:https://screenshots.debian.net/thumbnail-with-version/%s/%s]]\t" % (p, ver)        #10
-    out += desc + "<br>" + "<br>".join(abstract)    #11
-    out += "\t"            #12
+    out += "\t"            #10
+    out += "[[Image:https://screenshots.debian.net/thumbnail-with-version/%s/%s]]\t" % (p, ver)        #11
+    out += desc + "<br><br>" + "<br>".join(abstract)    #12
+    out += "\thttps://packages.debian.org/%s/%s" % (firstrepo, p)            #13
+
     print(out)

--- a/share/debian_pkgs/parse.py
+++ b/share/debian_pkgs/parse.py
@@ -66,19 +66,26 @@ for p in unstable:
 
 for (p, q) in pkgs.items():
 	desc = None
+	ver = None
 	abstract = []
 	if q["stable"] != None:		#11
 		abstract.append("stable (%s) %s https://packages.debian.org/%s/%s" % (stable_name, q["stable"]["ver"], stable_name, p))
 		if not desc:
 			desc = q["stable"]["desc"]
+		if not ver:
+			ver = q["stable"]["ver"]
 	if q["testing"] != None:
 		abstract.append("testing (%s) %s https://packages.debian.org/%s/%s" % (testing_name, q["testing"]["ver"], testing_name, p))
 		if not desc:
 			desc = q["testing"]["desc"]
+		if not ver:
+			ver = q["testing"]["ver"]
 	if q["unstable"] != None:
 		abstract.append("unstable (%s) %s https://packages.debian.org/%s/%s" % (unstable_name, q["unstable"]["ver"], unstable_name, p))
 		if not desc:
 			desc = q["unstable"]["desc"]
+		if not ver:
+			ver = q["unstable"]["ver"]
 
 	out = p + "\t"		#0
 	out += "A\t"		#1
@@ -90,7 +97,7 @@ for (p, q) in pkgs.items():
 	out += "\t"			#7
 	out += "\t"			#8
 	out += "\t"			#9
-	out += "\t"			#10
+	out += "[[Image:https://screenshots.debian.net/thumbnail-with-version/%s/%s]]\t" % (p, ver)		#10
 	out += desc + "<br>" + "<br>".join(abstract)	#11
 	out += "\t"			#12
 	print(out)

--- a/share/debian_pkgs/parse.sh
+++ b/share/debian_pkgs/parse.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 parse.py > output.txt


### PR DESCRIPTION
# Fathead Pull Request


**What does your instant answer do?**
Returns the version and short description of a Debian package in the current stable and testing repositories.


**What problem does your instant answer solve (Why is it better than organic links)?**
It provides enough information at a glance to tell a user the generalities of a package and the current versions in Debian. Organic links rarely provide such information without navigating to the destination.


**What is the data source for your instant answer? (Provide a link if possible)**
https://packages.debian.org/stable/allpackages?format=txt.gz
https://packages.debian.org/testing/allpackages?format=txt.gz


**Why did you choose this data source?**
This is the authoritative list of packages in Debian


**Are there any other alternative (better) data sources?**
There are alternatives, but they are not likely to be better than the list from packages.debian.org.


**What are some example queries that trigger this instant answer?**

    debian vim
    debian package plink
    netcat debian pkg


**Which communities will this instant answer be especially useful for? (gamers, book lovers, etc)**
Debian users; possibly Ubuntu users


**Is this instant answer connected to a DuckDuckHack [instant answer idea](https://duck.co/ideas)?**
https://duck.co/ideas/idea/277/debian-and-derivatives-like-ubuntu-package-infor


**Which existing instant answers will this one supercede/overlap with?**
None known. There is a unmerged branch at https://github.com/duckduckgo/zeroclickinfo-fathead/tree/debian_pkgs, but it hasn't been touched in years.


**Are you having any problems? Do you need our help with anything?**
None.