### PR TITLE
Cppreference-doc: Track a link to the release tarball, not the tarball itself

### DIFF
--- a/share/fathead/cppreference_doc/README.md
+++ b/share/fathead/cppreference_doc/README.md
@@ -9,7 +9,8 @@ Data source
 
 fetch.sh downloads and untars a snapshot of the website, which is available at
 http://en.cppreference.com/w/Cppreference:Archives. A new snapshot is released
-periodically. The script needs to be for the new location of the snapshot.
+periodically. The location of the newest archive that is tested for DuckDuckGo
+is upload.cppreference.com/w/Cppreference:DDG-link?action=raw.
 
 Dependencies
 ------------

--- a/share/fathead/cppreference_doc/data.url
+++ b/share/fathead/cppreference_doc/data.url
@@ -1,1 +1,1 @@
-http://en.cppreference.com/w/Cppreference:Archives
+upload.cppreference.com/w/Cppreference:DDG-link?action=raw

--- a/share/fathead/cppreference_doc/fetch.sh
+++ b/share/fathead/cppreference_doc/fetch.sh
@@ -3,6 +3,8 @@ rm -rf download
 mkdir -p download
 
 pushd download > /dev/null
-wget http://upload.cppreference.com/mwiki/images/e/e7/cppreference-doc-20130729-ddg.tar.gz
-tar -xzf cppreference-doc-20130729-ddg.tar.gz
+wget upload.cppreference.com/w/Cppreference:DDG-link?action=raw -O cppreference-link
+
+wget -i cppreference-link -O cppreference-doc-ddg.tar.gz
+tar -xzf cppreference-doc-ddg.tar.gz
 popd > /dev/null


### PR DESCRIPTION
This implements a suggestion that Jason has made in a private email that we add a layer of indirection in tracking the release tarballs: cppreference.com now has a separate webpage that only contains the link to the latest release tarball that DuckDuckGo should use.

https://duck.co/ia/view/cppreference_doc