### PR TITLE
Ryzom: search the wiki

### DIFF
--- a/lib/DDG/Fathead/Ryzom.pm
+++ b/lib/DDG/Fathead/Ryzom.pm
@@ -1,0 +1,28 @@
+package DDG::Fathead::Ryzom;
+
+use DDG::Fathead;
+
+primary_example_queries "ryzom Yelk";
+
+seconary_example_queries 
+	"ryzom Izam",
+	"ryzom Atys";
+
+description "All sorts of Ryzom wiki information";
+
+name "Ryzom";
+
+#icon_url "";
+
+source "Ryzom Wiki";
+
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/ryzom";
+
+topics "game", "ryzom";
+
+category "software";
+
+attribution
+	twitter => ['https://twitter.com/rubdos', 'rubdos'];
+
+1;

--- a/share/fathead/ryzom/.gitignore
+++ b/share/fathead/ryzom/.gitignore
@@ -1,0 +1,2 @@
+downloads
+output.txt

--- a/share/fathead/ryzom/README.md
+++ b/share/fathead/ryzom/README.md
@@ -1,0 +1,3 @@
+Dependencies:
+
+Python 2.7 (for fetch _and_ parse)

--- a/share/fathead/ryzom/fetch.py
+++ b/share/fathead/ryzom/fetch.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import os
+import urllib2
+import json
+
+# Defines the categories to download and iterate over
+categories = ["Herbivores", "Carnivores"]
+
+basepath = "http://en.wiki.ryzom.com/w/api.php?format=json&"
+
+def makepath(path):
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+def request(req):
+    res = urllib2.urlopen(basepath + req)
+    return res.read()
+
+def fetch_category(category):
+    makepath("downloads/" + category)
+    res = request("action=query&list=categorymembers&"
+            "cmlimit=100&cmtitle=Category:" +
+            category)
+    res = json.loads(res)
+    for member in res['query']['categorymembers']:
+        with open("downloads/"+category+"/"+str(member['pageid']), "wt") as member_file:
+            member_file.write(request("action=query&prop=revisions&rvprop=content&format=json&pageids=" + str(member['pageid'])))
+
+if __name__ == "__main__":
+    makepath("downloads")
+    with open("downloads/categories.txt", "wt") as categories_list:
+        for category in categories:
+            fetch_category(category)
+            categories_list.write(category+"\n")
+

--- a/share/fathead/ryzom/fetch.py
+++ b/share/fathead/ryzom/fetch.py
@@ -25,7 +25,7 @@ def fetch_category(category):
     res = json.loads(res)
     for member in res['query']['categorymembers']:
         with open("downloads/"+category+"/"+str(member['pageid']), "wt") as member_file:
-            member_file.write(request("action=query&prop=revisions&rvprop=content&format=json&pageids=" + str(member['pageid'])))
+            member_file.write(request("action=parse&format=json&pageid=" + str(member['pageid'])))
 
 if __name__ == "__main__":
     makepath("downloads")

--- a/share/fathead/ryzom/fetch.sh
+++ b/share/fathead/ryzom/fetch.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Fetching via the MediaWiki api needs some parsing while fetching
+python fetch.py

--- a/share/fathead/ryzom/parse.py
+++ b/share/fathead/ryzom/parse.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import json
+import re
+import codecs
+from HTMLParser import HTMLParser
+
+class PageReader(HTMLParser):
+    def __init__(self):
+        self.reset()
+        self.fed = []
+        self.do_text = True
+        self.image = ""
+        self.level = 0
+        self.imageflag = False
+    def handle_starttag(self, tag, attrs):
+        if(tag == "p" or (self.do_text and (tag == "a" or tag=="span"))):
+            self.do_text = True
+        else:
+            self.level = self.level + 1
+            self.do_text = False
+        if(tag == "a"):
+            for item in attrs:
+                if(item[0] == "class"):
+                    if(item[1] == "image"):
+                        self.imageflag = True
+        if(tag == "img" and self.imageflag):
+            for item in attrs:
+                if(item[0] == "src"):
+                    self.image = item[1]
+                    self.imageflag = False
+                    break
+#        self.imageflag = False
+
+    def handle_endtag(self, tag):
+        self.level = self.level - 1
+        if(self.level == 0):
+            self.do_text = True
+    def handle_data(self, d):
+        if(self.do_text):
+            self.fed.append(d)
+    def get_data(self):
+        return unicode('').join(self.fed)
+
+def page(articlename, image, abstract, url, categories=[], articletype="A", alias="", external_links=""):
+    s = (articlename + "\t" + 
+            articletype + "\t" + 
+            alias + "\t\t" +
+            "\\n".join(categories) + "\t\t" +
+            "" + "\t" +
+            "" + "\t" +
+            image + "\t" +
+            abstract + "\t" +
+            url
+            )
+    return s + "\n"
+
+basepath = unicode("http://en.wiki.ryzom.com/wiki/")
+
+if __name__ == "__main__":
+    # Read categories
+    with codecs.open("output.txt", "wt", "utf-8") as output:
+        with open("downloads/categories.txt", "r") as categories_file:
+            for line in categories_file.xreadlines():
+                category = line.strip(" \n\t")
+                output.write(page(category, "", "", basepath+"Category:"+category))
+                for f in os.listdir("downloads/"+category):
+                    fn = "downloads/"+category+"/"+f
+                    if not os.path.isfile(fn):
+                        continue
+                    with open(fn, "r") as article:
+                        a = json.loads(article.read())
+                        a = a['parse']
+                        title = a['displaytitle']
+                        data = PageReader()
+                        data.feed(a['text']['*'])
+                        try:
+                            text = re.match(r'(?:[^.:;]+[.:;]){2}', data.get_data()).group()
+                        except:
+                            text = ""
+                        output.write(page(title, data.image, text.strip(" \t\n"), basepath + title, [category]))
+

--- a/share/fathead/ryzom/parse.sh
+++ b/share/fathead/ryzom/parse.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./parse.py


### PR DESCRIPTION
I implemented an IA using fathead for the free software Ryzom game's wiki. C&C is welcome, if everything is okay, a merge is welcome.

In the future, I'll add the Ryzom Intelligent Plants and other articles. Probably will build some form of an infobox, if this is possible in ddhack.

What does your Instant Answer do?
 * It provides instant answers to search requests for Ryzom mobs data. It will display the first two sentences of the wiki and will provide an image of the mob.

What problem does your Instant Answer solve (Why is it better than organic links)?
 * It save the user making redundant clicks by giving the most popular definition for a term.

What is the data source for your Instant Answer? (Provide a link if possible)
 * http://en.wiki.ryzom.com

Why did you choose this data source?
 * It is the official Ryzom Wiki

Are there any other alternative (better) data sources?
 * Probably http://ballisticmystix.net/ has a lot of additional information.

What are some example queries that trigger this Instant Answer?
 * "ryzom Yelk"
 * "ryzom Izam", ...

Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)
 * Ryzom gamers and developers.

Is this Instant Answer connected to a DuckDuckHack Instant Answer idea?
 * Not that I know of...

Which existing Instant Answers will this one supercede/overlap with?
 * No one AFAIK

Are you having any problems? Do you need our help with anything?
 * Well, we understand that I cannot really test the Fathead plugins, so would wait for your review.

Where did you hear about DuckDuckHack? (For first time contributors)
 * I duckduckgo'd for an API or something.

What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)
 * No idea yet...