### PR TITLE
Update code urls for move of share subdirectories

### DIFF
--- a/lib/DDG/Fathead/Airports.pm
+++ b/lib/DDG/Fathead/Airports.pm
@@ -9,7 +9,7 @@ secondary_example_queries
 description "Airport IATA/ICAO codes";
 name "Airports";
 source "Wikipedia";
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/airports";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/airports";
 topics "special_interest";
 category "reference";
 attribution

--- a/lib/DDG/Fathead/ArchPkgs.pm
+++ b/lib/DDG/Fathead/ArchPkgs.pm
@@ -18,7 +18,7 @@ icon_url "/i/www.archlinux.org.ico";
 
 source "Arch Linux";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/arch_pkgs";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/arch_pkgs";
 
 topics "geek", "sysadmin", "special_interest";
 

--- a/lib/DDG/Fathead/Bible.pm
+++ b/lib/DDG/Fathead/Bible.pm
@@ -18,7 +18,7 @@ icon_url "/i/blueletterbible.org.ico";
 
 source "Blue Letter Bible";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/bible";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/bible";
 
 topics "everyday", "special_interest";
 

--- a/lib/DDG/Fathead/CSSRef.pm
+++ b/lib/DDG/Fathead/CSSRef.pm
@@ -15,7 +15,7 @@ icon_url "/i/developer.mozilla.org.ico";
 
 source "Mozilla Developer Network";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/css_ref";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/css_ref";
 
 topics "geek", "web_design";
 

--- a/lib/DDG/Fathead/CVE.pm
+++ b/lib/DDG/Fathead/CVE.pm
@@ -7,7 +7,7 @@ secondary_example_queries 'cve 2009-1234';
 description 'Common Vulnerabilities and Exposures (CVE) reference';
 name 'CVE';
 source 'CVE Details';
-code_url 'https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/cve';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/cve';
 topics 'computing', 'programming', 'special_interest';
 category 'reference';
 attribution

--- a/lib/DDG/Fathead/CanIUse.pm
+++ b/lib/DDG/Fathead/CanIUse.pm
@@ -16,7 +16,7 @@ icon_url "/i/caniuse.com.ico";
 
 source "GitHub";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/caniuse";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/caniuse";
 
 topics "geek", "web_design";
 

--- a/lib/DDG/Fathead/CelebHeights.pm
+++ b/lib/DDG/Fathead/CelebHeights.pm
@@ -8,7 +8,7 @@ description "Celebrity Heights";
 name "CelebHeights";
 icon_url "/i/celebheights.com.ico";
 source "GitHub";
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/celeb_heights";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/celeb_heights";
 topics "everyday", "trivia";
 category "reference";
 

--- a/lib/DDG/Fathead/CppreferenceDoc.pm
+++ b/lib/DDG/Fathead/CppreferenceDoc.pm
@@ -12,7 +12,7 @@ secondary_example_queries
 description "C++ reference";
 name "CppreferenceDoc";
 source "Cppreference";
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/cppreference_doc";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/cppreference_doc";
 topics "geek", "programming";
 category "reference";
 attribution web => ['http://en.cppreference.com/w/', 'Cppreference contributors'];

--- a/lib/DDG/Fathead/FileFormats.pm
+++ b/lib/DDG/Fathead/FileFormats.pm
@@ -16,7 +16,7 @@ icon_url "/assets/icon_wikipedia.v101.png";
 
 source "Wikipedia";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/file_formats";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/file_formats";
 
 topics "everyday", "geek", "sysadmin";
 

--- a/lib/DDG/Fathead/FirefoxAboutConfig.pm
+++ b/lib/DDG/Fathead/FirefoxAboutConfig.pm
@@ -17,7 +17,7 @@ icon_url "/i/mozillazine.org.ico";
 
 source "MozillaZine";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/firefox_about_config";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/firefox_about_config";
 
 topics "geek", "sysadmin", "special_interest";
 

--- a/lib/DDG/Fathead/HGNCGeneNames.pm
+++ b/lib/DDG/Fathead/HGNCGeneNames.pm
@@ -16,7 +16,7 @@ icon_url "/i/www.genenames.org.ico";
 
 source "HGNC";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/hgnc_gene_names";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/hgnc_gene_names";
 
 topics "science", "special_interest";
 

--- a/lib/DDG/Fathead/HTMLRef.pm
+++ b/lib/DDG/Fathead/HTMLRef.pm
@@ -16,7 +16,7 @@ icon_url "/i/html5doctor.com.ico";
 
 source "HTML5 Doctor";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/html_ref";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/html_ref";
 
 topics "geek", "everyday", "web_design";
 

--- a/lib/DDG/Fathead/HTTPHeaders.pm
+++ b/lib/DDG/Fathead/HTTPHeaders.pm
@@ -18,7 +18,7 @@ icon_url "/i/www.wikipedia.com.ico";
 
 source "Wikipedia";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/http_headers";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/http_headers";
 
 topics "geek", "programming";
 

--- a/lib/DDG/Fathead/HelloWorld.pm
+++ b/lib/DDG/Fathead/HelloWorld.pm
@@ -16,7 +16,7 @@ icon_url "/i/www.github.com.ico";
 
 source "GitHub";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/hello_world";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/hello_world";
 
 topics "geek", "programming";
 

--- a/lib/DDG/Fathead/ISO3166Codes.pm
+++ b/lib/DDG/Fathead/ISO3166Codes.pm
@@ -15,7 +15,7 @@ icon_url "/i/www.iso.org.ico";
 
 source "ISO";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/iso_3166_codes";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/iso_3166_codes";
 
 topics "geography", "travel", "special_interest";
 

--- a/lib/DDG/Fathead/Jargon.pm
+++ b/lib/DDG/Fathead/Jargon.pm
@@ -7,7 +7,7 @@ secondary_example_queries "one-line fix", "dinosaur";
 description "Jargon File glossary lookup";
 name "Jargon";
 source "The Jargon File (http://catb.org/~esr/jargon/html/index.html)";
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/jargon";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/jargon";
 topics "geek", "unix";
 category "reference";
 

--- a/lib/DDG/Fathead/Java.pm
+++ b/lib/DDG/Fathead/Java.pm
@@ -15,7 +15,7 @@ icon_url "/i/download.oracle.com.ico";
 
 source "Oracle";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/java";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/java";
 
 topics "geek", "programming";
 

--- a/lib/DDG/Fathead/LDraw.pm
+++ b/lib/DDG/Fathead/LDraw.pm
@@ -16,7 +16,7 @@ icon_url "http://www.ldraw.org/favicon.ico";
 
 source "LDraw Parts Tracker";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/ldraw_org";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/ldraw_org";
 
 topics "special_interest";
 

--- a/lib/DDG/Fathead/LegalDocs.pm
+++ b/lib/DDG/Fathead/LegalDocs.pm
@@ -16,7 +16,7 @@ icon_url "/i/www.docracy.com.ico";
 
 source "Docracy";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/legal_docs";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/legal_docs";
 
 topics "economy_and_finance", "special_interest";
 

--- a/lib/DDG/Fathead/MDNJS.pm
+++ b/lib/DDG/Fathead/MDNJS.pm
@@ -9,7 +9,7 @@ secondary_example_queries
 description "Method signatures for core JavaScript 1.5.";
 name "MDN JavaScript Reference";
 source "Mozilla Developer Network";
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/mdnjs";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/mdnjs";
 topics "programming";
 category "programming";
 attribution github => ['https://github.com/ericedens', 'ericedens'];

--- a/lib/DDG/Fathead/MIMETypes.pm
+++ b/lib/DDG/Fathead/MIMETypes.pm
@@ -16,7 +16,7 @@ icon_url "/assets/icon_wikipedia.v101.png";
 
 source "Wikipedia";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/mime_types";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/mime_types";
 
 topics "geek", "web_design", "special_interest";
 

--- a/lib/DDG/Fathead/NodeJS.pm
+++ b/lib/DDG/Fathead/NodeJS.pm
@@ -15,7 +15,7 @@ icon_url "/i/nodejs.org.ico";
 
 source "node.js";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/nodejs_ref";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/nodejs_ref";
 
 topics "geek", "programming";
 

--- a/lib/DDG/Fathead/PCIIDs.pm
+++ b/lib/DDG/Fathead/PCIIDs.pm
@@ -15,7 +15,7 @@ name "PCIIDs";
 
 source "pciids.sourceforge.net";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/pci_ids";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/pci_ids";
 
 topics "geek", "sysadmin", "special_interest";
 

--- a/lib/DDG/Fathead/Perl6Doc.pm
+++ b/lib/DDG/Fathead/Perl6Doc.pm
@@ -16,7 +16,7 @@ icon_url "/i/www.doc.perl6.org.ico";
 
 source "Perl 6 Documentation";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/perl6_doc";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/perl6_doc";
 
 topics "geek", "programming", "sysadmin";
 

--- a/lib/DDG/Fathead/Plone.pm
+++ b/lib/DDG/Fathead/Plone.pm
@@ -15,7 +15,7 @@ icon_url "/i/plone.org.ico";
 
 source "Plone";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/plone_org";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/plone_org";
 
 topics "geek", "web_design", "special_interest";
 

--- a/lib/DDG/Fathead/PyPI.pm
+++ b/lib/DDG/Fathead/PyPI.pm
@@ -16,7 +16,7 @@ icon_url "/i/pypi.python.org.ico";
 
 source "Python Package Index";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/pypi";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/pypi";
 
 topics "geek", "sysadmin", "programming";
 

--- a/lib/DDG/Fathead/RFC.pm
+++ b/lib/DDG/Fathead/RFC.pm
@@ -15,7 +15,7 @@ icon_url "/i/www.rfc-editor.org.ico";
 
 source "RFC-Editor";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/rfc_lookup";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/rfc_lookup";
 
 topics "geek", "special_interest";
 

--- a/lib/DDG/Fathead/RedisCommands.pm
+++ b/lib/DDG/Fathead/RedisCommands.pm
@@ -15,7 +15,7 @@ icon_url "/i/redis.io.ico";
 
 source "Redis";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/redis_commands";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/redis_commands";
 
 topics "geek", "sysadmin";
 

--- a/lib/DDG/Fathead/Scholrly.pm
+++ b/lib/DDG/Fathead/Scholrly.pm
@@ -7,7 +7,7 @@ secondary_example_queries "charles isbell", "sch greg abowd";
 description "Scholrly researcher profiles";
 name "Scholrly";
 source "Scholrly";
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/scholrly";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/scholrly";
 topics "computing", "math", "science", "programming";
 category "reference";
 attribution github => ['https://github.com/scholrly', 'scholrly'],

--- a/lib/DDG/Fathead/TclRef.pm
+++ b/lib/DDG/Fathead/TclRef.pm
@@ -16,7 +16,7 @@ icon_url "/i/www.tcl.tk.ico";
 
 source "Tcl Developer Xchange";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/tcl_ref";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/tcl_ref";
 
 topics "geek", "programming";
 

--- a/lib/DDG/Fathead/UnixMan.pm
+++ b/lib/DDG/Fathead/UnixMan.pm
@@ -15,7 +15,7 @@ icon_url "/i/www.linuxcommand.org.ico";
 
 source "LinuxCommand.org";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/unix_man";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/unix_man";
 
 topics "geek", "sysadmin";
 

--- a/lib/DDG/Fathead/XEP.pm
+++ b/lib/DDG/Fathead/XEP.pm
@@ -16,7 +16,7 @@ icon_url "/i/xmpp.org.ico";
 
 source "XMPP Standards Foundation";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/xep";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/xep";
 
 topics "geek", "sysadmin", "special_interest";
 

--- a/lib/DDG/Fathead/YUI3.pm
+++ b/lib/DDG/Fathead/YUI3.pm
@@ -15,7 +15,7 @@ icon_url "/i/yuilibrary.com.ico";
 
 source "YUI Library";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/yui3";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/yui3";
 
 topics "geek", "programming", "web_design";
 


### PR DESCRIPTION
In commit 7acff19cb01437db34dea1c0d41e5bceb0e5c627, the subdirectories
of share got moved into share/fathead. This turned all the code_urls
of the corrsponding Perl descriptions into 404s. Hence, we update the
Perl descriptions to also reflect this move of the share
subdirectories.