### PR TITLE
MDN CSS: Cleanup in initial value and code fragments parsing.

### DIFF
--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -212,7 +212,7 @@ sub make_and_write_article {
     say '';
     say "TITLE: $title";
     say "LINK: $link";
-    say "DESCRIPTION: $description"       if $description;
+    say "DESCRIPTION: $description" if $description;
     my $title_clean = clean_string($title);
     my @data        = join "\t",
       (
@@ -441,10 +441,15 @@ sub parse_initial_value {
                 #get text not in ul
                 $initial_value .= $td->at('ul')->remove->all_text;
 
-                #add new line after each li text so that it appears correctly
-                for my $li ( $ul->find('li')->each ) {
-                    $initial_value .= $li->all_text . '\\n ';
+                my $li_collection = $ul->find('li');
+                my $last_li       = $li_collection->last;
+                $li_collection->last->remove;
+
+                #Separate multiple values by commas
+                for my $li ( $li_collection->each ) {
+                    $initial_value .= $li->all_text . ', ';
                 }
+                $initial_value .= $last_li->all_text . '.';
             }
             else {
                 $initial_value = trim( $td->all_text );

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -410,7 +410,19 @@ sub parse_fragment_data {
                         $code = $code_dom->all_text;
                     }
                     else {
-                        $code = $code_dom->at('tbody')->to_string;
+                        my $tbody = $code_dom->at('tbody');
+                        my $trs   = $tbody->find('tr');
+                        for my $tr ( $trs->each ) {
+                            my $tds = $tr->find('td');
+                            $tds->each(
+                                sub {
+                                    my ( $td, $num ) = @_;
+                                    my $td_text = trim( $td->all_text );
+                                    $code .= $td_text if $num == 1;
+                                    $code .= " $td_text\n" if $num == 2;
+                                }
+                            );
+                        }
                         $code = clean_code($code);
                     }
                 }

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -436,18 +436,10 @@ sub parse_initial_value {
         if ( $a && $a->text =~ /Initial value/ ) {
             my $td = $tr->at('td');
             if ( $td->at('ul') ) {
-                my $ul = $td->at('ul');
-
-                #get text not in ul
-                $initial_value .= $td->at('ul')->remove->all_text;
-
-                #Take the <ul> as it is but remove <a> and <code> from <li>s
-                $ul->find('li')->map(
-                    sub {
-                        $_->content( $_->all_text );
-                    }
-                );
-                $initial_value .= $ul->to_string;
+                for my $element ( $td->find('code, a, br')->each ) {
+                    $element->replace( $element->all_text );
+                }
+                $initial_value .= $td->content;
             }
             else {
                 $initial_value = trim( $td->all_text );

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -441,15 +441,13 @@ sub parse_initial_value {
                 #get text not in ul
                 $initial_value .= $td->at('ul')->remove->all_text;
 
-                my $li_collection = $ul->find('li');
-                my $last_li       = $li_collection->last;
-                $li_collection->last->remove;
-
-                #Separate multiple values by commas
-                for my $li ( $li_collection->each ) {
-                    $initial_value .= $li->all_text . ', ';
-                }
-                $initial_value .= $last_li->all_text . '.';
+                #Take the <ul> as it is but remove <a> and <code> from <li>s
+                $ul->find('li')->map(
+                    sub {
+                        $_->content( $_->all_text );
+                    }
+                );
+                $initial_value .= $ul->to_string;
             }
             else {
                 $initial_value = trim( $td->all_text );


### PR DESCRIPTION
### Summary of changes:

1.  Added correct parsing of initial values embedded in `<ul>`.
2. Remove extra spaces from units of angle (like deg) and units of frequency.

I have tested the changes on codio and they look fine to me.

@moollaza please review.

https://duck.co/ia/view/mdn_css