### PR TITLE
Update dist.ini to match other repos

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ author  = Hunter Lang <hunter@duckduckgo.com>
 license = Perl_5
 copyright_holder = DuckDuckGo, Inc. L<http://duckduckgo.com/>
 copyright_year   = 2012
+main_module = lib/DDG/FatheadBundle/OpenSourceDuckDuckGo.pm
 
 [PromptIfStale]
 index_base_url = http://duckpan.org
@@ -13,19 +14,13 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 module = Dist::Zilla::Plugin::IAChangelog
 module = Dist::Zilla::Plugin::AnnounceRelease
 
-[Prereqs]
-
-[Prereqs / TestRequires]
-Test::More = 0.98
-Test::Dirs = 0.03
-File::Temp = 0.22
+[AutoPrereqs]
 
 [GatherDir]
+exclude_match = \.(?:js|handlebars|md|ini|p[ly]|rb|go|tcl|sh|tx)$
+exclude_match = ^template/
 [IAChangelog]
 [PruneCruft]
-[ManifestSkip]
-[ExtraTests]
-[ExecDir]
 [ShareDir]
 [MakeMaker]
 [Manifest]
@@ -33,20 +28,16 @@ File::Temp = 0.22
 [ConfirmRelease]
 [UploadToDuckPAN]
 [MetaJSON]
-[MetaYAML]
 [AnnounceRelease]
 
-[AutoModuleShareDirs]
-scan_namespaces = DDG::Goodie,DDG::Spice,DDG::Longtail,DDG::Fathead
-sharedir_method = module_share_dir
+;[AutoModuleShareDirs]
+;scan_namespaces = Fathead
+;sharedir_method = module_share_dir
 
 [Git::NextVersion]
 version_regexp = ^(.+)$
 [PkgVersion]
-[PodSyntaxTests]
 [GithubMeta]
-[Test::EOL]
-trailing_whitespace = 0
 [Git::Check]
 [Git::Commit]
 [Git::Tag::IAChangelog]


### PR DESCRIPTION
Should be mostly similar to goodies/spices.  Commented out the AutoModuleShareDirs since we don't have a share dir at the moment.

After this we should release using `V` to force the version.