### PR TITLE
HTMLRef: Make separate entries for each of the H1-H6 tags (fixes #33)

### DIFF
--- a/share/html_ref/parse.py
+++ b/share/html_ref/parse.py
@@ -80,8 +80,16 @@ class Parser(object):
                 reference = a_tags[0]['href']  # url for W3C
 
             reference = 'http://html5doctor.com/element-index/#' + name
-            new_tag = Tag(name, info, reference, example)
-            self.tags.append(new_tag)
+
+            # special case for h1-h6
+            if name == 'h1-h6':
+                for n in range(1, 7):
+                    new_tag = Tag('h' + str(n), info, reference, example)
+                    self.tags.append(new_tag)
+            else:
+                new_tag = Tag(name, info, reference, example)
+                self.tags.append(new_tag)
+
             logger.info('Tag parsed: %s' % new_tag.name)
 
 

--- a/share/html_ref/parse.sh
+++ b/share/html_ref/parse.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
-python parse.py
+python2 parse.py


### PR DESCRIPTION
This should fix the problem described in #33, but may need more work. The code looks correct, but the output is very different from the output.txt in the repo. The one in the repo has 8 fields; the one generated by the code has 13. I'm still not sure which one is the preferred format.

I also changed the interpreter to explicitly be `python2`. I think that may reduce confusion for new developers in the future.

Furthermore, I changed `bash` to `sh`. There's no need for any of bash's advanced features, and sh is often orders of magnitude smaller and faster.