### PR TITLE
MDN CSS: Improve parsing of list values of initial value.

### DIFF
--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -212,7 +212,7 @@ sub make_and_write_article {
     say '';
     say "TITLE: $title";
     say "LINK: $link";
-    say "DESCRIPTION: $description"       if $description;
+    say "DESCRIPTION: $description" if $description;
     my $title_clean = clean_string($title);
     my @data        = join "\t",
       (
@@ -441,10 +441,15 @@ sub parse_initial_value {
                 #get text not in ul
                 $initial_value .= $td->at('ul')->remove->all_text;
 
-                #add new line after each li text so that it appears correctly
-                for my $li ( $ul->find('li')->each ) {
-                    $initial_value .= $li->all_text . '\\n ';
+                my $li_collection = $ul->find('li');
+                my $last_li       = $li_collection->last;
+                $li_collection->last->remove;
+
+                #Separate multiple values by commas
+                for my $li ( $li_collection->each ) {
+                    $initial_value .= $li->all_text . ', ';
                 }
+                $initial_value .= $last_li->all_text . '.';
             }
             else {
                 $initial_value = trim( $td->all_text );

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -436,18 +436,10 @@ sub parse_initial_value {
         if ( $a && $a->text =~ /Initial value/ ) {
             my $td = $tr->at('td');
             if ( $td->at('ul') ) {
-                my $ul = $td->at('ul');
-
-                #get text not in ul
-                $initial_value .= $td->at('ul')->remove->all_text;
-
-                #Take the <ul> as it is but remove <a> and <code> from <li>s
-                $ul->find('li')->map(
-                    sub {
-                        $_->content( $_->all_text );
-                    }
-                );
-                $initial_value .= $ul->to_string;
+                for my $element ( $td->find('code, a, br')->each ) {
+                    $element->replace( $element->all_text );
+                }
+                $initial_value .= $td->content;
             }
             else {
                 $initial_value = trim( $td->all_text );

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -441,15 +441,13 @@ sub parse_initial_value {
                 #get text not in ul
                 $initial_value .= $td->at('ul')->remove->all_text;
 
-                my $li_collection = $ul->find('li');
-                my $last_li       = $li_collection->last;
-                $li_collection->last->remove;
-
-                #Separate multiple values by commas
-                for my $li ( $li_collection->each ) {
-                    $initial_value .= $li->all_text . ', ';
-                }
-                $initial_value .= $last_li->all_text . '.';
+                #Take the <ul> as it is but remove <a> and <code> from <li>s
+                $ul->find('li')->map(
+                    sub {
+                        $_->content( $_->all_text );
+                    }
+                );
+                $initial_value .= $ul->to_string;
             }
             else {
                 $initial_value = trim( $td->all_text );


### PR DESCRIPTION
**Issue**
For cases where we had a list for the initial values, the script produced
wrongly spaced output. 

**Fix**
Simply separate the list of values using commas.

Please review.
cc @moollaza 

https://duck.co/ia/view/mdn_css