### PR TITLE
PerlDoc : Restore index-language parsing.

### DIFF
--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -155,6 +155,7 @@ sub doc_fullurl {
 # Parsers for other keys (basenames) will only run on the matching file.
 my %parser_map = (
     'index-faq'       => ['parse_faq'],
+    'index-language'  => ['parse_faq'],
     'index-functions' => ['parse_functions'],
     'perldiag'        => ['parse_diag_messages'],
     'perlglossary'    => ['parse_glossary_definitions'],

--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -155,6 +155,8 @@ sub doc_fullurl {
 # Parsers for other keys (basenames) will only run on the matching file.
 my %parser_map = (
     'index-faq'       => ['parse_faq'],
+    # TODO: Add explicit parser for language syntax, or generalize the FAQ
+    # parser.
     'index-language'  => ['parse_faq'],
     'index-functions' => ['parse_functions'],
     'perldiag'        => ['parse_diag_messages'],


### PR DESCRIPTION
This is why entries for for, foreach and so on went missing.

IA Page : https://duck.co/ia/view/perl_doc