### PR TITLE
Plurals: restore parsing of '-s' plurals

### DIFF
--- a/share/fathead/plural/extract_plurals.pl
+++ b/share/fathead/plural/extract_plurals.pl
@@ -57,7 +57,14 @@ sub page {
 
     # Find and parse Template:en-noun templates
     # Reference: https://en.wiktionary.org/wiki/Template:en-noun
-    while ($wikitext =~ /{{en-noun\|?(?<plurals>[^\}]+)}}/g) {
+    while ($wikitext =~ /{{en-noun\|?(?<plurals>[^\}]+)?}}/g) {
+
+        # If no plural form information is given, the plural form '-s' is
+        # assumed
+        if (! $+{plurals}) {
+            $plurals{lc($term)}{$term}{$term .'s'}++;
+            return; 
+        }
 
         # Note it's possible for @forms to be length 0
         my @forms = split(/\|/, $+{plurals});


### PR DESCRIPTION
Fixes a bug introduced into the Plurals IA in #146. Restores handling of the situation where no plural form is specified so '-s' is assumed.

----
https://duck.co/ia/view/plural