### PR TITLE
PerlDoc: Add support for modules

### DIFF
--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -815,6 +815,13 @@ sub parse_variables {
 #                              Packages                               #
 #######################################################################
 
+sub aliases_package {
+    my ($package) = @_;
+    make_aliases($package,
+        $package =~ s/::/ /gr,
+    );
+}
+
 sub grab_section {
     my ($section_name, $dom) = @_;
     my $start = $dom->at(qq(a[name="$section_name"] + h1));
@@ -847,6 +854,7 @@ sub parse_package {
     };
     return {
         articles => [$article],
+        aliases  => [aliases_package($package_name)],
     };
 }
 

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -307,9 +307,8 @@ sub entry {
     my ($title, $text, $url, $related) = @article{qw(title text url related)};
     $text =~ s{\\}{\\\\}g;
     my $related_text = '';
-    # TODO: Find out how the related links should *actually* be formatted
     if (defined $related && @$related) {
-        $related_text = join '', map { "[[$_]]" } @$related;
+        $related_text = join '\n', map { "[[$_]]" } @$related;
     }
     my $category_text = join '\n', @{$article{categories} || []};
     return warn "No text for '$title'" unless $text;

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -312,6 +312,7 @@ sub entry {
     }
     my $category_text = join '\n', @{$article{categories} || []};
     return warn "No text for '$title'" unless $text;
+    $text =~ s/\t/&#09;/g;
     $self->insert({
         abstract => $text,
         categories => $category_text,

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -815,11 +815,28 @@ sub parse_variables {
 #                              Packages                               #
 #######################################################################
 
+sub grab_section {
+    my ($section_name, $dom) = @_;
+    my $start = $dom->at(qq(a[name="$section_name"] + h1));
+    return Mojo::Collection::c() unless $start;
+    my $elt = $start;
+    my @elts;
+    while (1) {
+        $elt = $elt->next;
+        last unless $elt;
+        if ($elt->matches('a[name]') && $elt->attr('name') =~ /^[A-Z]+$/) {
+            last;
+        }
+        push @elts, $elt;
+    }
+    return Mojo::Collection::c(@elts); # Give back a Mojo collection
+}
+
 sub parse_package {
     my ($self, $dom) = @_;
     my $package_name = $dom->at('div#from_search + h1')->text;
-    my $synopsis = $dom->at('a[name="SYNOPSIS"] + h1 + pre');
-    $synopsis //=  $dom->at('a[name="SYNOPSIS"] + h1 + p');
+    my $syns = grab_section('SYNOPSIS', $dom);
+    my $synopsis = $syns->join();
     return {} unless $synopsis;
     $synopsis = $synopsis->to_string;
     my $short_desc = $dom->at('a[name="NAME"] + h1 + p') // '';

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -816,8 +816,12 @@ sub parse_variables {
 
 sub aliases_package {
     my ($package) = @_;
-    make_aliases($package,
-        $package =~ s/::/ /gr,
+    my $spaced = $package =~ s/::/ /gr;
+    make_aliases("$package (module)",
+        "$spaced", "$package",
+        map { ("$package $_", "$spaced $_") } (
+            'module', 'library', 'package',
+        ),
     );
 }
 
@@ -854,7 +858,7 @@ sub parse_package {
         ->map('text')->each;
     my $article = {
         text  => "$short_desc$synopsis",
-        title => $package_name,
+        title => "$package_name (module)",
         related => \@related,
     };
     return {

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -156,8 +156,6 @@ sub doc_fullurl {
 my %parser_map = (
     'index-faq'       => ['parse_faq'],
     'index-functions' => ['parse_functions'],
-    'index-module'    => ['get_synopsis'],
-    'index-default'   => ['get_anchors'],
     'perldiag'        => ['parse_diag_messages'],
     'perlglossary'    => ['parse_glossary_definitions'],
     'perlop'          => ['parse_operators'],
@@ -323,40 +321,6 @@ sub entry {
         related  => $related_text,
         sourceurl => $url,
     });
-}
-
-sub get_synopsis {
-    my ( $self, $dom ) = @_;
-    my $articles;
-    my $title = $dom->at('title')->text;
-    my $module = $title =~ s/\s.*//r;
-    my $first_code_block = $dom->find('pre')->[0];
-
-    if ( !$first_code_block ) {
-        warn "No code block for $module";
-        return {};
-    }
-
-    my @articles = @{$articles->{articles} || []};
-    push @articles, {
-        title => $title,
-        text  => $first_code_block->to_string
-    };
-    $articles->{articles} = \@articles;
-
-    my @aliases = @{$articles->{aliases} || []};
-    push @aliases, {
-        new  => $module,
-        orig => $title,
-    };
-    $articles->{aliases} = \@aliases;
-
-    return $articles;
-}
-
-sub get_anchors {
-    my ( $self, $dom ) = @_;
-    my $articles;
 }
 
 sub retrieve_entry {


### PR DESCRIPTION
Fixes #340.

* Core modules are now supported.
* Content is brief summary (from name) + synopsis.
* 'See also' is used for the related topics.

---
IA Page: https://duck.co/ia/view/perl_doc
Maintainer: @GuiltyDolphin