### PR TITLE
MDN CSS: Add support for -webkit and -moz extensions

### DIFF
--- a/lib/fathead/mdn_css/fetch.pl
+++ b/lib/fathead/mdn_css/fetch.pl
@@ -24,8 +24,10 @@ my $webkit_extensions_url = Mojo::URL->new(
     'https://developer.mozilla.org/en-US/docs/Web/CSS/Webkit_Extensions');
 my $mozilla_css_extensions_url = Mojo::URL->new(
     'https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions');
-my $tx = $ua->get($reference_url);
 
+my @fetch_links =
+  ( $reference_url, $webkit_extensions_url, $mozilla_css_extensions_url );
+my @txs = map { $ua->get($_) } @fetch_links;
 my %urls;    #hash used to remove duplicate urls
 
 if ( $tx->success ) {

--- a/lib/fathead/mdn_css/fetch.pl
+++ b/lib/fathead/mdn_css/fetch.pl
@@ -20,6 +20,10 @@ something other than BASH to ease development and maintenance in the future.
 my $ua = Mojo::UserAgent->new()->max_redirects(4);
 my $reference_url =
   Mojo::URL->new('https://developer.mozilla.org/en-US/docs/Web/CSS/Reference');
+my $webkit_extensions_url = Mojo::URL->new(
+    'https://developer.mozilla.org/en-US/docs/Web/CSS/Webkit_Extensions');
+my $mozilla_css_extensions_url = Mojo::URL->new(
+    'https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions');
 my $tx = $ua->get($reference_url);
 
 my %urls;    #hash used to remove duplicate urls


### PR DESCRIPTION
Changes
===========
Add parsing of https://developer.mozilla.org/en-US/docs/Web/CSS/Webkit_Extensions
and https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions

This attempts to fix one of the listed tasks in [issue 293](https://github.com/duckduckgo/zeroclickinfo-fathead/issues/293)

This is work in progress.


cc @moollaza

https://duck.co/ia/view/mdn_css