### PR TITLE
Update pypi fathead

### DIFF
--- a/lib/fathead/py_pi/parse.py
+++ b/lib/fathead/py_pi/parse.py
@@ -19,13 +19,14 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
         if not summary or summary == 'UNKNOWN':
             continue
         abstract_lines.append(re.sub(r'\s', ' ', summary, flags=re.MULTILINE | re.UNICODE))
-        abstract_lines.append('Downloads in the last month: %s' % package_info['downloads']['last_month'])
-        abstract_lines.append("<pre><code>pip install " + package_info['name'] + "</code></pre>")
+#        abstract_lines.append('Downloads in the last month: %s' % package_info['downloads']['last_month'])
 
         for classifier in package_info['classifiers']:
             if classifier.startswith('Development Status'):
                 abstract_lines.append('Development status: %s' % classifier.split(' - ')[-1])
                 break
+
+        abstract_lines.append("<pre><code>pip install " + package_info['name'] + "</code></pre>")
 
         out_file.write('\t'.join([
             package_info['name'],  # Title

--- a/lib/fathead/py_pi/parse.py
+++ b/lib/fathead/py_pi/parse.py
@@ -5,7 +5,6 @@ import codecs
 import json
 import re
 import urllib
-import sys
 
 with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
         codecs.open('output.txt', mode='wb', encoding='utf-8') as out_file:
@@ -19,7 +18,7 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
         if not summary or summary == 'UNKNOWN':
             continue
         abstract_lines.append(re.sub(r'\s', ' ', summary, flags=re.MULTILINE | re.UNICODE))
-#        abstract_lines.append('Downloads in the last month: %s' % package_info['downloads']['last_month'])
+        #abstract_lines.append('Downloads in the last month: %s' % package_info['downloads']['last_month'])
 
         for classifier in package_info['classifiers']:
             if classifier.startswith('Development Status'):

--- a/lib/fathead/py_pi/parse.py
+++ b/lib/fathead/py_pi/parse.py
@@ -5,7 +5,7 @@ import codecs
 import json
 import re
 import urllib
-
+import sys
 
 with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
         codecs.open('output.txt', mode='wb', encoding='utf-8') as out_file:
@@ -20,10 +20,7 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
             continue
         abstract_lines.append(re.sub(r'\s', ' ', summary, flags=re.MULTILINE | re.UNICODE))
         abstract_lines.append('Downloads in the last month: %s' % package_info['downloads']['last_month'])
-
-        latest_release_info = package_dict['releases'][package_info['version']]
-        if latest_release_info:
-            abstract_lines.append('Latest release date: %s' % latest_release_info[0]['upload_time'].split('T')[0])
+        abstract_lines.append("<pre><code>pip install " + package_info['name'] + "</code></pre>")
 
         for classifier in package_info['classifiers']:
             if classifier.startswith('Development Status'):

--- a/lib/fathead/py_pi/parse.py
+++ b/lib/fathead/py_pi/parse.py
@@ -27,6 +27,11 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
 
         abstract_lines.append("<pre><code>pip install " + package_info['name'] + "</code></pre>")
 
+        official_site = ''
+        # check for real links. We can get stuff like 'unknown', '404' in here
+        if package_info['home_page'] and re.search(r'www.', package_info['home_page']):
+            official_site = '[' + package_info['home_page'] + ' Official site]\\\\n'
+
         out_file.write('\t'.join([
             package_info['name'],  # Title
             'A',  # Article type
@@ -36,7 +41,7 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
             '',  # References (ignored)
             '',  # No related topics
             '',  # Further reading (ignored)
-            '',  # External links (ignored)
+            official_site,  # External links (ignored)
             '',  # Disambiguation (ignored)
             '',  # No images
             '<br>'.join(abstract_lines),


### PR DESCRIPTION
Updating the [pypi fathead](https://duck.co/ia/view/py_pi)
- removed number of downloads and latest release. We don't update the data often enough to ensure this doesn't go stale

- added pip install command for people who like to copy/paste

- added a link to the official site if one exists