### PR TITLE
MDN CSS: Improve description and title parsing.

### DIFF
--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -207,9 +207,13 @@ sub build_initial_value {
 
 sub build_abstract {
     my ( $description, $code, $initial_value ) = @_;
-    say "NO DESCRIPTION!" if $description eq "";
-    $description = trim($description);
-    $description =~ s/\r?\n+/\\n/g;
+    if ($description) {
+        $description = trim($description);
+        $description =~ s/\r?\n+/\\n/g;
+    }
+    else {
+        say "NO DESCRIPTION!";
+    }
     $initial_value =~ s/\r?\n+/\\n/g if $initial_value;
     $code = clean_code($code) if $code;
     my $out;

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -89,16 +89,28 @@ foreach my $html_file ( glob 'download/*.html' ) {
         parse_fragment_data( $link, $dom );
     }
 
-    # Get article title and description
+    # Get article title
     for my $meta ( $dom->find('meta')->each ) {
         next unless $meta->attr('property');
         if ( $meta->attr('property') =~ /og\:title/ ) {
             $title = lc $meta->attr('content');
         }
-        elsif ( $meta->attr('property') =~ /og\:description/ ) {
-            $description = $meta->attr('content');
+        last if $title;
+    }
+
+    my $h2 = $dom->at('h2#Summary');
+    if ($h2) {
+        my $p = $h2->next;
+        if ($p) {
+            my $next = $p->next;
+            if ( $next && $next->tag eq 'ul' ) {
+                $description = $p->all_text;
+                $description .= $next->find('li')->map('all_text')->join(', ');
+            }
+            else {
+                $description = $p->all_text;
+            }
         }
-        last if $title and $description;
     }
 
     # Check if article already processed

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -90,13 +90,14 @@ foreach my $html_file ( glob 'download/*.html' ) {
     }
 
     # Get article title
-    for my $meta ( $dom->find('meta')->each ) {
-        next unless $meta->attr('property');
-        if ( $meta->attr('property') =~ /og\:title/ ) {
-            $title = lc $meta->attr('content');
+    my $meta_with_title = $dom->find('meta')->first(
+        sub {
+            my $meta     = $_;
+            my $property = $meta->attr('property');
+            $property && $property =~ /og\:title/;
         }
-        last if $title;
-    }
+    );
+    $title = lc $meta_with_title->attr('content') if $meta_with_title;
 
     my $h2 = $dom->at('h2#Summary');
     if ($h2) {

--- a/lib/fathead/mdn_css/parse.pl
+++ b/lib/fathead/mdn_css/parse.pl
@@ -102,13 +102,10 @@ foreach my $html_file ( glob 'download/*.html' ) {
     if ($h2) {
         my $p = $h2->next;
         if ($p) {
+            $description = $p->all_text;
             my $next = $p->next;
             if ( $next && $next->tag eq 'ul' ) {
-                $description = $p->all_text;
                 $description .= $next->find('li')->map('all_text')->join(', ');
-            }
-            else {
-                $description = $p->all_text;
             }
         }
     }


### PR DESCRIPTION
Current Changes
===============
1. Parse description from the body of html to avoid truncated descriptions.
2. Improve efficiency in title parsing.
3. Avoid spurious warnings about use of uninitialized values.

WIP
=======
Work on fixing a duplication of `color` in output.txt file
![screenshot from 2016-08-29 11-26-32](https://cloud.githubusercontent.com/assets/13175534/18045607/58edfcc6-6ddc-11e6-91c9-5206f04a65c9.png)

cc @moollaza 

IA Page: https://duck.co/ia/view/mdn_css