### PR TITLE
Fix issue #74: out-of-date pypi package info

### DIFF
--- a/share/pypi/fetch.sh
+++ b/share/pypi/fetch.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# rm -rf download
+rm -rf download
 mkdir -p download
-# Note - just picked 30 pages arbitrarily for the moment
-curl "http://pypi.python.org/pypi?%3Aaction=index" --output "download/pypy.html"
+curl -L "https://pypi.python.org/pypi?%3Aaction=index" --output "download/pypy.html"
 


### PR DESCRIPTION
The problem was that pypi added a 301 redirect from http to https and the fetch script just failed silently.

This should fix issue #74, but it's probably worth fixing the parse script as well, because a good chunk of it appears to be broken (lines 52-66). I'm happy to do it as part of a separate issue, as I'd fix it by completely rewriting the parser in Python. Thoughts?
