### PR TITLE
Removed the "hg " in front of the command name

### DIFF
--- a/share/UNCLEAN/parse_mercurial.py
+++ b/share/UNCLEAN/parse_mercurial.py
@@ -33,7 +33,7 @@ for file in files:
   for i in t[0].findAll('div'):
     searchname = None
     if len(i.findAll('h2')) != 0:
-      searchname = "hg %s"%(i.findAll('h2')[0].string)
+      searchname = i.findAll('h2')[0].string
       url = "http://www.selenic.com/mercurial/hg.1.html#%s"%(searchname)
     if len(i.findAll('pre')) != 0:
       synopsis = i.findAll('pre')[0].string.strip()


### PR DESCRIPTION
This fixes issue #67 -- the anchor part of the URL should only be the command name (like `#commit`), not `#hg commit`.

According to the documentation, it's impossible to test Fathead instant answers right now. Is that right? I have not tested this yet.