### PR TITLE
MDN CSS: Parsing of related articles and Cleanup

### DIFF
--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -207,8 +207,10 @@ sub build_initial_value {
 sub build_abstract {
     my ( $description, $code, $initial_value ) = @_;
     say "NO DESCRIPTION!" if $description eq "";
-    $description = trim($description);
-    $description =~ s/\r?\n+/\\n/g;
+    if ($description) {
+        $description = trim($description);
+        $description =~ s/\r?\n+/\\n/g;
+    }
     $initial_value =~ s/\r?\n+/\\n/g if $initial_value;
     $code = clean_code($code) if $code;
     my $out;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -144,11 +144,9 @@ foreach my $html_file ( glob 'download/*.html' ) {
     my $external_links;
     my $div_external = $dom->at('div#toc');
     if ($div_external) {
-        my $external_lis_collection = $div_external->find('li');
 
         #link is used to make link absolute
-        $external_links =
-          make_external_links( $link, $external_lis_collection );
+        $external_links = make_external_links( $link, $div_external );
     }
     $external_links ||= '';
     make_and_write_article( $title, $description, $link, $external_links );
@@ -241,15 +239,18 @@ sub make_and_write_article {
 }
 
 sub make_external_links {
-    my ( $link, $lis_collection ) = @_;
+    my ( $link, $div_external ) = @_;
     my $external_links;
-    for my $li ( $lis_collection->each ) {
-        my $a = $li->at('a');
-        next unless $a;
-        my $href          = $a->attr('href');
+    my $browser_compatibility_link = $div_external->find('a')->first(
+        sub {
+            $_->text =~ m/Browser compatibility/;
+        }
+    );
+    if ($browser_compatibility_link) {
+        my $href          = $browser_compatibility_link->attr('href');
         my $absolute_link = make_url_absolute( $href, $link );
-        my $link_text     = $a->text;
-        $external_links .= sprintf '[%s %s]\\\n', $link_text, $absolute_link;
+        my $link_text     = $browser_compatibility_link->text;
+        $external_links .= sprintf '[[%s %s]]', $absolute_link, $link_text;
     }
     return $external_links;
 }


### PR DESCRIPTION
Features being worked on:

- [x] Parsing of `related article titles`.

- [x] ~~Limit `external links` to only 'Browser Compatibility' link~~

- [ ] Remove extra spaces in some of the fields that mess up final rendering.

Feedback, help, criticism welcome.

cc @moollaza 

https://duck.co/ia/view/mdn_css