### PR TITLE
CanIUse: Adding notes to abstract as well as related links

### DIFF
--- a/lib/fathead/caniuse/README.txt
+++ b/lib/fathead/caniuse/README.txt
@@ -5,3 +5,4 @@ Git commands fetcher and parser for DuckDuckGo
 * Python 2.7.10
 * Python Packages
     * Markdown (pip install Markdown==2.6.6)
+    * BeautifulSoup (pip install BeautifulSoup==3.2.1)

--- a/lib/fathead/caniuse/README.txt
+++ b/lib/fathead/caniuse/README.txt
@@ -1,0 +1,7 @@
+Git commands fetcher and parser for DuckDuckGo
+
+# Dependencies:
+
+* Python 2.7.10
+* Python Packages
+    * Markdown (pip install Markdown==2.6.6)

--- a/lib/fathead/caniuse/parse.py
+++ b/lib/fathead/caniuse/parse.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from BeautifulSoup import BeautifulSoup
 import json
 import markdown
 import os
@@ -54,7 +55,10 @@ def generate_answers(data):
         notes = feature_data.get('notes', '')
         if notes:
             notes_in_html = markdown.markdown(notes)
-            abstract += '<p><b>Notes:</b> {}</p>'.format(notes_in_html)
+            bs = BeautifulSoup(notes_in_html)
+            for a in bs.findAll('a'):
+                a.replaceWithChildren()
+            abstract += '<p><b>Notes:</b> {}</p>'.format(bs.renderContents())
 
         abstract = abstract.replace('\n', '').replace('\r', '')
         print abstract

--- a/lib/fathead/caniuse/parse.py
+++ b/lib/fathead/caniuse/parse.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import json
+import markdown
 import os
 import re
 
@@ -31,12 +32,16 @@ def generate_answers(data):
         ])
         print ','.join(titles)
 
-        # Generate Related Topics
-        links = feature_data.get('links', [])
-        related = u' '.join([u'[[{} {}]]'.format(link['title'], link['url']) for link in links])
+        # Commented out for now -- we can revive if we ever have a way to display
+        # external links in the Related Topics Infobox
+        ## Generate Related Topics
+        #links = feature_data.get('links', [])
+        #related = u' '.join([u'[[{} {}]]'.format(link['title'], link['url']) for link in links])
+        related = ''
 
         # Generate abstract
-        abstract = feature_data['description']
+        abstract = '<p>{}</p>'.format(feature_data['description'])
+
         for browser in ['ie', 'firefox', 'chrome', 'safari', 'ios_saf', 'android']:
             agent = data['agents'][browser]
             out = browser_support(
@@ -48,7 +53,8 @@ def generate_answers(data):
         # Add notes to abstract, if there are any
         notes = feature_data.get('notes', '')
         if notes:
-            abstract += '<br>' + notes
+            notes_in_html = markdown.markdown(notes)
+            abstract += '<p><b>Notes:</b> {}</p>'.format(notes_in_html)
 
         abstract = abstract.replace('\n', '').replace('\r', '')
         print abstract

--- a/lib/fathead/caniuse/parse.py
+++ b/lib/fathead/caniuse/parse.py
@@ -113,6 +113,14 @@ def browser_support(browser, prefix, stats):
 
 def version_cmp(a, b):
     """Sort versions from newest to oldest"""
+    # "TP" is the Technology Preview version, and this version is by definition
+    # the latest version
+    if a == b == 'TP':
+        return 0
+    if a == 'TP':
+        return -1
+    elif b == 'TP':
+        return 1
     d = version2float(b) - version2float(a)
     return 1 if d > 0 else -1 if d < 0 else 0
 

--- a/lib/fathead/caniuse/parse.py
+++ b/lib/fathead/caniuse/parse.py
@@ -31,15 +31,25 @@ def generate_answers(data):
         ])
         print ','.join(titles)
 
+        # Generate Related Topics
+        links = feature_data.get('links', [])
+        related = u' '.join([u'[[{} {}]]'.format(link['title'], link['url']) for link in links])
+
         # Generate abstract
         abstract = feature_data['description']
         for browser in ['ie', 'firefox', 'chrome', 'safari', 'ios_saf', 'android']:
             agent = data['agents'][browser]
             out = browser_support(
-                browser=agent['browser'], 
-                prefix=agent['prefix'], 
+                browser=agent['browser'],
+                prefix=agent['prefix'],
                 stats=feature_data['stats'][browser])
             abstract += '<br>' + out
+
+        # Add notes to abstract, if there are any
+        notes = feature_data.get('notes', '')
+        if notes:
+            abstract += '<br>' + notes
+
         abstract = abstract.replace('\n', '').replace('\r', '')
         print abstract
         print '------------------------------------------'
@@ -53,7 +63,7 @@ def generate_answers(data):
                 '',         # Other uses
                 '',         # Categories
                 '',         # References
-                '',         # See also
+                related,    # See also
                 '',         # Further reading
                 '',         # External links
                 '',         # Disambiguation
@@ -82,7 +92,7 @@ def browser_support(browser, prefix, stats):
     """
     # Browser versions, sorted newest to oldest
     versions = sorted(stats.items(), key=lambda v: v[0], cmp=version_cmp)
-    
+
     # Find the earliest version which has equal support to latest
     scores = {'y': 3, 'a': 2, 'x': -1, 'p': -2, 'n': -3}
     current = versions[0]
@@ -138,5 +148,3 @@ def version2float(s):
 
 if __name__ == '__main__':
     main()
-
-


### PR DESCRIPTION
Fixes #245. I've added the 'notes' from the input data to the 'abstract' field as well as adding the links from the input data to the 'related' field in the IA. Also added support for the "TP" release version used by Safari to indicate "Technology Preview" -- we treat this as the latest version of the browser. 

This will requires some testing to make sure the links show up right as they might not be at the moment. It looks like to fix the triggering issue we should add some internal triggering words (specifically "compatibility") to fix everything discussed in issue 245. 

---

https://duck.co/ia/view/caniuse
Maintainer: @csytan 
