### PR TITLE
PerlDoc: Fix function parser

### DIFF
--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -558,12 +558,17 @@ sub parse_functions {
     my ($self, $dom) = @_;
 
     my $fname = $dom->at('div#from_search + h1')->text;
+    my @syntaxes = $dom->find('ul > li > a[name] + b')->map('text')->each;
 
     my $description = text_from_selector(
         $dom->at('ul:last-of-type > li > a[name]')->parent
     )->to_string;
     $description ||= $functions_fallback{$fname};
     return unless $description;
+    my $syntax = Mojo::DOM->new("<pre>$syntaxes[0]</pre>");
+    map { $syntax->at('pre')->append_content("<br />$_") }
+        @syntaxes[1..$#syntaxes];
+    $description = $syntax->to_string . $description;
 
     my $title = "$fname (function)";
 

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -551,27 +551,18 @@ sub parse_faq {
 
 # TODO: Some functions (e.g., 'xor') are documented in 'perlop' so do not
 # receive a good description from this parser.
-my $skip = qr/To get the best experience. |Please note: Many features/;
 sub parse_functions {
     my ($self, $dom) = @_;
 
-    my $fname = $dom->at('title')->text;
-    $fname =~ s/\s-\s.*//;
-
-    my $hint = $dom->at('b')->text;
-
-    $dom = $dom->at('div[id="content_body"]');
-
-    my $description;
-    foreach my $n ($dom->find('p, code')->each){
-        next unless $n->content;
-        next if $n->content =~ /$skip/;
-        $description .= $n->content;
-    }
-    return unless $description;
-    $description = trim_abstract($description, 100);
-    $description = "<code><br>$hint<br></code><br>". $description;
+    my $fname = $dom->at('div#from_search + h1')->text;
+    my $description = text_from_selector(
+        $dom->at('ul > li > a[name]')->parent
+    );
+    # TODO: Fall back on using the index description if we cannae find a good
+    # one.
+    warn "No text for $fname\n" and return {} unless $description;
     my $title = "$fname (function)";
+
     return {
         articles => [
             { title => $title, text => $description }

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -560,7 +560,7 @@ sub parse_functions {
     my $fname = $dom->at('div#from_search + h1')->text;
 
     my $description = text_from_selector(
-        $dom->at('ul > li > a[name]')->parent
+        $dom->at('ul:last-of-type > li > a[name]')->parent
     )->to_string;
     $description ||= $functions_fallback{$fname};
     return unless $description;


### PR DESCRIPTION
This fixes a few things with the function parser:

* Fixes the description
  - correct formatting for code blocks
  - have the function syntax(es) at the header
* Uses the index description as a fallback for when the function page doesn't have one

Fixes #344.

(I'd upload screenshots, but GH is being a bit funny at the moment).