### PR TITLE
Make dist.ini consistent with other repos

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,21 +11,17 @@ copyright_year   = 2012
 index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
-[Prereqs]
-
-[Prereqs / TestRequires]
-Test::More = 0.98
-Test::Dirs = 0.03
-File::Temp = 0.22
+[AutoPrereqs]
 
 [Run::BeforeBuild]
 run = mkdir -p share/fathead/meta
 run = curl https://duck.co/ia/repo/fathead/json -o "share/fathead/meta/metadata.json"
 [GatherDir]
+exclude_match = \.(?:js|handlebars|md|ini|p[ly]|rb|go|tcl|sh|txt?|url|json|csv|xsl)$
+exclude_match = ^template/
+exclude_match = README
 [PruneCruft]
 [ManifestSkip]
-[ExtraTests]
-[ExecDir]
 [ShareDir]
 [MakeMaker]
 [Manifest]
@@ -33,19 +29,15 @@ run = curl https://duck.co/ia/repo/fathead/json -o "share/fathead/meta/metadata.
 [ConfirmRelease]
 [UploadToDuckPAN]
 [MetaJSON]
-[MetaYAML]
 
 [AutoModuleShareDirs]
-scan_namespaces = DDG::Goodie,DDG::Spice,DDG::Longtail,DDG::Fathead
+scan_namespaces = DDG::Fathead
 sharedir_method = module_share_dir
 
 [Git::NextVersion]
 version_regexp = ^(.+)$
 [PkgVersion]
-[PodSyntaxTests]
 [GithubMeta]
-[Test::EOL]
-trailing_whitespace = 0
 [@Git]
 tag_format = %v
 


### PR DESCRIPTION
* Remove unnecessary plugins
* Prevent most share assets from going in release
* Scan fathead namespace only