### PR TITLE
Apple OSX Documentation

### DIFF
--- a/lib/DDG/Fathead/AppleOSX.pm
+++ b/lib/DDG/Fathead/AppleOSX.pm
@@ -9,7 +9,7 @@ secondary_example_queries
 
 description "OSX documentation";
 
-name "AppleOSX";
+name "Apple OSX";
 
 icon_url "";
 

--- a/lib/DDG/Fathead/AppleOSX.pm
+++ b/lib/DDG/Fathead/AppleOSX.pm
@@ -1,0 +1,28 @@
+package DDG::Fathead::AppleOSX;
+
+use DDG::Fathead;
+
+primary_example_queries "osx nsstring";
+
+secondary_example_queries
+    "nsstring osx";
+
+description "OSX documentation";
+
+name "AppleOSX";
+
+icon_url "";
+
+source "Apple Developer";
+
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/apple_osx";
+
+topics "geek", "programming";
+
+category "programming";
+
+attribution
+    twitter => ['https://twitter.com/boyter', 'boyter'],
+    web => ['http://www.boyter.org/', 'Ben Boyter'];
+
+1;

--- a/share/apple_osx/.gitignore
+++ b/share/apple_osx/.gitignore
@@ -1,0 +1,1 @@
+developer.apple.com.library/*

--- a/share/apple_osx/.gitignore
+++ b/share/apple_osx/.gitignore
@@ -1,1 +1,2 @@
 developer.apple.com.library/*
+developer.apple.com/*

--- a/share/apple_osx/.gitignore
+++ b/share/apple_osx/.gitignore
@@ -1,2 +1,2 @@
-developer.apple.com.library/*
 developer.apple.com/*
+output.txt

--- a/share/apple_osx/README.txt
+++ b/share/apple_osx/README.txt
@@ -1,0 +1,9 @@
+Dependencies:
+
+Python
+BeautifulSoup (bs4)
+
+To install in Ubuntu:
+
+sudo apt-get install pip
+sudo pip install beautifulsoup4

--- a/share/apple_osx/fetch.sh
+++ b/share/apple_osx/fetch.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname -- "$0")
+
+# wget madness here...

--- a/share/apple_osx/fetch.sh
+++ b/share/apple_osx/fetch.sh
@@ -3,8 +3,5 @@
 cd $(dirname -- "$0")
 
 # wget madness here... this takes a long time
-# may want to consider --limit-rate=20k to something 
+# may want to consider --limit-rate=20k to avoid being blocked
 wget -m -c --remote-encoding=UTF-8 --wait 0.25 https://developer.apple.com/library/mac/sitemap.php
-
-# if you are really impatient...
-#wget -m -c --remote-encoding=UTF-8 https://developer.apple.com/library/mac/sitemap.php

--- a/share/apple_osx/fetch.sh
+++ b/share/apple_osx/fetch.sh
@@ -2,4 +2,9 @@
 
 cd $(dirname -- "$0")
 
-# wget madness here...
+# wget madness here... this takes a long time
+# may want to consider --limit-rate=20k to something 
+wget -m -c --remote-encoding=UTF-8 --wait 0.25 https://developer.apple.com/library/mac/sitemap.php
+
+# if you are really impatient...
+#wget -m -c --remote-encoding=UTF-8 https://developer.apple.com/library/mac/sitemap.php

--- a/share/apple_osx/fetch.sh
+++ b/share/apple_osx/fetch.sh
@@ -4,4 +4,5 @@ cd $(dirname -- "$0")
 
 # wget madness here... this takes a long time
 # may want to consider --limit-rate=20k to avoid being blocked
-wget -m -c --remote-encoding=UTF-8 --wait 0.25 https://developer.apple.com/library/mac/sitemap.php
+# sadly you cannot --no-clobber with -m
+wget -m  --remote-encoding=UTF-8 --wait 0.25 https://developer.apple.com/library/mac/sitemap.php

--- a/share/apple_osx/meta.txt
+++ b/share/apple_osx/meta.txt
@@ -1,0 +1,20 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: Apple OSX
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: https://developer.apple.com/
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: Apple Developer
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with,
+Keywords: osx

--- a/share/apple_osx/parse.py
+++ b/share/apple_osx/parse.py
@@ -12,7 +12,7 @@ files = []
 
 for root, dirs, filelist in os.walk('./developer.apple.com/'):
     for file in filelist:
-        if '.html' in file and 'Reference' in file:
+        if '.html' in file and 'Reference' in file and '?' not in file:
             files.append("%s/%s" % (root, file))
 
 for file in files:
@@ -37,7 +37,9 @@ for file in files:
     synopsis = ''
     namespace = name
 
-    print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url, desc, synopsis, '', 'osx', 'en')
+    # https://stackoverflow.com/questions/19145183/redirecting-pythons-stdout-to-the-file-fails-with-unicodeencodeerror
+    encoding = sys.stdout.encoding or 'utf-8'
+    print ("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url, desc, synopsis, '', 'osx', 'en')).encode(encoding)
 
     space = name
     for i in soup.findAll(attrs={"class": "api instanceMethod"}):
@@ -56,7 +58,8 @@ for file in files:
 
         desc = UnicodeDammit(desc).unicode_markup
 
-        print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')
+        encoding = sys.stdout.encoding or 'utf-8'
+        print ("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')).encode(encoding)
 
     for i in soup.findAll(attrs={"class": "api classMethod"}):
         name = i.findAll('h3')[0].string
@@ -74,5 +77,6 @@ for file in files:
 
         desc = UnicodeDammit(desc).unicode_markup
 
-        print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')
+        encoding = sys.stdout.encoding or 'utf-8'
+        print ("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')).encode(encoding)
 

--- a/share/apple_osx/parse.py
+++ b/share/apple_osx/parse.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from bs4.dammit import UnicodeDammit
 import re
 import os
 import sys
@@ -8,9 +9,6 @@ openclosetags = re.compile('''<.*?>|</.*?>''', re.DOTALL)
 spaces = re.compile('''\s+''', re.DOTALL)
 
 files = []
-
-#files.append('./developer.apple.com.library/mac/documentation/Cocoa/Reference/
-# NSCondition_class/Reference-Reference.html')
 
 # ouput should be in format
 # name
@@ -22,11 +20,10 @@ files = []
 # type
 # lang
 
-for root, dirs, filelist in os.walk('./developer.apple.com.library/'):
+for root, dirs, filelist in os.walk('./developer.apple.com/'):
     for file in filelist:
-        if '.html' in file:
+        if '.html' in file and 'Reference' in file:
             files.append("%s/%s" % (root, file))
-
 
 for file in files:
     filecontents = ''
@@ -46,7 +43,7 @@ for file in files:
         desc = openclosetags.sub('', temp)
 
     name = name.split(' ')[0]
-    url = "http://%s" % (file.replace('./docs/apple/osx/', '').replace('\\', '/').replace('developer.apple.com.', 'developer.apple.com/').replace('-', '/'))
+    url = "https://%s" % (file.replace('\\', '/').replace('./developer.apple.com/', 'developer.apple.com/').replace('-', '/'))
     synopsis = ''
     namespace = name
 
@@ -66,7 +63,9 @@ for file in files:
         if len(i.findAll(attrs={'class': 'api availability'})) != 0:
             desc = '%s %s' % (desc, openclosetags.sub('', str(i.findAll(attrs={'class': 'api availability'})[0].findAll('li')[0])))
         synopsis = openclosetags.sub('', str(i.findAll(attrs={'class': 'declaration'})[0]))[2:]
-        print
+
+        desc = UnicodeDammit(desc).unicode_markup
+
         print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')
 
     for i in soup.findAll(attrs={"class": "api classMethod"}):
@@ -82,5 +81,8 @@ for file in files:
         if len(i.findAll(attrs={'class': 'api availability'})) != 0:
             desc = '%s %s' % (desc, openclosetags.sub('', str(i.findAll(attrs={'class': 'api availability'})[0].findAll('li')[0])))
         synopsis = openclosetags.sub('', str(i.findAll(attrs={'class': 'declaration'})[0]))[2:]
-        print
+
+        desc = UnicodeDammit(desc).unicode_markup
+
         print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')
+

--- a/share/apple_osx/parse.py
+++ b/share/apple_osx/parse.py
@@ -10,16 +10,6 @@ spaces = re.compile('''\s+''', re.DOTALL)
 
 files = []
 
-# ouput should be in format
-# name
-# namespace
-# url
-# description
-# synopsis (code)
-# details
-# type
-# lang
-
 for root, dirs, filelist in os.walk('./developer.apple.com/'):
     for file in filelist:
         if '.html' in file and 'Reference' in file:

--- a/share/apple_osx/parse.py
+++ b/share/apple_osx/parse.py
@@ -1,0 +1,86 @@
+from bs4 import BeautifulSoup
+import re
+import os
+import sys
+import string
+
+openclosetags = re.compile('''<.*?>|</.*?>''', re.DOTALL)
+spaces = re.compile('''\s+''', re.DOTALL)
+
+files = []
+
+#files.append('./developer.apple.com.library/mac/documentation/Cocoa/Reference/
+# NSCondition_class/Reference-Reference.html')
+
+# ouput should be in format
+# name
+# namespace
+# url
+# description
+# synopsis (code)
+# details
+# type
+# lang
+
+for root, dirs, filelist in os.walk('./developer.apple.com.library/'):
+    for file in filelist:
+        if '.html' in file:
+            files.append("%s/%s" % (root, file))
+
+
+for file in files:
+    filecontents = ''
+    for line in open(file):
+        line = ''.join(filter(lambda x: x in string.printable, line))
+        filecontents = "%s %s" % (filecontents, line.strip())
+
+    soup = BeautifulSoup(filecontents)
+
+    # Get Object Details
+    name = openclosetags.sub('', str(soup.findAll(attrs={"id": "pageTitle"})[0]))
+    if len(soup.findAll(attrs={"class": "abstract"})) != 0:
+        desc = openclosetags.sub('', str(soup.findAll(attrs={"class": "abstract"})[0]))
+    else:
+        temp = soup.findAll(attrs={"id": "Overview_section"})[0].findAll('p')
+        temp = ''.join(map(lambda x: str(x), temp))
+        desc = openclosetags.sub('', temp)
+
+    name = name.split(' ')[0]
+    url = "http://%s" % (file.replace('./docs/apple/osx/', '').replace('\\', '/').replace('developer.apple.com.', 'developer.apple.com/').replace('-', '/'))
+    synopsis = ''
+    namespace = name
+
+    print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url, desc, synopsis, '', 'osx', 'en')
+
+    space = name
+    for i in soup.findAll(attrs={"class": "api instanceMethod"}):
+        name = i.findAll('h3')[0].string
+        desc = openclosetags.sub('', str(i.findAll('p')[0]))
+        namespace = "%s.%s" % (space, name)
+
+        url2 = "%s#%s" % (url, i.findAll('a')[0]['name'])
+
+        api = i.findAll(attrs={'class': 'api discussion'})
+        if len(api) != 0:
+            desc = "%s %s" % (desc, openclosetags.sub('', ' '.join(map(lambda x: str(x), api[0].findAll('p')))))
+        if len(i.findAll(attrs={'class': 'api availability'})) != 0:
+            desc = '%s %s' % (desc, openclosetags.sub('', str(i.findAll(attrs={'class': 'api availability'})[0].findAll('li')[0])))
+        synopsis = openclosetags.sub('', str(i.findAll(attrs={'class': 'declaration'})[0]))[2:]
+        print
+        print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')
+
+    for i in soup.findAll(attrs={"class": "api classMethod"}):
+        name = i.findAll('h3')[0].string
+        desc = openclosetags.sub('', str(i.findAll('p')[0]))
+        namespace = "%s.%s" % (space, name)
+
+        url2 = "%s#%s" % (url, i.findAll('a')[0]['name'])
+
+        api = i.findAll(attrs={'class': 'api discussion'})
+        if len(api) != 0:
+            desc = "%s %s" % (desc, openclosetags.sub('', ' '.join(map(lambda x: str(x), api[0].findAll('p')))))
+        if len(i.findAll(attrs={'class': 'api availability'})) != 0:
+            desc = '%s %s' % (desc, openclosetags.sub('', str(i.findAll(attrs={'class': 'api availability'})[0].findAll('li')[0])))
+        synopsis = openclosetags.sub('', str(i.findAll(attrs={'class': 'declaration'})[0]))[2:]
+        print
+        print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (name, namespace, url2, desc, synopsis, '', 'osx', 'en')

--- a/share/apple_osx/parse.sh
+++ b/share/apple_osx/parse.sh
@@ -2,4 +2,4 @@
 
 cd $(dirname -- "$0")
 
-python parse.py
+python parse.py > output.txt

--- a/share/apple_osx/parse.sh
+++ b/share/apple_osx/parse.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname -- "$0")
+
+python parse.py


### PR DESCRIPTION
Updated the OSX documentation fathead parser based on the original one in UNCLEAN.
This matches most of the fathead requirements (I believe) and now pulls down and processes
the documentation from developer.apple.com.

Be aware it takes a very long time to make a mirror of the site using wget. There is a sitemap
provided by Apple (its the start point of the wget command in fetch.sh) which might be able to 
speed this up as each link appears to be the correct one.

This still isn't pep8 compliant due to some lines being too long, and isn't 100% Pythonic but 
is close enough for the moment.

Finally the output.txt is not added (nor the wget output) as it is well over the 1 meg limit specified.