### PR TITLE
New Fathead, see: https://duck.co/ideas/idea/515/languages-of-a-country

### DIFF
--- a/lib/DDG/Fathead/CountryLanguages.pm
+++ b/lib/DDG/Fathead/CountryLanguages.pm
@@ -1,0 +1,19 @@
+package DDG::Fathead::CountryLanguages;
+
+use DDG::Fathead;
+
+primary_example_queries "language of Gambia";
+secondary_example_queries "language of The Gambia",
+
+description "languages of countries";
+name "CountryLanguage";
+icon_url "/i/cia.gov.ico";
+source "cia.gov";
+category "reference";
+topics "everyday", "special_interest";
+code_url "https://github.com/roysten/zeroclickinfo-fathead/tree/master/share/fathead/country_language";
+attribution
+    github => ['https://github.com/roysten', 'Roysten'];
+
+1;
+

--- a/share/fathead/country_languages/README.txt
+++ b/share/fathead/country_languages/README.txt
@@ -1,0 +1,3 @@
+Dependencies
+------------
+npm install cheerio

--- a/share/fathead/country_languages/fetch.sh
+++ b/share/fathead/country_languages/fetch.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 mkdir download
-wget https://www.cia.gov/library/publications/the-world-factbook/fields/2098.html -O download/output.txt
+wget https://www.cia.gov/library/publications/the-world-factbook/fields/2098.html -O download/page.txt

--- a/share/fathead/country_languages/fetch.sh
+++ b/share/fathead/country_languages/fetch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir download
+wget https://www.cia.gov/library/publications/the-world-factbook/fields/2098.html -O download/output.txt

--- a/share/fathead/country_languages/parse.js
+++ b/share/fathead/country_languages/parse.js
@@ -1,0 +1,56 @@
+fs = require('fs');
+
+var rootUrl = 'https://www.cia.gov/library/publications/the-world-factbook/';
+var tableId = 'table#fieldListing';
+var countryClass = 'td.country';
+var abstractClass = 'td.fieldData';
+
+fs.readFile('download/page.txt', 'utf-8', function(err, data) {
+	if(err) throw err;
+
+	var cheerio = require('cheerio'), $ = cheerio.load(data);
+
+	fs.writeFile('output.txt', scrape($), function (err) {
+		if(err) throw err;
+	});
+});
+
+function scrape($) {
+	var output = '';
+
+	var titles = $(countryClass).map(function(index, element) {
+		return $(element).children().first().text().trim();
+	}).get();
+
+	//Take the first line of every abstract
+	var abstracts = $(abstractClass).map(function(index, element) {
+		return $(element).text().trim().split('\n')[0];
+	});
+
+	//strip "../" part from every url
+	var urls = $(countryClass).map(function(index, element) {
+		return rootUrl + $(element).children().first().attr('href').substr(3);
+	}).get();
+
+	if(titles.length != abstracts.length || abstracts.length != urls.length) throw "Scraped data invalid!";
+
+	for(var i = 0; i < titles.length; ++i) {
+		output += generateFatheadLine(titles[i], 'A', '', abstracts[i], urls[i]);
+	}
+
+	//now look for languages with variations, such as "Gambia, The", "The Gambia" and "Gambia"
+	titles.forEach(function (element, index) {
+		if(element.indexOf(', The') != -1) {
+			//The Gambia
+			output += generateFatheadLine('The ' + element.split(',')[0], 'R', element, abstracts[index], urls[index]);
+			//Gambia
+			output += generateFatheadLine(element.split(',')[0], 'R', element, abstracts[index], urls[index]);
+		}
+	});
+
+	return output;
+}
+
+function generateFatheadLine(title, type, redirect, abstract, url) {
+	return title + '\t' + type + '\t' + redirect + '\t\t\t\t\t\t\t\t\t' + abstract + '\t' + url + '\n';
+}

--- a/share/fathead/country_languages/parse.sh
+++ b/share/fathead/country_languages/parse.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+node parse.js


### PR DESCRIPTION
This is an attempt to add the Fathead as discussed here: https://duck.co/ideas/idea/515/languages-of-a-country. I have seen that someone else was also working on this Fathead (https://github.com/duckduckgo/zeroclickinfo-fathead/pull/54) but never finished it, so I decided to give it a try.

I'm not sure if the generated output.txt contains all the necessary information, so I have included a snippet:
```
1.Full article title	2.Type of article	3.For redirects only	4.Ignore.	5.Categories. 	6.Ignore.	7.Related topics. 	8.Ignore.	9.External links.	10.For disambiguation pages only. 	11.Image. 	12.Abstract. 	13.URL. 

Uzbekistan	A										Uzbek (official) 74.3%, Russian 14.2%, Tajik 4.4%, other 7.1%	https://www.cia.gov/library/publications/the-world-factbook/geos/uz.html
Vanuatu	A										local languages (more than 100) 63.2%, Bislama (official; creole) 33.7%, English (official) 2%, French (official) 0.6%, other 0.5% (2009 est.)	https://www.cia.gov/library/publications/the-world-factbook/geos/nh.html
Venezuela	A										Spanish (official), numerous indigenous dialects	https://www.cia.gov/library/publications/the-world-factbook/geos/ve.html
Vietnam	A										Vietnamese (official), English (increasingly favored as a second language), some French, Chinese, and Khmer, mountain area languages (Mon-Khmer and Malayo-Polynesian)	https://www.cia.gov/library/publications/the-world-factbook/geos/vm.html
Virgin Islands	A										English 71.6%, Spanish or Spanish Creole 17.2%, French or French Creole 8.6%, other 2.5% (2010 est.)	https://www.cia.gov/library/publications/the-world-factbook/geos/vq.html
Wallis and Futuna	A										Wallisian (indigenous Polynesian language) 58.9%, Futunian 30.1%, French (official) 10.8%, other 0.2% (2003 census)	https://www.cia.gov/library/publications/the-world-factbook/geos/wf.html
West Bank	A										Arabic, Hebrew (spoken by Israeli settlers and many Palestinians), English (widely understood)	https://www.cia.gov/library/publications/the-world-factbook/geos/we.html
Western Sahara	A										Standard Arabic (national), Hassaniya Arabic, Moroccan Arabic	https://www.cia.gov/library/publications/the-world-factbook/geos/wi.html
World	A										Mandarin Chinese 11.82%, Spanish 5.77%, English 4.67%, Hindi 3.62%, Arabic 3.3%, Portuguese 2.83%, Bengali 2.69%, Russian 2.33%, Japanese 1.7%, Javanese 1.15%, Standard German 1.09% (2014 est.)	https://www.cia.gov/library/publications/the-world-factbook/geos/xx.html
Yemen	A										Arabic (official)	https://www.cia.gov/library/publications/the-world-factbook/geos/ym.html
Zambia	A										Bembe 33.4%, Nyanja 14.7%, Tonga 11.4%, Lozi 5.5%, Chewa 4.5%, Nsenga 2.9%, Tumbuka 2.5%, Lunda (North Western) 1.9%, Kaonde 1.8%, Lala 1.8%, Lamba 1.8%, English (official) 1.7%, Luvale 1.5%, Mambwe 1.3%, Namwanga 1.2%, Lenje 1.1%, Bisa 1%, other 9.2%, unspecified 0.4%	https://www.cia.gov/library/publications/the-world-factbook/geos/za.html
Zimbabwe	A										Shona (official; most widely spoken), Ndebele (official, second most widely spoken), English (official; traditionally used for official business), 13 minority languages (official; includes Chewa, Chibarwe, Kalanga, Koisan, Nambya, Ndau, Shangani, sign language, Sotho, Tonga, Tswana, Venda, and Xhosa)	https://www.cia.gov/library/publications/the-world-factbook/geos/zi.html
The Bahamas	R	Bahamas, The									English (official), Creole (among Haitian immigrants)	https://www.cia.gov/library/publications/the-world-factbook/geos/bf.html
Bahamas	R	Bahamas, The									English (official), Creole (among Haitian immigrants)	https://www.cia.gov/library/publications/the-world-factbook/geos/bf.html
The Gambia	R	Gambia, The									English (official), Mandinka, Wolof, Fula, other indigenous vernaculars	https://www.cia.gov/library/publications/the-world-factbook/geos/ga.html
Gambia	R	Gambia, The									English (official), Mandinka, Wolof, Fula, other indigenous vernaculars	https://www.cia.gov/library/publications/the-world-factbook/geos/ga.html
```
Currently it ignores field 4 through 11. Also I'm not sure if I use field 3 correctly.
It adds variations for Gambia, The:
 _The Gambia_
_Gambia_ 
and Bahamas, The:
 _The Bahamas_
_Bahamas_.

https://duck.co/ia/view/country_languages