### PR TITLE
MDN CSS: sort output.txt

### DIFF
--- a/lib/fathead/mdn_css/parse.sh
+++ b/lib/fathead/mdn_css/parse.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/bash
 
 perl parse.pl
+echo "Sorting output.txt..."
+sort output.txt -o output.txt


### PR DESCRIPTION
This force the output.txt file to be alphabetically sorted via unix `sort`.

This way, it will be easier to visually detect any duplicates and ensures that when a new output.txt is created, only new/modified content will show in the diff, as the ordering is currently random.

/cc @hchienjo 

https://duck.co/ia/view/mdn_css