### PR TITLE
Improve extraction of plural forms from Wiktionary

### DIFF
--- a/share/fathead/plural/extract_plurals.pl
+++ b/share/fathead/plural/extract_plurals.pl
@@ -8,11 +8,11 @@ use Lingua::EN::Inflect qw(WORDLIST);
 use utf8;
 $|++;
 
-#Regex to catch weirdness (malformed tags etc.)
-# we don't want leaking into the results
+# Regex to catch weirdness (malformed tags etc.) we don't want leaking into
+# the results
 my $unsanitary = qr/[^\p{L}\s\-']/;
 
-#Get plural forms from Wiktionary
+# Get plural forms from Wiktionary
 my $processed;
 my $wiktionary = 'download/wiktionary.xml';
 my %plurals;
@@ -21,7 +21,7 @@ my $wiktionaryTwig = XML::Twig->new( twig_handlers => { page => \&page } );
 $wiktionaryTwig->parsefile($wiktionary);
 say "\r$processed terms processed";
 
-#Write output file
+# Write output file
 say 'Writing output...';
 open my $outputFH, '>:utf8', 'output.txt';
 print_output($_) for keys %plurals;
@@ -29,7 +29,7 @@ close $outputFH;
 
 exit;
 
-#Article parser
+# Article parser
 sub page {
 
     (my $twig, my $page) = @_;
@@ -37,52 +37,52 @@ sub page {
     ++$processed;
     print "\r$processed terms processed" unless $processed % 1000;
 
-    #Get the title of the page
+    # Get the title of the page
     my $term = $page->first_child_text('title');
 
-    #Skip Wiktionary internal pages
+    # Skip Wiktionary internal pages
     return if $term =~ /^Wiktionary:|
                         ^Template:|
                         ^Index: 
     /x;
 
-    #Don't want weirdness
+    # Don't want weirdness
     return if $term =~ /$unsanitary/;
 
-    #Skip acronyms and intialisms
+    # Skip acronyms and intialisms
     return if $term =~ /^[^a-z]{2,}$/;
 
-    #Get the wikitext of the page
+    # Get the wikitext of the page
     my $wikitext = $page->first_child('revision')->first_child_text('text');
 
-    #Find and parse Template:en-noun templates
+    # Find and parse Template:en-noun templates
     # Reference: https://en.wiktionary.org/wiki/Template:en-noun
     while ($wikitext =~ /{{en-noun\|?(?<plurals>[^\}]+)}}/g) {
 
-        #Note it's possible for @forms to be length 0
+        # Note it's possible for @forms to be length 0
         my @forms = split(/\|/, $+{plurals});
 
-        #Forms that look like "head=[[hot]] [[dog]]" are functionally
-        #equivalent to that token just not existing, since if no other form is
-        #given the plural '-s' is assumed while if other forms are given '-s'
-        #is not assumed. So we'll splice the head= forms out.
+        # Forms that look like 'head=[[hot]] [[dog]]' are functionally
+        # equivalent to that token just not existing, since if no other form
+        # is given the plural '-s' is assumed while if other forms are given
+        # '-s' is not assumed. So we'll splice the head= forms out.
         while (my ($index, $form) = each @forms) {
             if ($form =~ /^head=.+$/) {
                 splice(@forms, $index, 1);
             }
         }
 
-        #If no plural form information is given,
-        # the plural form '-s' is assumed
+        # If no plural form information is given, the plural form '-s' is
+        # assumed
         if (scalar @forms == 0) {
             $plurals{lc($term)}{$term}{$term .'s'}++;
             return; 
         }
 
-        # Sometimes a "qualifier" form is included the list, which is actually
-        # a qualifier for a form earlier in the list (for example, "moose" has
+        # Sometimes a 'qualifier' form is included the list, which is actually
+        # a qualifier for a form earlier in the list (for example, 'moose' has
         # the inflection given as
-        # "en-noun|moose|mooses|meese|pl3qual=uncommon, humorous". So we have
+        # 'en-noun|moose|mooses|meese|pl3qual=uncommon, humorous'. So we have
         # to detect these, and back-apply the qualification to the relevant
         # form
         while (my ($index, $form) = each @forms) {
@@ -95,47 +95,45 @@ sub page {
 
         foreach my $form (@forms) {
 
-            #Hyphen indicates uncountable or usually uncountable,
-            # meaningless for our purposes
+            # Hyphen indicates uncountable or usually uncountable, meaningless
+            # for our purposes
             if ($form eq '-') {
                 return; 
 
-            #Tilde indicates countable and uncountable, with -s
-            # pluralisation unless an alternative is specified
+            # Tilde indicates countable and uncountable, with -s pluralisation
+            # unless an alternative is specified
             } elsif ($form eq '~') {
                 $plurals{lc($term)}{$term}{$term .'s'}++;
 
-            #Exclamation point indicates an unattested plural,
-            # question mark indicates uncertain or unknown;
-            # ignore these for now
+            # Exclamation point indicates an unattested plural, question mark
+            # indicates uncertain or unknown; ignore these for now
             } elsif ($form eq '!' || $form eq '?') {
                 return;
 
-            #'s' and 'es' indicate standard -s or -es forms
+            # 's' and 'es' indicate standard -s or -es forms
             } elsif ($form eq 's' || $form eq 'es') {
                 $plurals{lc($term)}{$term}{$term . $form}++;
 
-            #Markup in square brackets is used for multi-word
-            # terms, with -s pluralisation unless an alternative
-            # is specified
+            # Markup in square brackets is used for multi-word terms, with -s
+            # pluralisation unless an alternative is specified
             } elsif ($form =~ /\[|\]/) {
                 $plurals{lc($term)}{$term}{$term .'s'}++;
 
-            #Sometimes there are undocumented tokens in the forms list. With
-            # the exception of the "qual" tokens handled above, most of these
+            # Sometimes there are undocumented tokens in the forms list. With
+            # the exception of the 'qual' tokens handled above, most of these
             # are more or less useless so they will be ignored 
             } elsif ($form =~ /=/) {
               return;
 
-            #Anything else is an explicit specification of a
-            # plural form, usually irregular
+            # Anything else is an explicit specification of a plural form,
+            # usually irregular
             } else {
                 $plurals{lc($term)}{$term}{$form}++;
             }
         }
     }
 
-    #Free up memory
+    # Free up memory
     $page->purge;
     $twig->purge;
 }
@@ -145,30 +143,30 @@ sub print_output {
     (my $key) = @_;
 
     my $output = join("\t",(
-            $key, #Title
-            'A', #Type
-            '', #Only for redirects
-            '', #Other uses
-            '', #Categories
-            '', #References
-            '', #See also
-            '', #Further reading
-            '', #External link
-            '', #Disambiguation
-            '', #Images
-            wrap_answer($key), #Abstract
-            wiktionary_URL($key) #Source URL
+            $key,                 # Title
+            'A',                  # Type
+            '',                   # Only for redirects
+            '',                   # Other uses
+            '',                   # Categories
+            '',                   # References
+            '',                   # See also
+            '',                   # Further reading
+            '',                   # External link
+            '',                   # Disambiguation
+            '',                   # Images
+            wrap_answer($key),    # Abstract
+            wiktionary_URL($key)  # Source URL
             ));
     say $outputFH $output;
 }
 
-#Wrap an answer up into an English statement
+# Wrap an answer up into an English statement
 sub wrap_answer {
 
     (my $key) = shift;
 
-    #For each matching caseform, construct a natural-language
-    # statement of the plural forms with links to Wiktionary
+    # For each matching caseform, construct a natural-language statement of
+    # the plural forms with links to Wiktionary
     my @statements;
     foreach my $caseForm (sort keys %{$plurals{$key}}) {
         my $article = @statements == 0 ? 'The' : 'the';
@@ -176,7 +174,7 @@ sub wrap_answer {
         push(@statements, $statement);
     }
 
-    #Join the statements together into a readable sentence
+    # Join the statements together into a readable sentence
     my $statement = join("; ", @statements);
     $statement = ucfirst($statement);
     $statement .= '.';


### PR DESCRIPTION
In response to issue #145, this fixes the way the 'plural' fathead parses Wiktionary noun inflection lists. In particular it handles cases where a qualifier such as 'archaic' or 'uncommon' is given, and is a little smarter about not letting unwanted or malformed text find its way into the IA. After applying these changes the result for 'plural moose' should look like 'The plural of moose is meese (uncommon, humorous); moose; or mooses.'

https://duck.co/ia/view/plural/