### PR TITLE
Enhancing MDN CSS Fathead

### DIFF
--- a/lib/fathead/mdn_css/fetch.pl
+++ b/lib/fathead/mdn_css/fetch.pl
@@ -102,6 +102,20 @@ if (@urls_with_fragments) {
             $clone->path($fragment);
             push @keyword_urls, $clone;
         }
+        elsif ( $url_with_fragment->fragment =~ /The_url/ ) {
+
+            #It is this: https://developer.mozilla.org/en-U/docs/Web/CSS/
+            #url#The_url()_functional_notation
+            #We get rid of the fragment part so that it can be downloaded
+            #and parsed by parse.pl because its format is like the others
+            my $clone = Mojo::URL->new(
+                sprintf "%s://%s",
+                $url_with_fragment->protocol,
+                $url_with_fragment->host
+            );
+            $clone->path($url_with_fragment->path);
+            push @keyword_urls, $clone;
+        }
         else {
             #we will deal with other types of urls later in parse.pl
             say $fh $url_with_fragment;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -426,9 +426,6 @@ sub parse_fragment_data {
             }
         }
     }
-    elsif ( $link =~ qr/url/ ) {
-        say "url $link";
-    }
     else {
         warn "Unmatched $link in parse_fragment_data()";
     }

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -223,10 +223,11 @@ sub make_and_write_article {
     say "LINK: $link";
     say "DESCRIPTION: $description"       if $description;
     say "EXTERNAL LINKS $external_links " if $external_links;
-    my @data = join "\t", (
+    my @data = join "\t",
+      (
         $title, 'A', '', '', '', '', '', '', $external_links || '',
         '', '', $description, $link
-    );
+      );
 
     # Check for CSS Functions
     # e.g. "not()"

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -128,15 +128,13 @@ foreach my $html_file ( glob 'download/*.html' ) {
     # Preserve HTML and use the same lib as Mozilla
     # (http://prismjs.com/) to render code?
 
-    my $hs = HTML::Strip->new( emit_spaces => 0 );
     if ( my $pre = $dom->at('#Syntax ~ pre') ) {
 
         if ( $pre->child_nodes->first->matches('code') ) {
             $code = $pre->child_nodes->first->text;
         }
         else {
-            $code = $hs->parse( $pre->to_string );
-            $code =~ tr/ / /s;
+            $code = clean_code( $pre->to_string );
         }
 
         $code = trim($code);
@@ -144,7 +142,6 @@ foreach my $html_file ( glob 'download/*.html' ) {
         say $code;
         $code =~ s/\r?\n/\\n/g;
     }
-    $hs->eof;
     my $initial_value;
 
     #initial value is found in the table properties
@@ -190,6 +187,16 @@ foreach my $html_file ( glob 'download/*.html' ) {
 }
 
 # PRIVATE FUNCTIONS
+
+sub clean_code {
+    my ($code) = @_;
+    my $hs = HTML::Strip->new( emit_spaces => 0 );
+    $code = $hs->parse($code);
+    $code =~ tr/ / /s;
+    $code =~ s/\r?\n/\\n/g;
+    $hs->eof;
+    return $code;
+}
 
 sub clean_string {
     my $input = shift;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -101,14 +101,13 @@ foreach my $html_file ( glob 'download/*.html' ) {
         last if $title and $description;
     }
 
-    # Clean title and check if article already processed
-    my $title_clean = clean_string($title);
-    if ( exists $seen{$title_clean} ) {
-        say "SKIPPING: $title_clean!";
+    # Check if article already processed
+    if ( exists $seen{$title} ) {
+        say "SKIPPING: $title!";
         next;
     }
 
-    $seen{$title_clean} = 1;
+    $seen{$title} = 1;
 
     # Get syntax code snippet
     my $code;
@@ -153,8 +152,7 @@ foreach my $html_file ( glob 'download/*.html' ) {
           make_external_links( $link, $external_lis_collection );
     }
     $external_links ||= '';
-    make_and_write_article( $title_clean, $description, $link,
-        $external_links );
+    make_and_write_article( $title, $description, $link, $external_links );
 }
 
 # PRIVATE FUNCTIONS
@@ -225,9 +223,10 @@ sub make_and_write_article {
     say "LINK: $link";
     say "DESCRIPTION: $description"       if $description;
     say "EXTERNAL LINKS $external_links " if $external_links;
-    my @data = join "\t",
+    my $title_clean = clean_string($title);
+    my @data        = join "\t",
       (
-        $title, 'A', '', '', '', '', '', '', $external_links || '',
+        $title_clean, 'A', '', '', '', '', '', '', $external_links || '',
         '', '', $description, $link
       );
 
@@ -242,6 +241,11 @@ sub make_and_write_article {
         push @data, make_redirect( $temp, $title );
         $temp = $title;
         $temp =~ s/\(\)$//;
+        push @data, make_redirect( $temp, $title );
+    }
+    elsif ( $title =~ qr/@/ ) {
+        my $temp = $title;
+        $temp =~ s/@//;
         push @data, make_redirect( $temp, $title );
     }
     write_to_file(@data);

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -230,6 +230,13 @@ sub clean_string {
     return $clean;
 }
 
+sub build_initial_value {
+    my ($content) = @_;
+    $content = clean_code($content);
+    my $initial_value = "<p><b>Initial Value: </b><em>$content</em></p>";
+    return $initial_value;
+}
+
 sub build_abstract {
     my ( $description, $code ) = @_;
     say "NO DESCRIPTION!" if $description eq "";

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -270,9 +270,15 @@ sub parse_fragment_data {
     return if exists $already_processed{$link};
     $already_processed{$link} = 1;
     if ( $link =~ qr/font-variant/ ) {
+
+        #TODO: Implement parsing when the page is available. Currently
+        #it generates 404 not found response
         say "Font Variant $link";
     }
     elsif ( $link =~ qr/src/ ) {
+
+        #TODO: Implement parsing when the page is available. Currently
+        #it generates 404 not found response
         say "src $link";
     }
     elsif ( $link =~ qr/color_value/ ) {

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -357,9 +357,6 @@ sub parse_fragment_data {
             write_to_file(@article_data);
         }
     }
-    elsif ( $link =~ qr/frequency/ ) {
-        say "frequency $link";
-    }
     elsif ( $link =~ qr/length/ ) {
         my $dl_collection = $dom->find('dl');
         for my $dl ( $dl_collection->each ) {
@@ -378,7 +375,7 @@ sub parse_fragment_data {
             }
         }
     }
-    elsif ( $link =~ qr/time/ ) {
+    elsif ( $link =~ qr/time|frequency/ ) {
         my $h2 = $dom->at('h2#Summary');
         my $ul_containing_fragments =
           $h2->following->first( sub { $_->tag eq 'ul' } );
@@ -389,7 +386,8 @@ sub parse_fragment_data {
                 my $url   = $link->clone->fragment($title);
 
 =begin
-              Current description of 's' and 'ms' appears as below:
+              Taking 's' and 'ms' fragments for /time/ as examples
+              their current description appears as below:
               s which represents a time in seconds...
               ms which represents a time in milliseconds...
 

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -122,7 +122,7 @@ foreach my $html_file ( glob 'download/*.html' ) {
             $code = $pre->child_nodes->first->text;
         }
         else {
-            $code = clean_code( $pre->to_string );
+            $code = $pre->to_string;
         }
 
         $code = trim($code);
@@ -210,6 +210,7 @@ sub build_abstract {
     $description = trim($description);
     $description =~ s/\r?\n+/\\n/g;
     $initial_value =~ s/\r?\n+/\\n/g if $initial_value;
+    $code = clean_code($code) if $code;
     my $out;
     $out .= "<p>$description</p>"           if $description;
     $out .= "$initial_value"                if $initial_value;
@@ -337,9 +338,7 @@ sub parse_fragment_data {
                 }
                 $next_element = $next_element->next;
             } while ( $next_element && $next_element->tag ne 'h3' );
-            $paragraphs    = trim($paragraphs);
-            $code_fragment = clean_code($code_fragment);
-            $description   = build_abstract( $paragraphs, $code_fragment );
+            $description = build_abstract( $paragraphs, $code_fragment );
             make_and_write_article( $title, $description, $url );
         }
     }
@@ -382,9 +381,7 @@ sub parse_fragment_data {
                 }
                 $next_element = $next_element->next;
             } while ( $next_element && $next_element->tag ne 'div' );
-            $paragraphs    = trim($paragraphs);
-            $code_fragment = clean_code($code_fragment);
-            $description   = build_abstract( $paragraphs, $code_fragment );
+            $description = build_abstract( $paragraphs, $code_fragment );
             make_and_write_article( $title, $description, $url );
         }
     }

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -155,20 +155,6 @@ foreach my $html_file ( glob 'download/*.html' ) {
     $external_links ||= '';
     make_and_write_article( $title_clean, $description, $link,
         $external_links );
-
-    # Check for CSS Functions
-    # e.g. "not()"
-    # Replace "()" with "function" in title
-    # e.g. "not()" - > "not function"
-    if ( $title_clean =~ m/\(\)$/ ) {
-        say "Found Function: $title_clean";
-        my $temp = $title_clean;
-        $temp =~ s/\(\)$/ function/;
-        push @entries, make_redirect( $temp, $title );
-        $temp = $title_clean;
-        $temp =~ s/\(\)$//;
-        push @entries, make_redirect( $temp, $title );
-    }
 }
 
 # PRIVATE FUNCTIONS
@@ -237,11 +223,25 @@ sub make_and_write_article {
     say "LINK: $link";
     say "DESCRIPTION: $description"       if $description;
     say "EXTERNAL LINKS $external_links " if $external_links;
-    my $data = join "\t", (
+    my @data = join "\t", (
         $title, 'A', '', '', '', '', '', '', $external_links || '',
         '', '', $description, $link
     );
-    write_to_file($data);
+
+    # Check for CSS Functions
+    # e.g. "not()"
+    # Replace "()" with "function" in title
+    # e.g. "not()" - > "not function"
+    if ( $title =~ m/\(\)$/ ) {
+        say "\nFound Function: $title";
+        my $temp = $title;
+        $temp =~ s/\(\)$/ function/;
+        push @data, make_redirect( $temp, $title );
+        $temp = $title;
+        $temp =~ s/\(\)$//;
+        push @data, make_redirect( $temp, $title );
+    }
+    write_to_file(@data);
 }
 
 sub make_external_links {

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -328,12 +328,13 @@ sub parse_fragment_data {
                     $paragraphs .= $next_element->all_text;
                 }
                 else {
-                    $code_fragment .= $next_element->all_text;
+                    $code_fragment .= $next_element->to_string;
                 }
                 $next_element = $next_element->next;
             } while ( $next_element && $next_element->tag ne 'h3' );
-
-            $description = build_abstract( $paragraphs, $code_fragment );
+            $paragraphs    = trim($paragraphs);
+            $code_fragment = clean_code($code_fragment);
+            $description   = build_abstract( $paragraphs, $code_fragment );
             my @article_data = make_article( $title, $description, $url );
             write_to_file(@article_data);
         }
@@ -373,11 +374,13 @@ sub parse_fragment_data {
                     $paragraphs .= $next_element->all_text;
                 }
                 else {
-                    $code_fragment .= $next_element->all_text;
+                    $code_fragment .= $next_element->to_string;
                 }
                 $next_element = $next_element->next;
             } while ( $next_element && $next_element->tag ne 'div' );
-            $description = build_abstract( $paragraphs, $code_fragment );
+            $paragraphs    = trim($paragraphs);
+            $code_fragment = clean_code($code_fragment);
+            $description   = build_abstract( $paragraphs, $code_fragment );
             my @article_data = make_article( $title, $description, $url );
             write_to_file(@article_data);
         }
@@ -439,7 +442,8 @@ sub parse_fragment_data {
                         $code = $code_dom->all_text;
                     }
                     else {
-                        $code = $code_dom->at('tbody')->all_text;
+                        $code = $code_dom->at('tbody')->to_string;
+                        $code = clean_code($code);
                     }
                 }
                 my $description = build_abstract( $paragraph, $code );

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -129,7 +129,6 @@ foreach my $html_file ( glob 'download/*.html' ) {
         $code = trim($code);
         say '';
         say $code;
-        $code =~ s/\r?\n/\\n/g;
     }
     my $initial_value;
 

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -153,9 +153,8 @@ foreach my $html_file ( glob 'download/*.html' ) {
           make_external_links( $link, $external_lis_collection );
     }
     $external_links ||= '';
-
-    push @entries,
-      make_article( $title_clean, $description, $link, $external_links );
+    make_and_write_article( $title_clean, $description, $link,
+        $external_links );
 
     # Check for CSS Functions
     # e.g. "not()"
@@ -170,8 +169,6 @@ foreach my $html_file ( glob 'download/*.html' ) {
         $temp =~ s/\(\)$//;
         push @entries, make_redirect( $temp, $title );
     }
-
-    write_to_file(@entries);
 }
 
 # PRIVATE FUNCTIONS
@@ -233,18 +230,18 @@ sub build_abstract {
     return $out;
 }
 
-sub make_article {
+sub make_and_write_article {
     my ( $title, $description, $link, $external_links ) = @_;
     say '';
     say "TITLE: $title";
     say "LINK: $link";
     say "DESCRIPTION: $description"       if $description;
     say "EXTERNAL LINKS $external_links " if $external_links;
-    my @data = (
+    my $data = join "\t", (
         $title, 'A', '', '', '', '', '', '', $external_links || '',
         '', '', $description, $link
     );
-    return join "\t", @data;
+    write_to_file($data);
 }
 
 sub make_external_links {
@@ -321,8 +318,7 @@ sub parse_fragment_data {
             $paragraphs    = trim($paragraphs);
             $code_fragment = clean_code($code_fragment);
             $description   = build_abstract( $paragraphs, $code_fragment );
-            my @article_data = make_article( $title, $description, $url );
-            write_to_file(@article_data);
+            make_and_write_article( $title, $description, $url );
         }
     }
     elsif ( $link =~ qr/filter/ ) {
@@ -367,8 +363,7 @@ sub parse_fragment_data {
             $paragraphs    = trim($paragraphs);
             $code_fragment = clean_code($code_fragment);
             $description   = build_abstract( $paragraphs, $code_fragment );
-            my @article_data = make_article( $title, $description, $url );
-            write_to_file(@article_data);
+            make_and_write_article( $title, $description, $url );
         }
     }
     elsif ( $link =~ qr/length/ ) {
@@ -384,8 +379,7 @@ sub parse_fragment_data {
                 if ($dd) {
                     $description = build_abstract( $dd->all_text );
                 }
-                my @article_data = make_article( $title, $description, $url );
-                write_to_file(@article_data);
+                make_and_write_article( $title, $description, $url );
             }
         }
     }
@@ -433,8 +427,7 @@ sub parse_fragment_data {
                     }
                 }
                 my $description = build_abstract( $paragraph, $code );
-                my @article_data = make_article( $title, $description, $url );
-                write_to_file(@article_data);
+                make_and_write_article( $title, $description, $url );
             }
         }
     }

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -135,9 +135,8 @@ foreach my $html_file ( glob 'download/*.html' ) {
     my $table_properties = $dom->at('table.properties');
     if ($table_properties) {
         $initial_value = parse_initial_value($table_properties);
-        $description = "$description $initial_value" if $initial_value;
     }
-    $description = build_abstract( $description, $code );
+    $description = build_abstract( $description, $code, $initial_value );
 
     next unless $title && $link && $description;
 
@@ -206,13 +205,15 @@ sub build_initial_value {
 }
 
 sub build_abstract {
-    my ( $description, $code ) = @_;
+    my ( $description, $code, $initial_value ) = @_;
     say "NO DESCRIPTION!" if $description eq "";
     $description = trim($description);
     $description =~ s/\r?\n+/\\n/g;
+    $initial_value =~ s/\r?\n+/\\n/g if $initial_value;
     my $out;
-    $out .= "<p>$description</p>" if $description;
-    $out .= "<br><pre><code>$code</code></pre>" if $code;
+    $out .= "<p>$description</p>"           if $description;
+    $out .= "$initial_value"                if $initial_value;
+    $out .= "<pre><code>$code</code></pre>" if $code;
     return $out;
 }
 

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -145,6 +145,14 @@ foreach my $html_file ( glob 'download/*.html' ) {
         $code =~ s/\r?\n/\\n/g;
     }
     $hs->eof;
+    my $initial_value;
+
+    #initial value is found in the table properties
+    my $table_properties = $dom->at('table.properties');
+    if ($table_properties) {
+        $initial_value = parse_initial_value($table_properties);
+        $description = "$description $initial_value" if $initial_value;
+    }
     $description = build_abstract( $description, $code );
 
     next unless $title && $link && $description;
@@ -429,6 +437,22 @@ sub parse_fragment_data {
     else {
         warn "Unmatched $link in parse_fragment_data()";
     }
+}
+
+sub parse_initial_value {
+    my ($table_properties) = @_;
+
+    #first <tr> Contains the initial value
+    my $tr = $table_properties->find('tr')->first;
+    my $th = $tr->at('th');
+    my $initial_value;
+    if ($th) {
+        my $a = $th->at('a');
+        if ( $a && $a->text =~ /Initial value/ ) {
+            $initial_value = $tr->all_text;
+        }
+    }
+    return $initial_value;
 }
 
 sub write_to_file {

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -161,12 +161,6 @@ foreach my $html_file ( glob 'download/*.html' ) {
     }
     $external_links ||= '';
 
-    say '';
-    say "TITLE: $title";
-    say "LINK: $link";
-    say "DESCRIPTION: $description";
-    say "EXTERNAL LINKS $external_links ";
-
     push @entries,
       make_article( $title_clean, $description, $link, $external_links );
 
@@ -232,6 +226,11 @@ sub build_abstract {
 
 sub make_article {
     my ( $title, $description, $link, $external_links ) = @_;
+    say '';
+    say "TITLE: $title";
+    say "LINK: $link";
+    say "DESCRIPTION: $description" if $description;
+    say "EXTERNAL LINKS $external_links " if $external_links;
     my @data = (
         $title, 'A', '', '', '', '', '', '', $external_links || '',
         '', '', $description, $link

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -232,7 +232,6 @@ sub clean_string {
 
 sub build_initial_value {
     my ($content) = @_;
-    $content = clean_code($content);
     my $initial_value = "<p><b>Initial Value: </b><em>$content</em></p>";
     return $initial_value;
 }
@@ -467,7 +466,23 @@ sub parse_initial_value {
     if ($th) {
         my $a = $th->at('a');
         if ( $a && $a->text =~ /Initial value/ ) {
-            $initial_value = $tr->all_text;
+            my $td = $tr->at('td');
+            if ( $td->at('ul') ) {
+                my $ul = $td->at('ul');
+
+                #get text not in ul
+                $initial_value .= $td->at('ul')->remove->all_text;
+
+                #add new line after each li text so that it appears correctly
+                for my $li ( $ul->find('li')->each ) {
+                    $initial_value .= $li->all_text . '\\n ';
+                }
+            }
+            else {
+                $initial_value = trim( $td->all_text );
+            }
+            $initial_value = trim($initial_value);
+            $initial_value = build_initial_value($initial_value);
         }
     }
     return $initial_value;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -210,6 +210,8 @@ sub build_initial_value {
 sub build_abstract {
     my ( $description, $code ) = @_;
     say "NO DESCRIPTION!" if $description eq "";
+    $description = trim($description);
+    $description =~ s/\r?\n+/\\n/g;
     my $out;
     $out .= "<p>$description</p>" if $description;
     $out .= "<br><pre><code>$code</code></pre>" if $code;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -398,12 +398,25 @@ sub parse_fragment_data {
 
                 my $paragraph = $li->all_text;
                 $paragraph =~ s/\s{1}which//;
-                my $pre = $dom->at('h2#Examples')->following->first(
+
+                #for /frequency/ the example code
+                #is contained in a table
+                #for /time/ it is contained in a <pre>
+                my $node_with_code = $link =~ /time/ ? 'pre': 'table';
+                my $code_dom = $dom->at('h2#Examples')->following->first(
                     sub {
-                        $_->tag eq 'pre';
+                        $_->tag eq $node_with_code;
                     }
                 ) if $dom->at('h2#Examples');
-                my $code = $pre->all_text if $pre;
+                my $code;
+                if ($code_dom){
+                  if($code_dom->tag eq 'pre'){
+                    $code = $code_dom->all_text;
+                  }
+                  else{
+                    $code = $code_dom->at('tbody')->all_text;
+                  }
+                }
                 my $description = build_abstract( $paragraph, $code );
                 my @article_data = make_article( $title, $description, $url );
                 write_to_file(@article_data);

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -275,9 +275,6 @@ sub parse_fragment_data {
     elsif ( $link =~ qr/src/ ) {
         say "src $link";
     }
-    elsif ( $link =~ qr/angle/ ) {
-        say "angle $link";
-    }
     elsif ( $link =~ qr/color_value/ ) {
         for my $fragment ( @{ $url_fragment{$link} } ) {
             my $h3 = $dom->at("h3#$fragment");
@@ -375,7 +372,7 @@ sub parse_fragment_data {
             }
         }
     }
-    elsif ( $link =~ qr/time|frequency/ ) {
+    elsif ( $link =~ qr/time|frequency|angle/ ) {
         my $h2 = $dom->at('h2#Summary');
         my $ul_containing_fragments =
           $h2->following->first( sub { $_->tag eq 'ul' } );
@@ -399,23 +396,23 @@ sub parse_fragment_data {
                 my $paragraph = $li->all_text;
                 $paragraph =~ s/\s{1}which//;
 
-                #for /frequency/ the example code
+                #for /frequency/ and /angle/ the example code
                 #is contained in a table
                 #for /time/ it is contained in a <pre>
-                my $node_with_code = $link =~ /time/ ? 'pre': 'table';
+                my $node_with_code = $link =~ /time/ ? 'pre' : 'table';
                 my $code_dom = $dom->at('h2#Examples')->following->first(
                     sub {
                         $_->tag eq $node_with_code;
                     }
                 ) if $dom->at('h2#Examples');
                 my $code;
-                if ($code_dom){
-                  if($code_dom->tag eq 'pre'){
-                    $code = $code_dom->all_text;
-                  }
-                  else{
-                    $code = $code_dom->at('tbody')->all_text;
-                  }
+                if ($code_dom) {
+                    if ( $code_dom->tag eq 'pre' ) {
+                        $code = $code_dom->all_text;
+                    }
+                    else {
+                        $code = $code_dom->at('tbody')->all_text;
+                    }
                 }
                 my $description = build_abstract( $paragraph, $code );
                 my @article_data = make_article( $title, $description, $url );


### PR DESCRIPTION
Implement parsing of the fragments after the following paths:

- [x] `/color_value/`

- [x] `/filter/`

- [x]  `/angle/`

- [x] `/frequency`/

- [x] `/time/`

- [x] `/url/`

for [`/font-variant/`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-variant) and [`src`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#local()) the pages generate 404 codes so I have left a [note](https://github.com/duckduckgo/zeroclickinfo-fathead/pull/292/commits/5fc9ac6e256c8ad2e5d260890d969e0e259c22f1) so that they will be implemented when the pages are fixed.

Other tasks:

- [x] Implement parsing of `initial value`

This is still work in progress.

https://duck.co/ia/view/mdn_css