### PR TITLE
MDN CSS: Put cleaned title in redirect field.

### DIFF
--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -283,6 +283,13 @@ sub make_redirect {
           ( $temp, 'R', $title, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
     }
+    elsif ( $title =~ /[<>]/ ) {
+        my $temp = $title;
+        $temp =~ s/[<>]//g;
+        $outputline = join "\t",
+          ( $temp, 'R', $title, '', '', '', '', '', '', '', '', '', '' );
+        push @data, $outputline;
+    }
     return @data;
 }
 

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -221,7 +221,7 @@ sub make_and_write_article {
       );
 
     if ( $title =~ /\(\)$/ or $title =~ qr/@/ ) {
-        push @data, make_redirect($title);
+        push @data, make_redirect( $title, $title_clean );
     }
     write_to_file(@data);
 }
@@ -236,7 +236,7 @@ sub make_redirect {
     output entry with redirect field
 =cut
 
-    my ($title) = @_;
+    my ( $title, $title_clean ) = @_;
     my @data;
     my $outputline;
     if ( $title =~ m/\(\)$/ ) {
@@ -244,19 +244,17 @@ sub make_redirect {
         my $temp = $title;
         $temp =~ s/\(\)$/ function/;
         $outputline = join "\t",
-          ( $temp, 'R', $title, '', '', '', '', '', '', '', '', '', '' );
+          ( $temp, 'R', $title_clean, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
         $temp = $title;
         $temp =~ s/\(\)$//;
         $outputline = join "\t",
-          ( $title, 'R', $temp, '', '', '', '', '', '', '', '', '', '' );
+          ( $title, 'R', $title_clean, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
     }
     elsif ( $title =~ qr/@/ ) {
-        my $temp = $title;
-        $temp =~ s/@//;
         $outputline = join "\t",
-          ( $title, 'R', $temp, '', '', '', '', '', '', '', '', '', '' );
+          ( $title, 'R', $title_clean, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
     }
     return @data;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -214,14 +214,21 @@ sub make_and_write_article {
     say "LINK: $link";
     say "DESCRIPTION: $description" if $description;
     my $title_clean = clean_string($title);
-    my @data        = join "\t",
-      (
-        $title_clean, 'A', '', '', '', '', '', '', '', '', '', $description,
-        $link
-      );
-
+    my @data;
     if ( $title =~ /\(\)$/ or $title =~ qr/@/ ) {
-        push @data, make_redirect( $title, $title_clean );
+        push @data, join "\t",
+          (
+            $title, 'A', '', '', '', '', '', '', '', '', '', $description,
+            $link
+          );
+        push @data, make_redirect($title);
+    }
+    else {
+        push @data, join "\t",
+          (
+            $title_clean, 'A', '', '', '', '', '', '', '', '', '', $description,
+            $link
+          );
     }
     write_to_file(@data);
 }
@@ -236,7 +243,7 @@ sub make_redirect {
     output entry with redirect field
 =cut
 
-    my ( $title, $title_clean ) = @_;
+    my ($title) = @_;
     my @data;
     my $outputline;
     if ( $title =~ m/\(\)$/ ) {
@@ -244,17 +251,19 @@ sub make_redirect {
         my $temp = $title;
         $temp =~ s/\(\)$/ function/;
         $outputline = join "\t",
-          ( $temp, 'R', $title_clean, '', '', '', '', '', '', '', '', '', '' );
+          ( $temp, 'R', $title, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
         $temp = $title;
         $temp =~ s/\(\)$//;
         $outputline = join "\t",
-          ( $title, 'R', $title_clean, '', '', '', '', '', '', '', '', '', '' );
+          ( $temp, 'R', $title, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
     }
     elsif ( $title =~ qr/@/ ) {
+        my $temp = $title;
+        $temp =~ s/@//;
         $outputline = join "\t",
-          ( $title, 'R', $title_clean, '', '', '', '', '', '', '', '', '', '' );
+          ( $temp, 'R', $title, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
     }
     return @data;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -215,7 +215,7 @@ sub make_and_write_article {
     say "DESCRIPTION: $description" if $description;
     my $title_clean = clean_string($title);
     my @data;
-    if ( $title =~ /\(\)$/ or $title =~ qr/@/ ) {
+    if ( $title =~ /[():<>@]/ ) {
         push @data, join "\t",
           (
             $title, 'A', '', '', '', '', '', '', '', '', '', $description,

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -221,7 +221,7 @@ sub make_and_write_article {
             $title, 'A', '', '', '', '', '', '', '', '', '', $description,
             $link
           );
-        push @data, make_redirect($title);
+        push @data, make_redirect( $title, $title_clean );
     }
     else {
         push @data, join "\t",
@@ -243,7 +243,7 @@ sub make_redirect {
     output entry with redirect field
 =cut
 
-    my ($title) = @_;
+    my ( $title, $title_clean ) = @_;
     my @data;
     my $outputline;
     if ( $title =~ m/\(\)$/ ) {
@@ -258,6 +258,23 @@ sub make_redirect {
         $outputline = join "\t",
           ( $temp, 'R', $title, '', '', '', '', '', '', '', '', '', '' );
         push @data, $outputline;
+
+        if ( $temp =~ /^:/ ) {
+
+            #Example :dir becomes :dir function and dir function entries
+            $outputline = join "\t",
+              (
+                $title_clean, 'R', $title, '', '', '', '', '', '', '', '', '',
+                ''
+              );
+            push @data, $outputline;
+            $outputline = join "\t",
+              (
+                "$title_clean function",
+                'R', $title, '', '', '', '', '', '', '', '', '', ''
+              );
+            push @data, $outputline;
+        }
     }
     elsif ( $title =~ qr/@/ ) {
         my $temp = $title;


### PR DESCRIPTION
Put the cleaned title in the redirect field so that it points to the right article.
 
Please not that I have not generated the output.txt after making this change.

cc @moollaza 

https://duck.co/ia/view/mdn_css