### PR TITLE
mdnjs: issue #372 -- redirects without punctuation for error articles

### DIFF
--- a/lib/fathead/mdnjs/output.txt
+++ b/lib/fathead/mdnjs/output.txt
@@ -103,7 +103,7 @@ AudioContext.createConvolver()	A										<pre><code>var audioCtx = new AudioCon
 AudioContext.createDelay()	A										<pre><code>var audioCtx = new AudioContext();\nvar synthDelay = audioCtx.createDelay(5.0);</code></pre>A DelayNode.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createDelay
 AudioContext.createDynamicsCompressor()	A										<pre><code>var audioCtx = new AudioContext();\nvar compressor = audioCtx.createDynamicsCompressor();</code></pre>Compression lowers the volume of the loudest parts of the signal and raises the volume of the softest parts. Overall, a louder, richer, and fuller sound can be achieved. It is especially important in games and musical applications where large numbers of individual sounds are played simultaneously, where you want to control the overall signal level and help avoid clipping (distorting) of the audio output.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createDynamicsCompressor
 AudioContext.createGain()	A										<pre><code>var audioCtx = new AudioContext();\nvar gainNode = audioCtx.createGain();</code></pre>A GainNode.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createGain
-CreateIIRFilter	A										<pre><code>var audioCtx = new AudioContext();\nvar iirFilter = audioCtx.createIIRFilter();</code></pre>The createIIRFilter() method of the AudioContext interface creates an IIRFilterNode, which represents a second order filter configurable as several different common filter types.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/CreateIIRFilter
+AudioContext.createIIRFilter()	A										<pre><code>var iirFilter = AudioContext.createIIRFilter(feedforward, feedback);</code></pre>The createIIRFilter() method of the AudioContext interface creates an IIRFilterNode, which represents a general infinite impulse response (IIR) filter which can be configured to serve as various types of filter.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createIIRFilter
 AudioContext.createMediaElementSource()	A										<pre><code>var audioCtx = new AudioContext();\nvar source = audioCtx.createMediaElementSource(myMediaElement);</code></pre>For more details about media element audio source nodes, check out the MediaElementAudioSourceNode reference page.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createMediaElementSource
 AudioContext.createMediaStreamDestination()	A										<pre><code>var audioCtx = new AudioContext();\nvar destination = audioCtx.createMediaStreamDestination();</code></pre>The MediaStream is created when the node is created and is accessible via the MediaStreamAudioDestinationNode 's strea m attribute. This stream can be used in a similar way as a MediaStream obtained via navigator.getUserMedia — it can, for example, be sent to a remote peer using the RTCPeerConnection addStream() method.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createMediaStreamDestination
 AudioContext.createMediaStreamSource()	A										<pre><code>var audioCtx = new AudioContext();\nvar source = audioCtx.createMediaStreamSource(stream);</code></pre>For more details about media stream audio source nodes, check out the MediaStreamAudioSourceNode reference page.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createMediaStreamSource
@@ -113,7 +113,6 @@ AudioContext.createPeriodicWave()	A										<pre><code>var audioCtx = new Audio
 AudioContext.createScriptProcessor()	A										<pre><code>var audioCtx = new AudioContext();\nmyScriptProcessor = audioCtx.createScriptProcessor(1024, 1, 1);</code></pre>A ScriptProcessorNode.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createScriptProcessor
 AudioContext.createStereoPanner()	A										<pre><code>var audioCtx = new AudioContext();\nvar panNode = audioCtx.createStereoPanner();</code></pre>A StereoPannerNode.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createStereoPanner
 AudioContext.createWaveShaper()	A										<pre><code>var audioCtx = new AudioContext();\nvar distortion = audioCtx.createWaveShaper();</code></pre>A WaveShaperNode.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createWaveShaper
-AudioContext.currentTime	A										<pre><code>var audioCtx = new AudioContext();\nconsole.log(audioCtx.currentTime);\n</code></pre>Tags: API\n      \n        AudioContext\n      \n        currentTime\n      \n        Property\n      \n        Reference\n      \n        R&#233;f&#233;rence\n      \n        Web Audio API	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/currentTime
 AudioContext.decodeAudioData()	A										<pre><code>audioCtx.decodeAudioData(audioData, function(decodedData) {\n  // use the dec&#8203;oded data here\n});</code></pre>This is the preferred method of creating an audio source for Web Audio API from an audio track.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/decodeAudioData
 AudioContext.destination	A										<pre><code>var audioCtx = new AudioContext();\ngainNode.connect(audioCtx.destination);</code></pre>An AudioDestinationNode.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/destination
 AudioContext.listener	A										<pre><code>var audioCtx = new AudioContext();\nvar myListener = audioCtx.listener;</code></pre>An AudioListener object.	https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/listener
@@ -171,7 +170,7 @@ BiquadFilterNode	A										The BiquadFilterNode interface represents a simple l
 BiquadFilterNode.detune	A										<pre><code>var audioCtx = new AudioContext();\nvar biquadFilter = audioCtx.createBiquadFilter();\nbiquadFilter.detune.value = 100;</code></pre>An a-rate AudioParam.	https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode/detune
 BiquadFilterNode.frequency	A										<pre><code>var audioCtx = new AudioContext();\nvar biquadFilter = audioCtx.createBiquadFilter();\nbiquadFilter.frequency.value = 3000;</code></pre>An AudioParam.	https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode/frequency
 BiquadFilterNode.gain	A										<pre><code>var audioCtx = new AudioContext();\nvar biquadFilter = audioCtx.createBiquadFilter();\nbiquadfilter.gain.value = 25;</code></pre>An AudioParam.	https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode/gain
-BiquadFilterNode.getFrequencyResponse()	A										<pre><code>var audioCtx = new AudioContext();\nvar biquadFilter = audioCtx.createBiquadFilter();\nbiquadfilter.getFrequencyResponse(myFrequencyArray,magResponseOutput,phaseResponseOutput);\n</code></pre>A BiquadFilterNode.	https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode/getFrequencyResponse
+BiquadFilterNode.getFrequencyResponse()	A										<pre><code>BiquadFilterNode.getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput);\n</code></pre>undefined	https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode/getFrequencyResponse
 BiquadFilterNode.Q	A										<pre><code>var audioCtx = new AudioContext();\nvar biquadFilter = audioCtx.createBiquadFilter();\nbiquadfilter.Q.value = 100;</code></pre>An AudioParam.	https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode/Q
 BiquadFilterNode.type	A										<pre><code>var audioCtx = new AudioContext();\nvar biquadFilter = audioCtx.createBiquadFilter();\nbiquadfilter.type = 'lowpass';</code></pre>A string (enum) representing a BiquadFilterType.	https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode/type
 Blob	A										A Blob object represents a file-like object of immutable, raw data. Blobs represent data that isn't necessarily in a JavaScript-native format. The File interface is based on Blob, inheriting blob functionality and expanding it to support files on the user's system.	https://developer.mozilla.org/en-US/docs/Web/API/Blob
@@ -259,7 +258,7 @@ Cache.put()	A										<pre><code>cache.put(request, response).then(function() {
 CacheStorage	A										The CacheStorage interface represents the storage for Cache objects. It provides a master directory of all the named caches that a ServiceWorker, other type of worker or window scope can access (you don't have to use it with service workers, even though that is the spec that defines it) and maintains a mapping of string names to corresponding Cache objects.	https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage
 CacheStorage.delete()	A										<pre><code>caches.delete(cacheName).then(function(true) {\n  //your cache is now deleted\n});\n</code></pre>The delete () method of the CacheStorage interface finds the Cache object matching the cacheName, and if found, deletes the Cache object and returns a Promise that resolves to true. If no Cache object is found, it returns false.	https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/delete
 CacheStorage.has()	A										<pre><code>caches.has(cacheName).then(function(true) {\n  // your cache exists!\n});\n</code></pre>The has() method of the CacheStorage interface returns a Promise that resolves to true if a Cache object matches the cacheName.	https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/has
-CacheStorage.keys()	A										<pre><code>caches.keys().then(function(keyList) {\n  //do something with your keyList\n});\n</code></pre>The keys () method of the CacheStorage interface returns a Promise that will resolve with an array containing strings corresponding to all of the named Cache objects tracked by the CacheStorage object. Use this method to iterate over a list of all Cache objects.	https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/keys
+CacheStorage.keys()	A										<pre><code>caches.keys().then(function(keyList) {\n  //do something with your keyList\n});\n</code></pre>The keys () method of the CacheStorage interface returns a Promise that will resolve with an array containing strings corresponding to all of the named Cache objects tracked by the CacheStorage object in the order they were created. Use this method to iterate over a list of all Cache objects.	https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/keys
 CacheStorage.match()	A										<pre><code>caches.match(request,{options}).then(function(response) {\n  //do something with the request\n});\n</code></pre>The match() method of the CacheStorage interface checks if a given Request is a key in any of the Cache objects that the CacheStorage object tracks and returns a Promise that resolves to the matching Response.	https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/match
 CacheStorage.open()	A										<pre><code>caches.open(cacheName).then(function(cache) {\n  //do something with your cache\n});\n</code></pre>The open() method of the CacheStorage interface returns a Promise that resolves to the Cache object matching the cacheName.	https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/open
 CanvasCaptureMediaStream	A										The CanvasCaptureMediaStream interface represents a MediaStream capturing in real-time the surface of an HTMLCanvasElement.	https://developer.mozilla.org/en-US/docs/Web/API/CanvasCaptureMediaStream
@@ -444,7 +443,7 @@ CSS	A										The CSS interface holds useful CSS-related methods. No object wit
 CSS.escape()	A										<pre><code>escapedStr = CSS.escape(str);\n</code></pre>The CSS.escape() static method returns a DOMString containing the escaped string passed as parameter, mostly for use as part of a CSS selector.	https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape
 CSS.supports()	A										<pre><code>boolValue = CSS.supports(propertyName, value);\nboolValue = CSS.supports(supportCondition);\n</code></pre>The CSS.supports() static methods returns a Boolean value indicating if the browser supports a given CSS feature, or not.	https://developer.mozilla.org/en-US/docs/Web/API/CSS/supports
 CSSConditionRule	A										<pre><code>interface CSSConditionRule : CSSGroupingRule {\n    attribute DOMString conditionText;\n}\n</code></pre>An object implementing the CSSConditionRule interface represents a single condition CSS at-rule, which consists of a condition and a statement block. It is a child of CSSGroupingRule.	https://developer.mozilla.org/en-US/docs/Web/API/CSSConditionRule
-CSSCounterStyleRule	A										The CSSCounterStyleRule interface represents …	https://developer.mozilla.org/en-US/docs/Web/API/CSSCounterStyleRule
+CSSCounterStyleRule	A										The CSSCounterStyleRule interface represents an @counter-style at-rule.	https://developer.mozilla.org/en-US/docs/Web/API/CSSCounterStyleRule
 CSSGroupingRule	A										An object implementing the CSSGroupingRule interface represents any CSS at-rule that contains other rules nested within it.	https://developer.mozilla.org/en-US/docs/Web/API/CSSGroupingRule
 CSSKeyframeRule	A										The CSSKeyframeRule interface describes an object representing a set of style for a given keyframe. It corresponds to the contains of a single keyframe of a @keyframes at-rule. It implements the CSSRule interface with a type value of 8 (CSSRule.KEYFRAME_RULE).	https://developer.mozilla.org/en-US/docs/Web/API/CSSKeyframeRule
 CSSKeyframesRule	A										The CSSKeyframesRule interface describes an object representing a complete set of keyframes for a CSS animation. It corresponds to the contains of a whole @keyframes at-rule. It implements the CSSRule interface with a type value of 7 (CSSRule.KEYFRAMES_RULE).	https://developer.mozilla.org/en-US/docs/Web/API/CSSKeyframesRule
@@ -482,6 +481,7 @@ CSSValue.cssValueType	A										<pre><code>cssValueType = cssValue.cssValueType
 CSSValueList	A										The CSSValueList interface derives from the CSSValue interface and provides the abstraction of an ordered collection of CSS values.	https://developer.mozilla.org/en-US/docs/Web/API/CSSValueList
 CSSValueList.item()	A										<pre><code>var cssValue = cssValueList.item(index);</code></pre>The item() method of the CSSValueList interface is used to retrieve a CSSValue by ordinal index.	https://developer.mozilla.org/en-US/docs/Web/API/CSSValueList/item
 CSSValueList.length	A										<pre><code>var length = cssValueList.length;\n</code></pre>The length read-only property of the CSSValueList interface represents the number of CSSValue s in the list. The range of valid values of the indices is 0 to length-1 inclusive.	https://developer.mozilla.org/en-US/docs/Web/API/CSSValueList/length
+CSS Counter Styles	A										The CSS Counter Styles module allows to define custom counter styles, which can be used for CSS list-marker and generated-content counters.	https://developer.mozilla.org/en-US/docs/Web/API/CSS_Counter_Styles
 CSS Font Loading API	A										The CSS Font Loading API provides events and interfaces for dynamically loading font resources.	https://developer.mozilla.org/en-US/docs/Web/API/CSS_Font_Loading_API
 CSS Object Model	A										The CSS Object Model is a set of APIs allowing to manipulate CSS from JavaScript. It is the pendant of DOM and HTML APIs, but for CSS. It allows to read and modify CSS style dynamically.	https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model
 Determining the dimensions of elements	A										There are several properties you can look at in order to determine the width and height of elements, and it can be tricky to determine which is the right one for your needs. This article is designed to help you make that decision.  Note that all these properties are read-only.  If you want to set the width and height of an element, use width and height ; or, the overriding min-width and max-width, and min-height and max-height properties.	https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements
@@ -510,16 +510,16 @@ DataTransfer.setData()	A										<pre><code>void dataTransfer.setData(format, d
 DataTransfer.setDragImage()	A										<pre><code>void dataTransfer.setDragImage(img, xOffset, yOffset);\n</code></pre>When a drag occurs, a translucent image is generated from the drag target (the element the dragstart event is fired at), and follows the mouse pointer during the drag. This image is created automatically, so you do not need to create it yourself. However, if a custom image is desired, the DataTransfer.setDragImage() method can be used to set the custom image to be used.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setDragImage
 DataTransfer.types	A										<pre><code>dataTransfer.types;\n</code></pre>The DataTransfer.types read-only property is an array of the drag data formats (as strings) that were set in the dragstart event. The order of the formats is the same order as the data included in the drag operation.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types
 DataTransferItem	A										The DataTransferItem object represents one drag data item. During a drag operation, each drag event has a dataTransfer property which contains a list of drag data items. Each item in the list is a DataTransferItem object.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem
-DataTransferItem.getAsFile()	A										<pre><code>File dataTransferItem.getAsFile();\n</code></pre>The DataTransferItem.getAsFile() method returns the drag data item's File object if the item is a file. If the item is not a file, this method returns null.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFile
-DataTransferItem.getAsString()	A										<pre><code>void dataTransferItem.getAsString(callback);\n</code></pre>The DataTransferItem.getAsString() method invokes the given callback with the drag data item's string data as the argument if the item's kind is a Plain unicode string (i.e. kind is string).	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsString
-DataTransferItem.kind	A										<pre><code>dataItem.kind;\n</code></pre>The DataTransferItem.kind property returns the drag data item kind. It must be one of the following:	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/kind
-DataTransferItem.type	A										<pre><code>dataItem.type;\n</code></pre>The DataTransferItem.type property returns the type (format) of the drag data item. The type is a Unicode string generally given by a MIME type, although a MIME type is not required.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/type
-DataTransferItemList	A										The DataTransferItemList object is a list of drag data items. During a drag operation, each drag event has a dataTransfer property and that property is a DataTransferItemList.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList
-DataTransferItemList.add()	A										<pre><code>DataTransferItem dataTransferItemList.add(data, type);\nDataTransferItem dataTransferItemList.add(file);\n</code></pre>The DataTransferItemList.add() method adds a new drag data item to the drag data list. The item may be a File or a string of a specific type. If the item is successfully added to the list, a new DataTransferItem object will be returned.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/add
-DataTransferItemList.clear()	A										<pre><code>void dataTransferItemList.clear();\n</code></pre>The DataTransferItemList.clear() method removes all drag data items from the list.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/clear
-DataTransferItemList.DataTransferItem()	A										<pre><code>var dataItem = dataTransferItemList[index];\n</code></pre>The DataTransferItemList() getter method allows the data transfer items in the list to be accessed with an array operator (i.e. [].)	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/DataTransferItem
-DataTransferItemList.length	A										<pre><code>dataItemList.length;\n</code></pre>The DataTransferItemList.length property returns the number of drag data items in the list. If the list has no items, this property returns zero.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/length
-DataTransferItemList.remove()	A										<pre><code>void dataTransferItemList.remove(index);\n</code></pre>The DataTransferItemList.remove() method removes the drag data item at the specified index from the list. If the index is less than zero or greater than one less than the length of the list, the list will not be changed.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/remove
+DataTransferItem.getAsFile()	A										<pre><code>File = DataTransferItem.getAsFile();\n</code></pre>The DataTransferItem.getAsFile() method returns the drag data item's File object if the item is a file. If the item is not a file, this method returns null.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFile
+DataTransferItem.getAsString()	A										<pre><code>dataTransferItem.getAsString(callback);\n</code></pre>The DataTransferItem.getAsString() method invokes the given callback with the drag data item's string data as the argument if the item's kind is a Plain unicode string (i.e. kind is string).	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsString
+DataTransferItem.kind	A										<pre><code>var itemKind = DataTransferItem.kind;\n</code></pre>The read-only DataTransferItem.kind property returns the drag data item kind.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/kind
+DataTransferItem.type	A										<pre><code>dataItem.type;\n</code></pre>The read-only DataTransferItem.type property returns the type (format) of the drag data item. The type is a Unicode string generally given by a MIME type, although a MIME type is not required.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/type
+DataTransferItemList	A										The DataTransferItemList object is a list of DataTransferItem objects representing items being dragged. During a drag operation, each DragEvent has a dataTransfer property and that property is a DataTransferItemList.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList
+DataTransferItemList.add()	A										<pre><code>DataTransferItem = DataTransferItemList.add(data, type);\nDataTransferItem = DataTransferItemList.add(file);\n</code></pre>The DataTransferItemList.add() method creates a new DataTransferItem using the specified data and adds it to the drag data list. The item may be a File or a string of a given type. If the item is successfully added to the list, the newly-created DataTransferItem object is returned.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/add
+DataTransferItemList.clear()	A										<pre><code>DataTransferItemList.clear();\n</code></pre>The DataTransferItemList.clear() method removes all DataTransferItem objects from the drag data items list, leaving the list empty.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/clear
+DataTransferItemList.DataTransferItem()	A										<pre><code>dataItem = DataTransferItemList[index];\n</code></pre>The DataTransferItemList() getter method implements support for accessing items in the DataTransferItemList using array-style syntax (that is DataTransferItemList [ index ]).	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/DataTransferItem
+DataTransferItemList.length	A										<pre><code>length = DataTransferItemList.length;\n</code></pre>The read-only DataTransferItemList.length property returns the number of items in the list. If the list has no items, or is disabled (because it has no data store at all), this property returns zero.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/length
+DataTransferItemList.remove()	A										<pre><code>DataTransferItemList.remove(index);\n</code></pre>The DataTransferItemList.remove() method removes the DataTransferItem at the specified index from the list. If the index is less than zero or greater than one less than the length of the list, the list will not be changed.	https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/remove
 DedicatedWorkerGlobalScope.onmessage	A										<pre><code>self.onmessage = function() { ... };</code></pre>The onmessage property of the DedicatedWorkerGlobalScope interface represents an EventHandler to be called when the message event occurs and bubbles through the Worker &#8212; i.e. when a message is sent to the worker using the Worker.postMessage method.	https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/onmessage
 DedicatedWorkerGlobalScope.postMessage()	A										<pre><code>postMessage(aMessage, transferList);</code></pre>The postMessage() method of the DedicatedWorkerGlobalScope interface sends a message to the main thread that spawned it. This accepts a single parameter, which is the data to send to the worker. The data may be any value or JavaScript object handled by the structured clone algorithm, which includes cyclical references.	https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/postMessage
 DelayNode	A										When creating a graph that has a cycle, it is mandatory to have at least one DelayNode in the cycle, or the nodes taking part in the cycle will be muted.	https://developer.mozilla.org/en-US/docs/Web/API/DelayNode
@@ -589,7 +589,7 @@ Document.createTouch()	A										<pre><code>var touch = DocumentTouch.createTou
 Document.createTouchList()	A										<pre><code>var list = DocumentTouch.createTouchList([touch1 [, touch2 [, ...]]]);\n</code></pre>This method creates and returns a new TouchList object.	https://developer.mozilla.org/en-US/docs/Web/API/Document/createTouchList
 Document.createTreeWalker()	A										<pre><code>treeWalker = document.createTreeWalker(root, whatToShow, filter, entityReferenceExpansion);\n</code></pre>The Document.createTreeWalker() creator method returns a newly created TreeWalker object.	https://developer.mozilla.org/en-US/docs/Web/API/Document/createTreeWalker
 Document.currentScript	A										<pre><code>var curScriptElement = document.currentScript;\n</code></pre>Returns the script element whose script is currently being processed.	https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript
-Document.defaultView	A										<pre><code>var win = document.defaultView;</code></pre>In browsers, document.defaultView returns the window object associated with a document, or null if none available.	https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView
+Document.defaultView	A										<pre><code>var win = document.defaultView;</code></pre>In browsers, document.defaultView returns the window object associated with a document, or null if none is available.	https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView
 Document.designMode	A										<pre><code>var mode = document.designMode;\ndocument.designMode = "on";\ndocument.designMode = "off";</code></pre>document.designMode controls whether the entire document is editable. Valid values are "on" and "off".&#160;According to the specification, this property is meant to default to "off". Firefox follows this standard. The earlier versions of Chrome and IE default to "inherit". Starting in Chrome 43, the default is "off" and "inherit" is no longer supported.&#160;In IE6-10, the value is capitalized.&#160;	https://developer.mozilla.org/en-US/docs/Web/API/Document/designMode
 Document.dir	A										<pre><code>dirStr = document.dir;\ndocument.dir = dirStr;\n</code></pre>The Document.dir property is a DOMString representing the directionality of the text of the document, whether left to right (default) or right to left. Possible values are 'rtl', right to left, and 'ltr', left to right.	https://developer.mozilla.org/en-US/docs/Web/API/Document/dir
 Document.doctype	A										<pre><code>doctype = document.doctype;\n</code></pre>Returns the Document Type Declaration (DTD) associated with current document. The returned object implements the DocumentType interface. Use DOMImplementation.createDocumentType() to create a DocumentType.	https://developer.mozilla.org/en-US/docs/Web/API/Document/doctype
@@ -604,7 +604,7 @@ Document.embeds	A										embeds returns a list of the embedded OBJECTS within 
 Document.enableStyleSheetsForSet()	A										<pre><code>document.enableStyleSheetsForSet(name)\n</code></pre>Enables the style sheets matching the specified name in the current style sheet set, and disables all other style sheets (except those without a title, which are always enabled).	https://developer.mozilla.org/en-US/docs/Web/API/Document/enableStyleSheetsForSet
 Document.evaluate()	A										<pre><code>var xpathResult = document.evaluate(\n xpathExpression, \n contextNode, \n namespaceResolver, \n resultType, \n result\n);</code></pre>Returns an XPathResult based on an XPath expression and other given parameters.	https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate
 Document.execCommand()	A										<pre><code>bool = document.execCommand(aCommandName, aShowDefaultUI, aValueArgument)\n</code></pre>When an HTML document has been switched to designMode, the document object exposes the execCommand method which allows one to run commands to manipulate the contents of the editable region. Most commands affect the document's selection (bold, italics, etc.), while others insert new elements (adding a link) or affect an entire line (indenting). When using contentEditable, calling execCommand() will affect the currently active editable element.	https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
-Document.exitFullscreen()	A										<pre><code>document.exitFullscreen();\n</code></pre>The Document.exitFullscrean() is a method that takes the document out of full-screen mode; this is used to reverse the effects of a call to make an element in the document full-screen using its Element.requestFullscreen() method.	https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
+Document.exitFullscreen()	A										<pre><code>document.exitFullscreen();\n</code></pre>The Document.exitFullscreen() is a method that takes the document out of full-screen mode; this is used to reverse the effects of a call to make an element in the document full-screen using its Element.requestFullscreen() method.	https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
 Document.exitPointerLock()	A										<pre><code>document.exitPointerLock();\n</code></pre>The exitPointerLock asynchronously releases a pointer lock previously requested through Element.requestPointerLock.	https://developer.mozilla.org/en-US/docs/Web/API/Document/exitPointerLock
 Document.fgColor	A										<pre><code>var color = document.fgColor;\n</code></pre>fgColor gets/sets the foreground color, or text color, of the current document.	https://developer.mozilla.org/en-US/docs/Web/API/Document/fgColor
 Document.forms	A										<pre><code>collection = document.forms;</code></pre>forms returns a collection (an HTMLCollection) of the form elements within the current document.	https://developer.mozilla.org/en-US/docs/Web/API/Document/forms
@@ -619,7 +619,7 @@ Document.getElementsByTagNameNS()	A										<pre><code>elements = document.getE
 Document.getSelection()	A										This method functions identically to the Window.getSelection() method; it returns a Selection object representing the text currently selected in the document.	https://developer.mozilla.org/en-US/docs/Web/API/Document/getSelection
 Document.hasFocus()	A										<pre><code>focused = document.hasFocus();</code></pre>false if the active element in the document has no focus; true if the active element in the document has focus.	https://developer.mozilla.org/en-US/docs/Web/API/Document/hasFocus
 Document.head	A										<pre><code>var objRef = document.head;\n</code></pre>Returns the head element of the current document. If there are more than one head elements, the first one is returned.	https://developer.mozilla.org/en-US/docs/Web/API/Document/head
-Document.images	A										<pre><code>var htmlCollection = document.images;</code></pre>document.images retorna una colección de las imagenes en el documento HTML actual.	https://developer.mozilla.org/en-US/docs/Web/API/Document/images
+Document.images	A										<pre><code>var htmlCollection = document.images;</code></pre>document.images returns a collection of the images in the current HTML document.	https://developer.mozilla.org/en-US/docs/Web/API/Document/images
 Document.implementation	A										<pre><code>DOMImpObj = document.implementation;\n</code></pre>Returns a DOMImplementation object associated with the current document.	https://developer.mozilla.org/en-US/docs/Web/API/Document/implementation
 Document.importNode()	A										<pre><code>var node = document.importNode(externalNode, deep);\n</code></pre>Creates a copy of a node from an external document that can be inserted into the current document.	https://developer.mozilla.org/en-US/docs/Web/API/Document/importNode
 Document.lastModified	A										<pre><code>string = document.lastModified; \n</code></pre>Returns a string containing the date and time on which the current document was last modified.	https://developer.mozilla.org/en-US/docs/Web/API/Document/lastModified
@@ -680,7 +680,6 @@ Introduction to the DOM	A										This section provides a brief conceptual intr
 Locating DOM elements using selectors	A										The Selectors API provides methods that make it quick and easy to retrieve Element nodes from the DOM by matching against a set of selectors. This is much faster than past techniques, wherein it was necessary to, for example, use a loop in JavaScript code to locate the specific items you needed to find.	https://developer.mozilla.org/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors
 Traversing an HTML table with JavaScript and DOM Interfaces	A										This article is an overview of some powerful, fundamental DOM level 1 methods and how to use them from JavaScript. You will learn how to create, access and control, and remove HTML elements dynamically. The DOM methods presented here are not specific to HTML; they also apply to XML. The demonstrations provided here will work fine in any modern browser, including all versions of Firefox and IE 5+.	https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
 Using the W3C DOM Level 1 Core	A										The W3C's DOM Level 1 Core is a powerful object model for changing the content tree of documents. It is supported in all major browsers including Mozilla Firefox and Microsoft Internet Explorer. It is a powerful base for scripting on the web.	https://developer.mozilla.org/en-US/docs/Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core
-Example	A										Tags: DOM	https://developer.mozilla.org/en-US/docs/Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core/Example
 Whitespace in the DOM	A										The presence of whitespace in the DOM can make manipulation of the content tree difficult in unforeseen ways. In Mozilla, all whitespace in the text content of the original document is represented in the DOM (this does not include whitespace within tags). (This is needed internally so that the editor can preserve formatting of documents and so that white-space: pre in CSS will work.) This means that:	https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace_in_the_DOM
 DOMError	A										The DOMError interface describes an error object that contains an error name.	https://developer.mozilla.org/en-US/docs/Web/API/DOMError
 DOMException	A										The DOMException interface represents an abnormal event (called an exception) which occurs as a result of calling a method or accessing a property of a web API. This is basically how error conditions are described in web APIs.	https://developer.mozilla.org/en-US/docs/Web/API/DOMException
@@ -731,8 +730,8 @@ DynamicsCompressorNode.release	A										<pre><code>var audioCtx = new AudioCon
 DynamicsCompressorNode.threshold	A										<pre><code>var audioCtx = new AudioContext();\nvar compressor = audioCtx.createDynamicsCompressor();\ncompressor.threshold.value = -50;\n</code></pre>An AudioParam.	https://developer.mozilla.org/en-US/docs/Web/API/DynamicsCompressorNode/threshold
 Element	A										The Element interface represents an object of a Document. This interface describes methods and properties common to all kinds of elements. Specific behaviors are described in interfaces which inherit from Element but add additional functionality.	https://developer.mozilla.org/en-US/docs/Web/API/Element
 Element.accessKey	A										The Element.accessKey property sets the keystroke by which a user can press to jump to this element.	https://developer.mozilla.org/en-US/docs/Web/API/Element/accessKey
-Element.animate()	A										<pre><code>document.getElementById("tunnel").animate([\n&#160; // keyframes\n&#160; { transform: 'translateY(0px)' },&#160;\n&#160; { transform: 'translateY(-300px)' }\n], { \n&#160; // timing options\n&#160; duration: 1000,\n&#160; iterations: Infinity\n});\n</code></pre>Tags: Animation\n      \n        API\n      \n        Element\n      \n        Experimental\n      \n        Method\n      \n        waapi\n      \n        web animations api	https://developer.mozilla.org/en-US/docs/Web/API/Element/animate
-attachShadow	A										<pre><code>var shadowroot = element.attachShadow(shadowRootInit); \n</code></pre>The Element.attachShadow() method attatches a shadow DOM tree to the specified element and returns a reference to its ShadowRoot.	https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow
+Element.assignedSlot	A										<pre><code>var htmlSlotElement = element.assignedSlot</code></pre>The assignedSlot property of the Element interface returns the HTMLSlotElement interface associated with the element.	https://developer.mozilla.org/en-US/docs/Web/API/Element/assignedSlot
+Element.attachShadow()	A										<pre><code>var shadowroot = element.attachShadow(shadowRootInit); \n</code></pre>The Element.attachShadow() method attatches a shadow DOM tree to the specified element and returns a reference to its ShadowRoot.	https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow
 Element.attributes	A										<pre><code>var attr = element.attributes;\n</code></pre>The Element.attributes property returns a live collection of all attribute nodes registered to the specified node. It is a NamedNodeMap, not an Array, so it has no Array methods and the Attr nodes' indexes may differ among browsers. To be more specific, attributes is a key/value pair of strings that represents any information regarding that attribute.	https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes
 Element.classList	A										<pre><code>var elementClasses = elementNodeReference.classList;\n</code></pre>The Element.classList is a read-only property which returns a live DOMTokenList collection of the class attributes of the element.	https://developer.mozilla.org/en-US/docs/Web/API/Element/classList
 Element.className	A										<pre><code>var cName = elementNodeReference.className;\nelementNodeReference.className = cName;</code></pre>className gets and sets the value of the class attribute of the specified element.	https://developer.mozilla.org/en-US/docs/Web/API/Element/className
@@ -793,11 +792,12 @@ Element.setAttributeNS()	A										<pre><code>element.setAttributeNS(\nnamespac
 Element.setCapture()	A										<pre><code>element.setCapture(retargetToElement);\n</code></pre>Call this method during the handling of a mousedown event to retarget all mouse events to this element until the mouse button is released or document.releaseCapture() is called.	https://developer.mozilla.org/en-US/docs/Web/API/Element/setCapture
 Element.setPointerCapture()	A										<pre><code>targetElement.setPointerCapture(pointerId);\n</code></pre>Pointer capture allows events for a particular pointer event (PointerEvent) to be re-targeted to a particular element instead of the normal target (or hit test) at a pointer's location. This can be used to ensure that an element continues to receive pointer events even if the pointer device's contact moves off the element (for example by scrolling).	https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
 Element.shadowRoot	A										<pre><code>var shadowroot = element.shadowRoot; \n</code></pre>The Element.shadowRoot read-only property represents the youngest shadow root that is hosted on the element.	https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot
+Element.slot	A										<pre><code>var aString = element.slot\nelement.slot = aString\n</code></pre>The slot property of the Element interface returns the name of the shadow DOM slot attatched to the element. A slot is a placeholder inside a web component that users can fill with their own markup.	https://developer.mozilla.org/en-US/docs/Web/API/Element/slot
 Element.tabStop	A										<pre><code>var isTabStop = element.tabStop;\nelement.tabStop = (true|false);\n</code></pre>The tabStop property of the Element interface returns a Boolean indicating if the element can receive input focus via the tab key. If the specified element is a shadow host tab navigation is delegated to its children.	https://developer.mozilla.org/en-US/docs/Web/API/Element/tabStop
 Element.tagName	A										<pre><code>elementName = element.tagName;\n</code></pre>Returns the name of the element.	https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName
 Encoding API	A										The Encoding API defines allows to deal with text encoded with different methods. It mainly allows to handle legacy content, encrypted with old methods, as it requires new content to be encoded using UTF-8.	https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API
 Encrypted Media Extensions API	A										The EncryptedMediaExtenstions API provides interfaces for controlling the playback of content which is subject to a digital restrictions management scheme.	https://developer.mozilla.org/en-US/docs/Web/API/Encrypted_Media_Extensions_API
-Entry	A										The Entry interface of the FileSystem API represents an entry in a file system. The entry can be a file or a directory. It includes methods for working with files—including copying, moving, removing, and reading files—as well as information about a file it points to—including the file name and its path from the root to the entry.	https://developer.mozilla.org/en-US/docs/Web/API/Entry
+Entry	A										The Entry interface of the File and Directory Entries API represents a single in a file system. The entry can be a file or a directory (directories are represented by the DirectoryEntry interface. It includes methods for working with files—including copying, moving, removing, and reading files—as well as information about a file it points to—including the file name and its path from the root to the entry.	https://developer.mozilla.org/en-US/docs/Web/API/Entry
 EntrySync	A										The EntrySync interface of the FileSystem API represents an entry in a file system. The entry can be a FileEntrySync or a DirectoryEntry. It includes methods for working with files—including copying, moving, removing, and reading files—as well as information about the file it points to—including the file name and its path from the root to the entry.	https://developer.mozilla.org/en-US/docs/Web/API/EntrySync
 ErrorEvent	A										The ErrorEvent interface represents events providing information related to errors in scripts or in files.	https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent
 Event	A										The Event interface represents any event of the DOM. It contains common properties and methods to any event.	https://developer.mozilla.org/en-US/docs/Web/API/Event
@@ -878,7 +878,6 @@ File.fileSize	A										<pre><code>var size = instanceOfFile.fileSize</code></p
 File.getAsDataURL()	A										<pre><code>var url = instanceOfFile.getAsDataURL();</code></pre>The getAsDataURL provides a data: URL that encodes the entire contents of the referenced file.	https://developer.mozilla.org/en-US/docs/Web/API/File/getAsDataURL
 File.getAsText()	A										<pre><code>var str = instanceOfFile.getAsText(encoding);</code></pre>The getAsText method provides the file's data interpreted as text using a given encoding.	https://developer.mozilla.org/en-US/docs/Web/API/File/getAsText
 File.lastModifiedDate	A										<pre><code>var time = instanceOfFile.lastModifiedDate</code></pre>The File.lastModifiedDate read-only property returns the last modified date of the file. Files without a known last modified date returns the current date.	https://developer.mozilla.org/en-US/docs/Web/API/File/lastModifiedDate
-File.mozFullPath	A										Tags: API\n      \n        File API\n      \n        Files\n      \n        NeedsContent\n      \n        Property\n      \n        Reference\n      \n        R&#233;f&#233;rence	https://developer.mozilla.org/en-US/docs/Web/API/File/mozFullPath
 File.name	A										<pre><code>var name = file.name;</code></pre>Returns the name of the file represented by a File object. For security reasons, the path is excluded from this property.	https://developer.mozilla.org/en-US/docs/Web/API/File/name
 File.webkitRelativePath	A										<pre><code>&#160;str = fileObj.webkitRelativePath</code></pre>The File.webkitRelativePath is a read-only property that contains a DOMString with the path relative to the directory selected when the webkitdirectory has been set on the input element.	https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath
 FileEntry	A										The FileEntry interface of the File System API represents a file in a file system. It lets you write content to a file.	https://developer.mozilla.org/en-US/docs/Web/API/FileEntry
@@ -901,9 +900,9 @@ FileRequest.lockedFile	A										<pre><code>var lockedFile = instanceOfFileRequ
 FileRequest.onprogress	A										<pre><code>instanceOfFileRequest.onprogress = function;\n</code></pre>This property specifies a callback function to be run repeatedly while the operation represented by a FileRequest object is in progress.	https://developer.mozilla.org/en-US/docs/Web/API/FileRequest/onprogress
 FileSystem	A										In the File System API, a FileSystem object represents a file system. The object is the argument of a successful callback of requestFileSystem(). The FileSystem object has two properties.	https://developer.mozilla.org/en-US/docs/Web/API/FileSystem
 FileSystemSync	A										In the File System API, a FileSystemSync object represents a file system. It has two properties.	https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSync
+File and Directory Entries API	A										The File and Directory Entries API simulates a local file system that web apps can navigate within. You can develop apps which read, write, and create files and/or directories in a virtual, sandboxed file system.	https://developer.mozilla.org/en-US/docs/Web/API/File_and_Directory_Entries_API
+Introduction to the File and Directory Entries API	A										The File and Directory Entries API simulates a local file system that web apps can navigate around. You can develop apps that can read, write, and create files and directories in a sandboxed, virtual file system.	https://developer.mozilla.org/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction
 FileHandle API	A										The FileHandle API allows for the manipulating of files, including creating files and modifying their content (unlike the File API). Because the files manipulated through that API can be physically stored on the device, the editing part uses a turn-based locking mechanism in order to avoid race issues.	https://developer.mozilla.org/en-US/docs/Web/API/File_Handle_API
-File System API	A										The File System API simulates a local file system that web apps can navigate within. You can develop apps which read, write, and create files and/or directories in a virtual, sandboxed file system.	https://developer.mozilla.org/en-US/docs/Web/API/File_System_API
-Introduction to the File System API	A										The File System API simulates a local file system that web apps can navigate around. You can develop apps that can read, write, and create files and directories in a sandboxed, virtual file system.	https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Introduction
 FocusEvent	A										The FocusEvent interface represents focus-related events like focus, blur, focusin, or focusout.	https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent
 FocusEvent()	A										<pre><code>var focusEvent = new FocusEvent(typeArg, focusEventInit); \n</code></pre>The FocusEvent() constructor returns a newly created FocusEvent object with an optional EventTarget. When a change a focus has a source and a destination, the relatedTarget value must be set to the other target.	https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/FocusEvent
 FocusEvent.relatedTarget	A										<pre><code>secondTarget = focusEvent.relatedTarget</code></pre>The FocusEvent.relatedTarget read-only property represents a secondary target for this event, which will depend on the event itself. In some cases (like when tabbing in or out a page), this property may be set to null for security reasons.	https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget
@@ -913,7 +912,6 @@ FontFaceSet.check()	A										<pre><code>bool = aFontFaceSet.check(font);\nbool
 FontFaceSet.load()	A										<pre><code>result = aFontFaceSet.load(font);\n\nresult = aFontFaceSet.load(font, text);\n</code></pre>A Promise of an Array of FontFace loaded. The promise is fulfilled when all the fonts are loaded; it is rejected if one of the fonts failed to load.	https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/load
 FontFaceSet.ready	A										<pre><code>FontFaceSet.ready().then(function(FontFaceSet) { ... });</code></pre>The ready() method of the FontFaceSet interface returns a Promise that resolves to a list of font faces for a requested font.	https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready
 Force Touch events	A										Force Touch events are a proprietary, Apple-specific feature which makes possible (where supported by the input hardware) new interactions based on how hard the user clicks or presses down on the touchscreen or trackpad.	https://developer.mozilla.org/en-US/docs/Web/API/Force_Touch_events
-SVGAltGlyphDefElement	A										Tags: API\n      \n        Interface\n      \n        Junk\n      \n        junk\n      \n        NeedsContent\n      \n        SVG\n      \n        SVGAltGlyphDefElement	https://developer.mozilla.org/en-US/docs/Web/API/Format
 FormData	A										The FormData interface provides a way to easily construct a set of key/value pairs representing form fields and their values, which can then be easily sent using the XMLHttpRequest.send() method. It uses the same format a form would use if the encoding type were set to "multipart/form-data".	https://developer.mozilla.org/en-US/docs/Web/API/FormData
 FormData.append()	A										<pre><code>formData.append(name, value);\nformData.append(name, value, filename);</code></pre>The append() method of the FormData interface appends a new value onto an existing key inside a FormData object, or adds the key if it does not already exist.	https://developer.mozilla.org/en-US/docs/Web/API/FormData/append
 FormData.delete()	A										<pre><code>formData.delete(name);</code></pre>The delete() method of the FormData interface deletes a key and its value(s) from a FormData object.	https://developer.mozilla.org/en-US/docs/Web/API/FormData/delete
@@ -1093,7 +1091,7 @@ HTMLEmbedElement	A										The HTMLEmbedElement interface, which provides speci
 HTMLFieldSetElement	A										The HTMLFieldSetElement interface has special properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of field-set elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFieldSetElement
 HTMLFormControlsCollection	A										The HTMLFormControlsCollection interface represents a collection of HTML form control elements. It replaces one method of HTMLCollection.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormControlsCollection
 HTMLFormControlsCollection.namedItem()	A										<pre><code>var item = collection.namedItem[str];\nvar item = collection[str];\n</code></pre>Note that this version of namedItem() hide the one inherited from HTMLCollection. Like that one, in JavaScript, using the array bracket syntax with a String, like collection ["value"] is equivalent to collection.namedItem("value").	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormControlsCollection/namedItem
-HTMLFormElement	A										The HTMLFormElement interface provides methods to create and modify form elements; it inherits from properties and methods of the HTMLElement interface.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
+HTMLFormElement	A										The HTMLFormElement interface provides methods to create and modify form elements. document.forms - returns an array of HTMLFormElement objects referencing all forms on the page. document.forms[index] - returns an HTMLFormElement object referencing the form at the specified index. document.forms['id'] - returns an HTMLFormElement object referencing the form with the specified id. document.forms['name'] - returns an HTMLFormElement object referencing the form with the specified id.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
 HTMLFormElement.acceptCharset	A										<pre><code>string = form.acceptCharset;\nform.acceptCharset = string;\n</code></pre>The HTMLFormElement.acceptCharset property represents a list of the supported character encodings for the given FORM element. This list can be comma- or space-separated.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/acceptCharset
 HTMLFormElement.action	A										<pre><code>string = form.action\nform.action = string\n</code></pre>The HTMLFormElement.action property represents the action of the form element.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/action
 HTMLFormElement.elements	A										<pre><code>nodeList = HTMLFormElement.elements\n</code></pre>The HTMLFormElement.elements property returns an HTMLFormControlsCollection (HTML 4 HTMLCollection) of all the form controls contained in the FORM element, with the exception of input elements which have a type attribute of image.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements
@@ -1163,7 +1161,7 @@ HTMLIFrameElement.zoom()	A										<pre><code>var instanceOfDOMRequest = instan
 HTMLImageElement	A										The HTMLImageElement interface provides special properties and methods  for manipulating the layout and presentation of img elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement
 Image()	A										Accepts two optional parameters: Image([unsigned long width, unsigned long height ])	https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image
 HTMLImageElement.referrerPolicy	A										<pre><code>refStr = imgElt.referrerPolicy;\nimgElt.referrerPolicy = refStr;</code></pre>The HTMLImageElement.referrerPolicy property reflect the HTML referrerpolicy attribute of the img element defining which referrer is sent when fetching the resource.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy
-HTMLInputElement	A										The HTMLInputElement interface provides special properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of input elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
+HTMLInputElement	A										The HTMLInputElement interface provides special properties and methods for manipulating the layout and presentation of input elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
 HTMLInputElement.mozGetFileNameArray()	A										<pre><code>inputElement.mozGetFileNameArray(aLength, aFileNames);\n</code></pre>The HTMLInputElement.mozGetFileNameArray() method returns an array of the names of the files that were selected by the user on an HTML input element.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/mozGetFileNameArray
 HTMLInputElement.mozSetFileNameArray()	A										<pre><code>inputElement.mozSetFileNameArray(aFileNames, aLength);\n</code></pre>The HTMLInputElement.mozSetFileNameArray() sets the names of the files that selected on an HTML input element.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/mozSetFileNameArray
 HTMLInputElement.multiple	A										The HTMLInputElement.multiple property indicates if an input can have more than one value. Firefox currently only supports multiple for input type="file".	https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/multiple
@@ -1248,6 +1246,9 @@ HTMLSelectElement.setCustomValidity()	A										<pre><code>selectElt.setCustomV
 HTMLSelectElement.type	A										<pre><code>var str = selectElt.type;</code></pre>The HTMLSelectElement.type read-only property returns the form control's type. The possible values are:	https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/type
 HTMLShadowElement	A										The HTMLShadowElement interface represents a shadow HTML Element, which is used in Shadow DOM.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLShadowElement
 HTMLShadowElement.getDistributedNodes()	A										<pre><code>var nodeList = object.getDistributedNodes()\n</code></pre>The HTMLShadowElement.getDistributedNodes() method returns a static NodeList of the distributed nodes associated with this shadow element.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLShadowElement/getDistributedNodes
+HTMLSlotElement	A										The HTMLSlotElement interface of the Shadow DOM API defines the location of a slot.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement
+HTMLSlotElement.assignedNodes()	A										<pre><code>var assignedNodes[] = HTMLSlotElement.assignedNodes([options])</code></pre>The assignedNodes() property of the HTMLSlotElement interface returns the sequence of elements assigned to this slot or, alternatively, the slot's fallback content.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes
+HTMLSlotElement.name	A										<pre><code>var name = htmlSlotElement.name\nhtmlSlotElement.name = name\n</code></pre>The name property of the HTMLSlotElement interface returns or sets the slot name. A slot is a placeholder inside a web component that users can fill with their own markup.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/name
 HTMLSourceElement	A										The HTMLSourceElement interface provides special properties (beyond the regular HTMLElement object interface it also has available to it by inheritance) for manipulating source elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLSourceElement
 HTMLSpanElement	A										The HTMLSpanElement interface represents a span element and derives from the HTMLElement interface, but without implementing any additional properties or methods.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLSpanElement
 HTMLStyleElement	A										The HTMLStyleElement interface represents a style element. It inherits properties and methods from its parent, HTMLElement, and from LinkStyle.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement
@@ -1286,7 +1287,7 @@ HTMLTableRowElement	A										The HTMLTableRowElement interface provides specia
 HTMLTableRowElement.insertCell()	A										<pre><code>var cell = HTMLTableRowElement.insertCell(optionalindex = -1);\n</code></pre>The HTMLTableRowElement.insertCell() method inserts a new cell into a table row and returns a reference to the cell.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableRowElement/insertCell
 HTMLTableRowElement.rowIndex	A										The HTMLTableRowElement.rowIndex property represents the position of a row in relation to the whole table.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableRowElement/rowIndex
 HTMLTableSectionElement	A										The HTMLTableSectionElement interface provides special properties and methods (beyond the HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of sections, that is headers, footers and bodies, in an HTML table.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableSectionElement
-HTMLTextAreaElement	A										The HTMLTextAreaElement interface, which provides special properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of textarea elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement
+HTMLTextAreaElement	A										The HTMLTextAreaElement interface provides special properties and methods for manipulating the layout and presentation of textarea elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement
 HTMLTimeElement	A										The HTMLTimeElement interface provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating time elements.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTimeElement
 HTMLTimeElement.dateTime	A										<pre><code>dateTimeString = timeElt.dateTime;\ntimeElt.dateTime = dateTimeString\n</code></pre>The HTMLTimeElement.dateTime property is a DOMString that reflects the datetime HTML attribute, containing a machine-readable form of the element's date and time value.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTimeElement/dateTime
 HTMLTitleElement	A										The HTMLTitleElement interface contains the title for a document. This element inherits all of the properties and methods of the HTMLElement interface.	https://developer.mozilla.org/en-US/docs/Web/API/HTMLTitleElement
@@ -1317,6 +1318,7 @@ IDBDatabase.deleteObjectStore()	A										<pre><code>db.deleteObjectStore("toDo
 IDBDatabase.name	A										<pre><code>db.name</code></pre>A DOMString containing the name of the connected database.	https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/name
 IDBDatabase.objectStoreNames	A										<pre><code>db.objectStoreNames</code></pre>A DOMStringList containing a list of the names of the object stores currently in the connected database.	https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/objectStoreNames
 IDBDatabase.onabort	A										<pre><code>db.onabort = function() { ... }</code></pre>This example shows an IDBOpenDBRequest.onupgradeneeded block that creates a new object store; it also includes onerror and onabort functions to handle non-success cases.	https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/onabort
+IDBDatabase.onclose	A										<pre><code>IDBDatabase.onclose = function;</code></pre>A function which is called when the close event is fired.	https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/onclose
 IDBDatabase.onerror	A										<pre><code>db.onerror = function() { ... }</code></pre>This example shows an IDBOpenDBRequest.onupgradeneeded block that creates a new object store; it also includes onerror and onabort functions to handle non-success cases.	https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/onerror
 IDBDatabase.onversionchange	A										<pre><code>db.onversionchange = function() { ... }</code></pre>This example shows an IDBOpenDBRequest.onupgradeneeded block that creates a new object store; it also includes onerror and onabort functions to handle non-success cases, and an onversionchange function to notify when a database structure change has occurred.	https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/onversionchange
 IDBDatabase.transaction()	A										<pre><code>var transaction = db.transaction(["toDoList"], "readwrite");</code></pre>An IDBTransaction object.	https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/transaction
@@ -1419,8 +1421,9 @@ IdentityManager.get()	A										<pre><code>navigator.id.get(gotAssertion);\nnav
 IdentityManager.getVerifiedEmail()	A										<pre><code>window.navigator.id.getVerifiedEmail(gotAssertion);</code></pre>This function enables a web site to use BrowserID to authenticate its users. Call it in the click handler to your "log in with BrowserID" button with a callback function as a parameter.	https://developer.mozilla.org/en-US/docs/Web/API/IdentityManager/getVerifiedEmail
 IdentityManager.logout()	A										<pre><code>navigator.id.logout();</code></pre>This function is used in Persona to cause the browser to reset the automatic / persistent login flag for a website. After being called, the user will need to explicitly log back into your site instead of being signed in automatically.	https://developer.mozilla.org/en-US/docs/Web/API/IdentityManager/logout
 IdentityManager.request()	A										<pre><code>navigator.id.request();\nnavigator.id.request({siteName: 'Example Site', siteLogo: '/logo.png'});\nnavigator.id.request({termsOfService: '/tos.html', privacyPolicy: '/privacy.html'});\n</code></pre>This function enables a web site to use Persona to authenticate its users. It must be invoked from within a click handler. For example, you should call it when a user clicks your "log in with Persona" button.	https://developer.mozilla.org/en-US/docs/Web/API/IdentityManager/request
-IdentityManager.watch()	A										<pre><code>See also:\n  BrowserID\n navigator.id\n navigator.id.logout()\n navigator.id.request()\n  BrowserID</code></pre>This function registers callbacks that respond to a Persona user logging in or out.	https://developer.mozilla.org/en-US/docs/Web/API/IdentityManager/watch
-IIRFilterNode	A										Tags: API\n      \n        IIRFilterNode\n      \n        Interface\n      \n        NeedsMobileBrowserCompatibility\n      \n        Reference\n      \n        Web Audio API	https://developer.mozilla.org/en-US/docs/Web/API/IIRFilterNode
+IdentityManager.watch()	A										This function registers callbacks that respond to a Persona user logging in or out.	https://developer.mozilla.org/en-US/docs/Web/API/IdentityManager/watch
+IIRFilterNode	A										The IIRFilterNode interface of the Web Audio API is a AudioNode processor which implements a general infinite impulse response (IIR)  filter; this type of filter can be used to implement tone control devices and graphic equalizers as well. It lets the parameters of the filter response be specified, so that it can be tuned as needed.	https://developer.mozilla.org/en-US/docs/Web/API/IIRFilterNode
+IIRFilterNode.getFrequencyResponse()	A										<pre><code>IIRFilterNode.getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput);\n</code></pre>undefined	https://developer.mozilla.org/en-US/docs/Web/API/IIRFilterNode/getFrequencyResponse
 IIRFilterNode.getFrequencyResponse()	A										<pre><code>var audioCtx = new AudioContext();\nvar iirFilter = audioCtx.createIIRFilter();\niirFilter.getFrequencyResponse(myFrequencyArray,magResponseOutput,phaseResponseOutput);\n</code></pre>The getFrequencyResponse() method of the IIRFilterNode interface takes the current filtering algorithm's settings and calculates the frequency response for frequencies specified in the frequencyHz array of frequencies.	https://developer.mozilla.org/en-US/docs/Web/API/IIRFilterNode/getFrequencyResponse()
 ImageBitmap	A										The ImageBitmap interface represents a bitmap image which can be drawn to a canvas without undue latency. It can be created from a variety of source objects using the createImageBitmap() factory method. ImageBitmap provides an asynchronous and resource efficient pathway to prepare textures for rendering in WebGL.	https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap
 ImageBitmap.close()	A										<pre><code>void ImageBitmap.close()</code></pre>The ImageBitmap.close() method disposes of all graphical resources associated with an ImageBitmap.	https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close
@@ -1531,6 +1534,7 @@ MediaDevices.getUserMedia()	A										<pre><code>navigator.mediaDevices.getUser
 MediaElementAudioSourceNode	A										A MediaElementSourceNode has no inputs and exactly one output, and is created using the AudioContext.createMediaElementSource method. The amount of channels in the output equals the number of channels of the audio referenced by the HTMLMediaElement used in the creation of the node, or is 1 if the HTMLMediaElement has no audio.	https://developer.mozilla.org/en-US/docs/Web/API/MediaElementAudioSourceNode
 MediaError	A										The MediaError interface represents an error associated to a media, like a HTMLMediaElement.	https://developer.mozilla.org/en-US/docs/Web/API/MediaError
 MediaError.code	A										<pre><code>var myError = mediaError.code</code></pre>The MediaError.code is a read-only unsigned short that represents the error:	https://developer.mozilla.org/en-US/docs/Web/API/MediaError/code
+mediaerror code	R	MediaError.code										
 MediaKeyMessageEvent	A										The MediaKeyMessageEvent interface of the EncryptedMediaExtensions API contains the content and related data when the content decryption module generates a message for the session.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyMessageEvent
 message	A										<pre><code>var messageType = mediaKeyMessageEvent.messageType;</code></pre>The MediaKeyMessageEvent.message read-only property returns an ArrayBuffer with a message from the content decryption module. Messages vary by key system.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyMessageEvent/message
 messageType	A										<pre><code>var messageType = mediaKeyMessageEvent.messageType;</code></pre>The MediaKeyMessageEvent.messageType read-only property indicates the type of message. It may be one of license-request, license-renewal, license-renewal, or individualization-request.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyMessageEvent/messageType
@@ -1548,6 +1552,13 @@ remove()	A										The MediaKeySession.remove() method returns a Promise after 
 sessionId	A										<pre><code>&#8203;var sessionId = mediaKeySessionObj.sessionId;</code></pre>The MediaKeySession.sessionId read-only property contains a unique string generated by the CDM for the current media object and its associated keys or licenses.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySession/sessionId
 update()	A										<pre><code>mediaKeySession.update(response).then(function() { ... });</code></pre>The MediaKeySession.update() method loads messages and licenses to the CDM, and then returns a Promise.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySession/update
 MediaKeyStatusMap	A										The MediaKeyStatusMap interface of the EncryptedMediaExtensions API is a read-only map of media key statuses by key IDs.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap
+MediaKeyStatusMap.entries()	A										<pre><code>// TBD</code></pre>The entries() read-only property of the MediaKeyStatusMap interface returns a new Iterator object containing an array of [key, value] pairs for each element in the status map, in insertion order.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap/entries
+MediaKeyStatusMap.forEach()	A										<pre><code>mediaKeyStatusMap.forEach(callback[, thisArg])</code></pre>The forEach property of the MediaKeyStatusMap interface calls callback once for each key-value pair in the status map, in insertion order. If argument is present it will be passed to the callback.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap/forEach
+MediaKeyStatusMap.get()	A										<pre><code>var value = mediaKeyStatusMap.get(key);</code></pre>The get property of the MediaKeyStatusMap interface returns the value associated with the given key or undefined if there is none.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap/get
+MediaKeyStatusMap.has()	A										<pre><code>var boolean = mediaKeyStatusMap(key)</code></pre>The has property of the MediaKeyStatusMap interface returns a Boolean asserting whether a value has been associated with the given key.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap/has
+MediaKeyStatusMap.keys()	A										<pre><code>var iterator = mediaKeyStatusMap.keys()</code></pre>The keys property of the MediaKeyStatusMap interface returns a new Iterator object containing keys for each element in the status map, in insertion order.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap/keys
+MediaKeyStatusMap.size	A										<pre><code>var size = MediaKeyStatusMap.size;</code></pre>The size read-only property of the MediaKeyStatusMap interface returns the number of key/value paris in the status map.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap/size
+MediaKeyStatusMap.values()	A										<pre><code>var iterator = mediaKeyStatusMap.values()</code></pre>The values property of the MediaKeyStatusMap interface returns a new Iterator object containing values for each element in the status map, in insertion order.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeyStatusMap/values
 MediaKeySystemAccess	A										The MediaKeySystemAccess interface of the EncryptedMediaExtensions API provides access to a Key System for decryption and/or a content protection provider. You can request an instance of this object using the Navigator.requestMediaKeySystemAccess method.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySystemAccess
 createMediaKeys()	A										<pre><code>var mediaKeys = mediaKeySystemAccess.createMediaKeys();</code></pre>The MediaKeySystemAccess.createMediaKeys() method returns a Promise that resolves to a new MediaKeys object.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySystemAccess/createMediaKeys
 getConfiguration()	A										<pre><code>var mediaKeySystemConfiguration = mediaKeySystemAccess.getConfiguration();</code></pre>The MediaKeySystemAccess.getConfiguration() method returns a MediaKeySystemConfiguration object with the supported combination of configuration options.	https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySystemAccess/getConfiguration
@@ -1590,9 +1601,10 @@ MediaSource.MediaSource()	A										<pre><code>var mediaSource = new MediaSourc
 MediaSource.readyState	A										<pre><code>var myReadyState = mediaSource.readyState;</code></pre>The readyState read-only property of the MediaSource interface returns an enum representing the state of the current MediaSource. The three possible values are:	https://developer.mozilla.org/en-US/docs/Web/API/MediaSource/readyState
 MediaSource.removeSourceBuffer()	A										<pre><code>mediaSource.removeSourceBuffer(sourceBuffer);</code></pre>The removeSourceBuffer() method of the MediaSource interface removes the given SourceBuffer from the SourceBuffers list associated with this MediaSource object.	https://developer.mozilla.org/en-US/docs/Web/API/MediaSource/removeSourceBuffer
 MediaSource.sourceBuffers	A										<pre><code>var mySourceBuffers = mediaSource.sourceBuffers;</code></pre>The sourceBuffers read-only property of the MediaSource interface returns a SourceBufferList object containing the list of SourceBuffer objects associated with this MediaSource.	https://developer.mozilla.org/en-US/docs/Web/API/MediaSource/sourceBuffers
-MediaStream	A										The MediaStream interface represents a stream of media content. A stream consists of several tracks such as video or audio tracks. Each track is specified as an instance of MediaTrack.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream
+MediaStream	A										The MediaStream interface represents a stream of media content. A stream consists of several tracks such as video or audio tracks. Each track is specified as an instance of MediaStreamTrack.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream
 active	A										<pre><code>var isActive = MediaStream.active;</code></pre>The active read-only property of the MediaStream interface returns a Boolean value that will return to be true if the MediaStream is active, else false.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/active
 MediaStream.addTrack()	A										<pre><code>stream.addTrack(track);\n</code></pre>The MediaStream.addTrack() method adds a new track to the stream. The track is specified as a parameter of type MediaStreamTrack.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
+MediaStream.clone()	A										<pre><code>var stream = MediaStream.clone();</code></pre>The clone() method of the MediaStream interface creates a duplicate of the MediaStream. This new MediaStream object has a new unique id and contains clones of every MediaStreamTrack contained by the MediaStream on which clone() was called.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/clone
 MediaStream.getTrackById()	A										<pre><code>var track = MediaStream.getTrackById(id);\n</code></pre>The MediaStream.getTrackById() method returns a MediaStreamTrack object representing the track with the specified ID string. If there is no track with the specified ID, this method returns null.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/getTrackById
 MediaStream.id	A										<pre><code>var id = mediaStream.id;\n</code></pre>The MediaStream.id() read-only property is a DOMString containing 36 characters denoting a unique identifier (GUID) for the object.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/id
 MediaStream.onaddtrack	A										<pre><code>MediaStream.onaddtrack = eventHandler;\n</code></pre>The MediaStream.onaddtrack property is an EventHandler which specifies a function to be called when the addtrack event occurs on a MediaStream instance. This happens when a new track of any kind is added to the media stream.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/onaddtrack
@@ -1603,11 +1615,13 @@ MediaStreamAudioSourceNode	A										A MediaElementSourceNode has no inputs and
 MediaStreamEvent	A										The MediaStreamEvent interface represents events that occurs in relation to a MediaStream. Two events of this type can be thrown: addstream and removestream.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamEvent
 MediaStreamEvent()	A										<pre><code> var event = new MediaStreamEvent(type, mediaStreamEventInit);</code></pre>The MediaStreamEvent() constructor creates a new MediaStreamEvent.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamEvent/MediaStreamEvent
 MediaStreamEvent.stream	A										<pre><code> var stream = event.stream;</code></pre>The read-only property MediaStreamEvent.stream returns the MediaStream associated with the event.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamEvent/stream
-MediaStreamTrack	A										The MediaStreamTrack interface represents&#160;a media source in the User Agent, like video or audio tracks.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
+MediaStreamTrack	A										The MediaStreamTrack interface represents a single media track within a stream; typically, these are audio or video tracks, but other track types may exist as well.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
+MediaStreamTrack.applyConstraints()	A										<pre><code>var appliedPromise = MediaStreamTrack.applyConstraints(constraints);</code></pre>The applyConstraints () method of the MediaStreamTrack interface applies a set of constraints to the track; these constraints let the Web site or app establish ideal values and acceptable ranges of values for the constrainable properties of the track, such as frame rate, dimensions, echo cancelation, and so forth.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/applyConstraints
 MediaStreamTrack.clone()	A										<pre><code>var track&#160;= MediaStreamTrack.clone();</code></pre>The clone() method of the MediaStreamTrack interface creates a duplicate of the MediaStreamTrack. This new MediaStreamTrack object is identical except for its unique id.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/clone
 MediaStreamTrack.enabled	A										<pre><code>var bool = track.enabled;\ntrack.enabled = [true | false];</code></pre>The MediaStreamTrack.enabled property returns a Boolean with a value of true if the track is enabled, that is allowed to render the media source stream; or false if it is disabled, that is not rendering the media source stream but silence and blackness. If the track has been disconnected, this value can be changed but has no effect.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/enabled
-MediaStreamTrack.getConstraints()	A										<pre><code>var constraints&#160;= mediaStreamTrack.getConstraints();</code></pre>The getConstraints() method of the MediaStreamTrack interface returns a MediaTrackConstraints object containing the full set of constraints for the properties of the current MediaStreamTrack.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getConstraints
-MediaStreamTrack.getSettings()	A										<pre><code>var settings&#160;=mediaStreamTrack.getSettings();</code></pre>The getSettings() method of the MediaStreamTrack interface returns a MediaTrackSettings object containing the state of the constrainable properties for the current MediaStreamTrack.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getSettings
+MediaStreamTrack.getCapabilities()	A										<pre><code>var capabilities = MediaStreamTrack.getCapabilities();</code></pre>The getCapabilities() method of the MediaStreamTrack interface returns a MediaTrackCapabilities object which specifies the values or range of values which each constrianable property, based upon the platform and user agent.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities
+MediaStreamTrack.getConstraints()	A										<pre><code>var constraints = MediaStreamTrack.getConstraints();</code></pre>The getConstraints() method of the MediaStreamTrack interface returns a MediaTrackConstraints object containing the set of constraints most recently established for the track using a prior call to applyConstraints(). These constraints indicate values and ranges of values that the Web site or application has specified are acceptable for the included constrainable properties.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getConstraints
+MediaStreamTrack.getSettings()	A										<pre><code>var settings = MediaStreamTrack.getSettings();</code></pre>The getSettings() method of the MediaStreamTrack interface returns a MediaTrackSettings object containing the current values of each of the constrainable properties for the current MediaStreamTrack.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getSettings
 MediaStreamTrack.id	A										<pre><code> var id = track.id;</code></pre>The read-only property MediaStreamTrack.id returns a DOMString containing a unique identifier (GUID) for the track; it is generated by the browser.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/id
 MediaStreamTrack.kind	A										<pre><code> var type = track.kind;</code></pre>The read-only property MediaStreamTrack.kind returns a DOMString set to "audio" if the track is an audio track and to "video", if it is a video track. It doesn't change if the track is deassociated from its source.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/kind
 MediaStreamTrack.label	A										<pre><code> var name = track.label;</code></pre>The read-only property MediaStreamTrack.label returns a DOMString containing a user agent-assigned label that identifies the track source, as in "internal microphone". The string may be left empty and is empty as long as no source has been connected. When the track is deassociated from its source, the label is not changed.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/label
@@ -1621,9 +1635,12 @@ MediaStreamTrack.remote	A										<pre><code>var bool &#8203;= track.remote;</c
 MediaStreamTrack.stop()	A										<pre><code>track.stop();\n</code></pre>The MediaStreamTrack.stop() method stops playing the source associated with the track. Both the source and the track are deassociated. The track state is set to ended.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/stop
 MediaStreamTrackEvent	A										The MediaStreamTrackEvent interface represents events which indicate that a MediaStream has had tracks added to or removed from the stream through calls to Media Stream API methods. These events are sent to the stream when these changes occur.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrackEvent
 MediaStreamTrackEvent()	A										<pre><code>var trackEvent = new MediaStreamTrackEvent(type, {track: aMediaStreamTrack});\n</code></pre>The MediaStreamTrackEvent() constructor returns a newly created MediaStreamTrackEvent object, which represents an event announcing that a MediaStreamTrack has been added to or removed from a MediaStream.	https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrackEvent/MediaStreamTrackEvent
+MediaTrackConstraints	A										The MediaTrackConstraints dictionary is used to describe a set of capabilities and the value or values each can take on. A constraints dictionary is passed into applyConstraints() to allow a script to establish a set of ideal values and/or preferred ranges of values for the track, and the most recently-requested set of custom constraints can be retrieved by calling getConstraints().	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints
+MediaTrackSettings	A										The MediaTrackSettings dictionary is used to return the current values configured for each of a MediaStreamTrack 's settings. These values will adhere as closely as possible to any constraints previously set using applyConstraints(), and will adhere to the default constraints for any properties whose constraints haven't been changed, or whose customized constraints couldn't be matched.	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings
+MediaTrackSupportedConstraints	A										The MediaTrackSupportedConstraints dictionary establishes the list of constrainable properties recognized by the user agent or browser in its implementation of the MediaStreamTrack object. An object conforming to MediaTrackSupportedConstraints is returned by MediaDevices.getSupportedConstraints().	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSupportedConstraints
 Media Source Extensions API	A										The Media Source Extensions API (MSE) provides functionality enabling plugin-free web-based streaming media. Using MSE, media streams can be created via JavaScript, and played using audio and video elements.	https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API
 Transcoding assets for Media Source Extensions	A										When working with media source extensions, it is likely that you need to condition your assets before you can stream them. This article takes you through the requirements and shows you a toolchain you can use to encode your assets appropriately.	https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE
-MediaStream API	A										The MediaStream Processing API, often called the Media Stream API or the Stream API,  is the part of WebRTC describing a stream of audio or video data, the methods for working with them, the constraints associated with the type of data, the success and error callbacks when using the data asynchronously, and the events that are fired during the process.	https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API
+Media Capture and Streams API (Media Streams)	A										The Media Capture and Streams API, often called the Media Stream API or the Stream API,  is an API related to WebRTC which supports streams of audio or video data, the methods for working with them, the constraints associated with the type of data, the success and error callbacks when using the data asynchronously, and the events that are fired during the process.	https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API
 MessageChannel	A										The MessageChannel interface of the Channel Messaging API allows us to create a new message channel and send data through it via its two MessagePort properties.	https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel
 MessageChannel()	A										<pre><code>var channel = new MessageChannel();</code></pre>The MessageChannel() constructor of the MessageChannel interface returns a new MessageChannel object with two new MessagePort objects.	https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel/MessageChannel
 MessageChannel.port1	A										<pre><code>channel.port1;</code></pre>The port1 read-only property of the MessageChannel interface returns the first port of the message channel, the port attached to the context that originated the channel.	https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel/port1
@@ -1713,7 +1730,7 @@ Navigator.registerContentHandler()	A										<pre><code>navigator.registerConte
 Navigator.registerProtocolHandler()	A										<pre><code>window.navigator.registerProtocolHandler(protocol, url, title);\n</code></pre>Allows web sites to register themselves as possible handlers for particular protocols.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler
 Navigator.requestMediaKeySystemAccess()	A										<pre><code>&#8203;Navigator.requestMediaKeySystemAccess(keySystem, supportedConfigurations).then(function(mediaKeySystemAccess) { ... });</code></pre>The Navigator.requestMediaKeySystemAccess() method returns a Promise for a MediaKeySystemAccess object.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess
 Navigator.requestWakeLock()	A										<pre><code>lock = window.navigator.requestWakeLock(resourceName);</code></pre>This Navigator.requestWakeLock() method of the Wake Lock API is used to request a MozWakeLock on any resource of the device. This means that you can prevent that resource from becoming unavailable as long as your app holds a lock for that resource. For example, a voice recording app can obtain a lock to keep the screen on during recording so that it can give prover visual feedback to the user that recording is progressing.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestWakeLock
-Navigator.sendBeacon()	A										<pre><code>navigator.sendBeacon(url, data);\n</code></pre>The navigator.sendBeacon() method can be used to asynchronously transfer small HTTP data from the User Agent to a web server.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
+Navigator.sendBeacon()	A										<pre><code>navigator.sendBeacon(url, data);\n</code></pre>The navigator.sendBeacon() method can be used to asynchronously transfer a small amount of data over HTTP to a web server.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
 Navigator.serviceWorker	A										<pre><code>var workerContainerInstance = navigator.serviceWorker;\n</code></pre>The Navigator.serviceWorker read-only property returns the ServiceWorkerContainer object for the associated document, which provides access to registration, removal, upgrade, and communication with the ServiceWorker.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/serviceWorker
 Navigator.vendor	A										<pre><code>venString = window.navigator.vendor \n</code></pre>Returns the name of the browser vendor for the current browser.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
 Navigator.vendorSub	A										<pre><code>venSub = window.navigator.vendorSub \n</code></pre>The Navigator.vendorSub read-only property is the substring of the vendor having to do with the vendor version number.  The specification allows browsers to always return the empty string, so don't rely on this property to get a reliable answer.	https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendorSub
@@ -1764,7 +1781,6 @@ Node.lookupNamespaceURI()	A										The Node.lookupNamespaceURI() method takes 
 Node.lookupPrefix()	A										The Node.lookupPrefix() method returns a DOMString containing the prefix for a given namespace URI, if present, and null if not. When multiple prefixes are possible, the result is implementation-dependent.	https://developer.mozilla.org/en-US/docs/Web/API/Node/lookupPrefix
 Node.nextSibling	A										<pre><code>nextNode = node.nextSibling\n</code></pre>The Node.nextSibling read-only property returns the node immediately following the specified one in its parent's childNodes list, or null if the specified node is the last node in that list.	https://developer.mozilla.org/en-US/docs/Web/API/Node/nextSibling
 Node.nodeName	A										<pre><code>var str = node.nodeName;\n</code></pre>The Node.nodeName read-only property returns the name of the current node as a string.	https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName
-Node.nodePrincipal	A										<pre><code>principalObj = element.nodePrincipal\n</code></pre>Tags: API\n      \n        DOM\n      \n        Gecko\n      \n        Property	https://developer.mozilla.org/en-US/docs/Web/API/Node/nodePrincipal
 Node.nodeType	A										<pre><code>var type = node.nodeType;\n</code></pre>The read-only Node.nodeType property that represents the type of the node.	https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
 Node.nodeValue	A										<pre><code>value = node.nodeValue;\n</code></pre>The Node.nodeValue property returns or sets the value of the current node.	https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue
 Node.normalize()	A										<pre><code>element.normalize();\n</code></pre>The Node.normalize() method puts the specified node and all of its sub-tree into a "normalized" form. In a normalized sub-tree, no text nodes in the sub-tree are empty and there are no adjacent text nodes.	https://developer.mozilla.org/en-US/docs/Web/API/Node/normalize
@@ -1795,6 +1811,8 @@ NonDocumentTypeChildNode	A										The NonDocumentTypeChildNode interface conta
 NonDocumentTypeChildNode.nextElementSibling	A										<pre><code>var nextNode = elementNodeReference.nextElementSibling; </code></pre>The NonDocumentTypeChildNode.nextElementSibling read-only property returns the element immediately following the specified one in its parent's children list, or null if the specified element is the last one in the list.	https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/nextElementSibling
 NonDocumentTypeChildNode.previousElementSibling	A										<pre><code>prevNode = elementNodeReference.previousElementSibling; \n</code></pre>The NonDocumentTypeChildNode.previousElementSibling read-only property returns the Element immediately prior to the specified one in its parent's children list, or null if the specified element is the first one in the list.	https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/previousElementSibling
 Notification	A										The Notification interface of the Notifications API is used to configure and display desktop notifications to the user.	https://developer.mozilla.org/en-US/docs/Web/API/notification
+Notification.actions	A										<pre><code>var actions[] = Notification.actions;</code></pre>The actions read-only property of the Notification interface returns the actions array of the notification as specified in the options parameter of the Notification() constructor.	https://developer.mozilla.org/en-US/docs/Web/API/notification/actions
+Notification.badge	A										<pre><code>var url = Notification.badge</code></pre>The badge property of the Notification interface returns the URL of the image used to represent the notification when there is not enough space to display the notification itself.	https://developer.mozilla.org/en-US/docs/Web/API/notification/badge
 Notification.body	A										<pre><code>var body = Notification.body;\n</code></pre>The body read-only property of the Notification interface indicates the body string of the notification, as specified in the body option of the Notification() constructor.	https://developer.mozilla.org/en-US/docs/Web/API/Notification/body
 Notification.close()	A										<pre><code>Notification.close();</code></pre>The close() method of the Notification interface is used to close a previously displayed notification.	https://developer.mozilla.org/en-US/docs/Web/API/Notification/close
 Notification.data	A										<pre><code>var data = Notification.data;\n</code></pre>The data read-only property of the Notification interface returns a structured clone of the notification's data, as specified in the data option of the Notification() constructor.	https://developer.mozilla.org/en-US/docs/Web/API/notification/data
@@ -1823,7 +1841,6 @@ NotificationEvent.notification	A										The notification read-only property of
 NotificationEvent.NotificationEvent()	A										<pre><code>var myNotificationEvent = new NotificationEvent(type, NotificationEventInit);</code></pre>The NotificationEvent() constructor creates a new NotificationEvent object.	https://developer.mozilla.org/en-US/docs/Web/API/NotificationEvent/NotificationEvent
 Notifications API	A										The Notifications API allows web pages to control the display of system notifications to the end user — these are outside the top-level browsing context viewport, so therefore can be displayed even the user has switched tabs or moved to a different app. The API is designed to be compatible with existing notification systems across different platforms.	https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API
 Using the Notifications API	A										The Notifications API lets a web page or app send notifications that are displayed outside the page at the system level; this lets web apps send information to a user even if the application is idle or in the background. This article looks at the basics of using this API in your own apps.	https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API
-NotifyAudioAvailableEvent	A										Tags: API\n      \n        Deprecated\n      \n        NeedsContent\n      \n        Reference\n      \n        R&#233;f&#233;rence	https://developer.mozilla.org/en-US/docs/Web/API/NotifyAudioAvailableEvent
 OES_element_index_uint	A										The OES_element_index_uint extension is part of the WebGL API and adds support for gl.UNSIGNED_INT types to WebGLRenderingContext.drawElements().	https://developer.mozilla.org/en-US/docs/Web/API/OES_element_index_uint
 OES_standard_derivatives	A										The OES_standard_derivatives extension is part of the WebGL API and adds the GLSL derivative functions dFdx, dFdy, and fwidth.	https://developer.mozilla.org/en-US/docs/Web/API/OES_standard_derivatives
 OES_texture_float	A										The OES_texture_float extension is part of the WebGL API and exposes floating-point pixel types for textures.	https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float
@@ -1893,23 +1910,36 @@ Path2D	A										The Path2D interface of the Canvas 2D API is used to declare p
 Path2D.addPath()	A										<pre><code>void path.addPath(path [, transform]);\n</code></pre>The Path2D.addPath() method of the Canvas 2D API adds to the path the path given by the argument.	https://developer.mozilla.org/en-US/docs/Web/API/Path2D/addPath
 Path2D()	A										<pre><code>new Path2D();\nnew Path2D(path);\nnew Path2D(d);\n</code></pre>The Path2D() constructor returns a newly instantiated Path2D object, optionally with another path as an argument (creates a copy), or optionally with a string consisting of SVG path data.	https://developer.mozilla.org/en-US/docs/Web/API/Path2D/Path2D
 PaymentAddress	A										The PaymentAddress interface of the the Payment Request API stores address information.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress
+PaymentAddress.addressLine	A										<pre><code>var paymentAddressLines = PaymentAddress.addressLine;</code></pre>The addressLine read-only property of the PaymentAddress interface returns a string array containing specific parts of the address such as street name, house number, apartment number, rural delivery route, descriptive instructions, or post office box.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/addressLine
+PaymentAddress.careOf	A										<pre><code>var paymentCareOf = PaymentAddress.careOf;</code></pre>The careOf read-only property of the PaymentAddress interface returns a string containing the name of an intermediary party or entity responsible for transferring packages between the postal service and the recipient.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/careOf
+PaymentAddress.city	A										<pre><code>var paymentCity = PaymentAddress.city;</code></pre>The city read-only property of the PaymentAddress interface returns a string containing the city or town portion of the address.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/city
+PaymentAddress.country	A										<pre><code>var paymentCountry = PaymentAddress.country;</code></pre>The country read-only property of the PaymentAddress interface returns a string containing the Common Locale Data Repository (CLDR) region code for the user's country, for example, US, GB, CN, JP, etc.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/country
+PaymentAddress.dependentLocality	A										<pre><code>var paymentDependentLocality = PaymentAddress.dependentLocality;</code></pre>The dependentLocality read-only property of the PaymentAddress interface returns a string containing a sublocality designation within a city, for example, a neighborhood, borough, district, or UK dependent locality.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/dependentLocality
+PaymentAddress.languageCode	A										<pre><code>var paymentLanguageCode = PaymentAddress.languageCode;</code></pre>The languageCode read-only property of the PaymentAddress interface returns a string containing the BCP-47 language code for the address, used to determine the field separators and the order of fields when formatting the address for display.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/languageCode
+PaymentAddress.organization	A										<pre><code>var paymentOrganization = PaymentAddress.organization;</code></pre>The organization read-only property of the PaymentAddress interface returns a string containing the name of the organization, firm, company, or institution at the payment address.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/organization
+PaymentAddress.country	A										<pre><code>var paymentCountry = PaymentAddress.country;</code></pre>The country read-only property of the PaymentAddress interface returns a string containing the Common Locale Data Repository (CLDR) region code for the user's country, for example, US, GB, CN, etc.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/PaymentAddress.country
+PaymentAddress.phone	A										<pre><code>var paymentPhone = PaymentAddress.phone;</code></pre>The phone read-only property of the PaymentAddress interface returns a string containing the telephone number of the recipient or contact person.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/phone
+PaymentAddress.postalCode	A										<pre><code>var paymentPostalCode = PaymentAddress.postalCode;</code></pre>The postalCode read-only property of the PaymentAddress interface returns a string containing a code used by a jurisdiction for mail routing, for example, the ZIP code in the United States or the PIN code in India.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/postalCode
+PaymentAddress.recipient	A										<pre><code>var paymentRecipient = PaymentAddress.recipient;</code></pre>The recipient read-only property of the PaymentAddress interface returns a string containing the name of the recipient, purchaser, or contact person at the payment address.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/recipient
+PaymentAddress.region	A										<pre><code>var paymentRegion = PaymentAddress.region;</code></pre>The region read-only property of the PaymentAddress interface returns a string containing a top level administrative subdivision of the country, for example, a state, province, oblast, or prefecture.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/region
+PaymentAddress.sortingCode	A										<pre><code>var paymentSortingCode = PaymentAddress.sortingCode;</code></pre>The sortingCode read-only property of the PaymentAddress interface returns a string containing a postal sorting code such as is used in France.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/sortingCode
 PaymentRequest	A										The PaymentRequest interface of the the Payment Request API manages the process of a user making a payment.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest
-abort	A										<pre><code>PaymentRequest.abort();</code></pre>The PaymentRequest.abort() method of the PaymentRequest interface cayses the user agent to end the payment request and to tear down any user interface that might be shown.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/abort
-PaymentRequest.onshippingaddresschange	A										The onshippingaddresschange event of the PaymentRequest interface is fired whenever the user changes their shipping address. This event is also triggered by the user interactions with the user agent. This is fired both when the existing default address is updated and when an address is added by the user for the first time.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/onshippingaddresschange
-onshippingoptionchange	A										The onshippingoptionchange event of the PaymentRequest interface is fired whenever the user changes a shipping option.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/onshippingoptionchange
-PaymentRequest.PaymentRequest()	A										<pre><code>var paymentRequest = new PaymentRequest(supportedMethods, details[, options][, data])</code></pre>The PaymentRequest() constructor creates a new PaymentRequest object.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/PaymentRequest
-PaymentRequest.shippingAddress	A										<pre><code>var paymentAddress = PaymentRequest.shippingAddress</code></pre>The shippingAddress read-only property of the PaymentRequest interface returns a PaymentAddress object containing the shipping address provided by the user.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/shippingAddress
-PaymentRequest.shippingOption	A										<pre><code>var shippingOption = PaymentRequest.shippingOption;</code></pre>The shippingOption read-only property of the PaymentRequest interface returns the ID of the selected shipping option. This property is only populated if the constructor is called with the requestShipping flag set to true.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/shippingOption
+abort	A										<pre><code>PaymentRequest.abort();</code></pre>The PaymentRequest.abort() method of the PaymentRequest interface causes the user agent to end the payment request and to remove any user interface that might be shown.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/abort
+PaymentRequest.onshippingaddresschange	A										The onshippingaddresschange event of the PaymentRequest interface is fired whenever the user changes their shipping address, including when an address is added by the user for the first time.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/onshippingaddresschange
+PaymentRequest.onshippingoptionchange	A										The onshippingoptionchange event of the PaymentRequest interface is fired whenever the user changes a shipping option.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/onshippingoptionchange
+PaymentRequest.PaymentRequest()	A										<pre><code>var paymentRequest = new PaymentRequest(methodData, details [, options]);</code></pre>The PaymentRequest() constructor creates a new PaymentRequest object.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/PaymentRequest
+PaymentRequest.shippingAddress	A										<pre><code>var paymentAddress = PaymentRequest.shippingAddress;</code></pre>The shippingAddress read-only property of the PaymentRequest interface returns the shipping address provided by the user. It is null by default.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/shippingAddress
+PaymentRequest.shippingOption	A										<pre><code>var shippingOption = PaymentRequest.shippingOption;</code></pre>The shippingOption read-only property of the PaymentRequest interface returns the shipping option selected by the user. It is null by default. This property is only populated if the constructor is called with the requestShipping flag set to true.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/shippingOption
 PaymentRequest.show()	A										<pre><code>PaymentRequest.show()\n    .then( paymentResponse =&gt; { ... })\n    .catch( error =&gt; { ... })</code></pre>The PaymentRequest.show() method of the PaymentRequest interface causes the user agent to begin the user interaction for the payment request.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/show
 PaymentResponse	A										The PaymentResponse interface of the the Payment Request API is returned after a user selects a payment method and approves a payment request.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse
-PaymentResponse.complete()	A										<pre><code>PaymentRequest.complete([result])\n&#160;  .then(function() { ... } )\n&#160;  .catch( error =&gt; { ... } )</code></pre>The PaymentRequest.complete() method of the PaymentRequest API notifies the user agent that the user interaction is over. This causes any remaining user interface to be closed. This method should only be called after the Promise returned by the PaymentRequest.show() method.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/complete
-PaymentResponse.details	A										<pre><code>var detailsObject = PaymentResponse.details</code></pre>The details read-only property of the PaymentResponse interface returns a JSON-serializable object that provides a payment method specific message used by the merchant to process the transaction and determine successful fund transfer. This data is returned by the payment app that satisfies the payment request.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/details
-PaymentResponse.methodName	A										<pre><code>var methodName = PaymentResponse.methodName;</code></pre>The methodName read-only property of the PaymentResponse interface returns the payment method identifier for the payment method that the user selected, for example, Visa, Mastercard, Paypal, etc..	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/methodName
+PaymentResponse.complete()	A										<pre><code>PaymentRequest.complete([result])\n&#160;  .then(function() { ... } )\n&#160;  .catch( error =&gt; { ... } )</code></pre>The PaymentRequest.complete() method of the PaymentRequest API notifies the user agent that the user interaction is over, and causes any remaining user interface to be closed. This method must be called after the user accepts the payment request and the Promise returned by the PaymentRequest.show() method is resolved.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/complete
+PaymentResponse.details	A										<pre><code>var detailsObject = PaymentResponse.details;</code></pre>The details read-only property of the PaymentResponse interface returns a JSON-serializable object that provides a payment method specific message used by the merchant to process the transaction and determine a successful funds transfer. This data is returned by the payment app that satisfies the payment request.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/details
+PaymentResponse.methodName	A										<pre><code>var methodName = PaymentResponse.methodName;</code></pre>The methodName read-only property of the PaymentResponse interface returns the payment method identifier for the payment method that the user selected, for example, Visa, Mastercard, Paypal, etc.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/methodName
 PaymentResponse.payerEmail	A										<pre><code>var payerEmail = PaymentResponse.payerEmail;</code></pre>The payerEmail read-only property of the PaymentResponse interface returns the email address supplied by the user. This option is only present when the requestPayerEmail option is set to true in the PaymentOptions object passed to the PaymentRequest constructor.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/payerEmail
 PayerResponse.payerPhone	A										<pre><code>var payerPhone = PaymentResponse.payerPhone;</code></pre>The payerPhone read-only property of the PaymentResponse interface returns the phone number supplied by the user. This option is only present when the requestPayerPhone option is set to true in the PaymentOptions object passed to the PaymentRequest constructor.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/payerPhone
 PaymentRespoonse.shippingAddress	A										<pre><code>var paymentAddress = PaymentRequest.shippingAddress;</code></pre>The shippingAddress read-only property of the PaymentRequest interface returns a PaymentAddress object containing the shipping address provided by the user.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/shippingAddress
-PaymentResponse.shippingOption	A										<pre><code>var shippingOption = PaymentRequest.shippingOption</code></pre>The shippingOption read-only property of the PaymentRequest interface returns the ID attribute of the shipping option selected by the user. This option is only present when the requestShipping option is set to true in the PaymentOptions object passed to the PaymentRequest constructor.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/shippingOption
-Payment Request API	A										Most problems related to online purchase abandonment can be traced to checkout forms, which are user-intensive, difficult to use, slow to load and refresh, and require multiple steps to complete. The Payment Request API is a system that is meant to eliminate checkout forms. It vastly improves user workflow during the purchase process, providing a more consistent user experience and enabling web merchants to easily leverage disparate payment methods.	https://developer.mozilla.org/en-US/docs/Web/API/Payment_Request_API
+PaymentResponse.shippingOption	A										<pre><code>var shippingOption = PaymentRequest.shippingOption;</code></pre>The shippingOption read-only property of the PaymentRequest interface returns the ID attribute of the shipping option selected by the user. This option is only present when the requestShipping option is set to true in the PaymentOptions object passed to the PaymentRequest constructor.	https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/shippingOption
+Payment Request API	A										Many problems related to online purchase abandonment can be traced to checkout forms, which are user-intensive, difficult to use, slow to load and refresh, and require multiple steps to complete. The Payment Request API is a system that is meant to eliminate checkout forms. It vastly improves user workflow during the purchase process, providing a more consistent user experience and enabling web merchants to easily leverage disparate payment methods.	https://developer.mozilla.org/en-US/docs/Web/API/Payment_Request_API
 Performance	A										The Performance interface represents timing-related performance information for the given page.	https://developer.mozilla.org/en-US/docs/Web/API/Performance
 Performance.clearMarks()	A										<pre><code>performance.clearMarks();\nperformance.clearMarks(name);\n</code></pre>The clearMarks() method removes the named mark from the browser's performance entry buffer. If the method is called with no arguments, all performance entries with an entry type of " mark " will be removed from the performance entry buffer.	https://developer.mozilla.org/en-US/docs/Web/API/Performance/clearMarks
 Performance.clearMeasures()	A										<pre><code>performance.clearMeasures();\nperformance.clearMeasures(name);\n</code></pre>The clearMeasures() method removes the named measure from the browser's performance entry buffer. If the method is called with no arguments, all performance entries with an entry type of " measure " will be removed from the performance entry buffer.	https://developer.mozilla.org/en-US/docs/Web/API/Performance/clearMeasures
@@ -2034,13 +2064,14 @@ Pinch zoom gestures	A										Adding gestures to an application can significant
 Using Pointer Events	A										This document demonstrates how to use pointer events and canvas to build a multi-touch enabled drawing application. This example is identical to the application described in the Touch events Overview except this example uses the pointer events input event model (instead of touch events. Another difference is that because pointer events are pointer device agnostic, the application accepts both touch input, pen and mouse input, the latter two for free.	https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Using_Pointer_Events
 Pointer Lock API	A										The Pointer Lock API (formerly called Mouse Lock API) provides input methods based on the movement of the mouse over time (i.e., deltas), not just the absolute position of the mouse cursor in the viewport. It gives you access to raw mouse movement, locks the target of mouse events to a single element, eliminates limits on how far mouse movement can go in a single direction, and removes the cursor from view.	https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API
 PopStateEvent	A										<pre><code>window.onpopstate = funcRef;\n</code></pre>An event handler for the popstate event on the window.	https://developer.mozilla.org/en-US/docs/Web/API/PopStateEvent
-PortCollection	A										Tags: API\n      \n        Channel messaging\n      \n        Interface\n      \n        PortCollection\n      \n        Reference\n      \n        R&#233;f&#233;rence	https://developer.mozilla.org/en-US/docs/Web/API/PortCollection
 Position	A										The Position interface represents the position of the concerned device at a given time. The position, represented by a Coordinates object, comprehends the 2D position of the device, on a spheroid representing the Earth, but also its altitude and its speed.	https://developer.mozilla.org/en-US/docs/Web/API/Position
 Position.coords	A										<pre><code>coord = position.coords\n</code></pre>The Position.coords read-only property, a Coordinates object, represents a geographic attitude: it contains the location, that is longitude and latitude on the Earth, the altitude, and the speed of the object concerned, regrouped inside the returned value. It also contains accuracy information about these values.	https://developer.mozilla.org/en-US/docs/Web/API/Position/coords
 Position.timestamp	A										<pre><code>coord = position.timestamp\n</code></pre>The Position.timestamp read-only property, a DOMTimeStamp object, represents the date and the time of the creation of the Position object it belongs to. The precision is to the millisecond.	https://developer.mozilla.org/en-US/docs/Web/API/Position/timestamp
 PositionError	A										The PositionError interface represents the reason of an error occurring when using the geolocating device.	https://developer.mozilla.org/en-US/docs/Web/API/PositionError
 PositionError.code	A										<pre><code>typeErr = poserr.code\n</code></pre>The PositionError.code read-only property is an unsigned short representing the error code. The following values are possible:	https://developer.mozilla.org/en-US/docs/Web/API/PositionError/code
+positionerror code	R	PositionError.code										
 PositionError.message	A										<pre><code>msg = positionError.message\n</code></pre>The PositionError.message read-only property returns a human-readable DOMString describing the details of the error.	https://developer.mozilla.org/en-US/docs/Web/API/PositionError/message
+positionerror message	R	PositionError.message										
 PositionOptions	A										The PositionOptions interface describes an object containing option properties to pass as a parameter of Geolocation.getCurrentPosition() and Geolocation.watchPosition().	https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
 PositionOptions.enableHighAccuracy	A										<pre><code>positionOptions.enableHighAccuracy = booleanValue\n</code></pre>The PositionOptions.enableHighAccuracy property is a Boolean that indicates the application would like to receive the best possible results. If true and if the device is able to provide a more accurate position, it will do so. Note that this can result in slower response times or increased power consumption (with a GPS chip on a mobile device for example). On the other hand, if false (the default value), the device can take the liberty to save resources by responding more quickly and/or using less power.	https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions/enableHighAccuracy
 PositionOptions.maximumAge	A										<pre><code>positionOptions.maximumAge = timeLength\n</code></pre>The PositionOptions.maximumAge property is a positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position. If set to Infinity the device must return a cached position regardless of its age.	https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions/maximumAge
@@ -2071,7 +2102,7 @@ onconnectionavailable	A										The following are the event handlers (and their
 reconnect	A										When the reconnect (presentationId) method is called on a PresentationRequest presentationRequest, the user agent MUST run the following steps to reconnect to a presentation :	https://developer.mozilla.org/en-US/docs/Web/API/PresentationRequest/reconnect
 start	A										When the start method is called, the user agent MUST run the following steps to start a presentation :	https://developer.mozilla.org/en-US/docs/Web/API/PresentationRequest/start
 Presentation API	A										The Presentation API is developed to effectively display web content through large scale presentation devices such as projectors and connected TVs. The relevant multimedia devices include wired displays, such as HDMI, DVI, or similar, and wireless technologies like Miracast, Chromecast, DLNA, or AirPlay.	https://developer.mozilla.org/en-US/docs/Web/API/Presentation_API
-ProcessingInstruction	A										<pre><code>See also:\n  document.createProcessingInstruction\n  en/DOM/document.createProcessingInstruction</code></pre>A processing instruction provides an opportunity for application-specific instructions to be embedded within XML and which can be ignored by XML processors which do not support processing their instructions (outside of their having a place in the DOM).	https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction
+ProcessingInstruction	A										A processing instruction provides an opportunity for application-specific instructions to be embedded within XML and which can be ignored by XML processors which do not support processing their instructions (outside of their having a place in the DOM).	https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction
 ProgressEvent	A										The ProgressEvent interface represents events measuring progress of an underlying process, like an HTTP request (for an XMLHttpRequest, or the loading of the underlying resource of an img, audio, video, style or link).	https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
 ProgressEvent.initProgressEvent()	A										<pre><code>Progress.initProgressEvent(typeArg, canBubbleArg, cancelableArg, lengthComputable, loaded, total);\n</code></pre>The ProgressEvent.initProgressEvent() method Initializes an animation event created using the deprecated Document.createEvent("ProgressEvent") method.	https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/initProgressEvent
 ProgressEvent.lengthComputable	A										<pre><code>flag = ProgressEvent.lengthComputable</code></pre>The ProgressEvent.lengthComputable read-only property is a Boolean flag indicating if the resource concerned by the ProgressEvent has a length that can be calculated. If not, the ProgressEvent.total property has no significant value.	https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable
@@ -2210,8 +2241,11 @@ RTCIceServer.username	A										<pre><code>var iceServer = {\n                 
 RTCIdentityAssertion	A										The RTCIdentityAssertion interface of the the WebRTC API represents the identity of the a remote peer of the current connection. If no peer has yet been set and verified this interface returns null. Once set it can't be changed.	https://developer.mozilla.org/en-US/docs/Web/API/RTCIdentityAssertion
 RTCIdentityErrorEvent	A										The RTCIdentityErrorEvent interface represents an error associated with the identity provider (idP). This is usually for an RTCPeerConnection. Two events are sent with this type: idpassertionerror and idpvalidationerror.	https://developer.mozilla.org/en-US/docs/Web/API/RTCIdentityErrorEvent
 RTCIdentityErrorEvent.idp	A										<pre><code>var idp = event.idp;\nevent.idp = "developer.mozilla.org";\n</code></pre>The read-only property RTCIdentityErrorEvent.idp returns the DOMString describing the domain name of the identity provider (idp) generating the error response event.	https://developer.mozilla.org/en-US/docs/Web/API/RTCIdentityErrorEvent/idp
+rtcidentityerrorevent idp	R	RTCIdentityErrorEvent.idp										
 RTCIdentityErrorEvent.loginUrl	A										<pre><code>var loginUrl = event.loginUrl;\nevent.loginUrl = "https://developer.mozilla.org/fakeURL";\n</code></pre>The read-only property RTCIdentityErrorEvent.loginUrl is a DOMString giving the URL where the user can complete the authentication. It can be null and is provided by the identity provider (idp).	https://developer.mozilla.org/en-US/docs/Web/API/RTCIdentityErrorEvent/loginUrl
+rtcidentityerrorevent loginurl	R	RTCIdentityErrorEvent.loginUrl										
 RTCIdentityErrorEvent.protocol	A										<pre><code>var protocol = event.protocol;\nevent.protocol = "idp.html";\n</code></pre>The read-only property RTCIdentityErrorEvent.protocol is a DOMString describing the Idp protocol in use.	https://developer.mozilla.org/en-US/docs/Web/API/RTCIdentityErrorEvent/protocol
+rtcidentityerrorevent protocol	R	RTCIdentityErrorEvent.protocol										
 RTCIdentityEvent	A										The RTCIdentityEvent interface represents an identity assertion generated by an identity provider (idP). This is usually for an RTCPeerConnection. The only event sent with this type is identityresult..	https://developer.mozilla.org/en-US/docs/Web/API/RTCIdentityEvent
 RTCIdentityEvent.assertion	A										<pre><code> var blob = event.assertion;</code></pre>The read-only property RTCIdentityEvent.assertion returns the DOMString containing a blob being the coded assertion associated with the event.	https://developer.mozilla.org/en-US/docs/Web/API/RTCIdentityEvent/assertion
 RTCPeerConnection	A										The RTCPeerConnection interface represents a WebRTC connection between the local computer and a remote peer. It provides methods to connect to a remote peer, maintain and monitor the connection, and close the connection once it's no longer needed.	https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection
@@ -2273,7 +2307,6 @@ RTCSessionDescription()	A										<pre><code> sessionDescription = new RTCSessi
 RTCSessionDescription.sdp	A										<pre><code>var value = sessionDescription.sdp;\nsessionDescription.sdp = value; \n</code></pre>The property RTCSessionDescription.sdp is a read-only DOMString containing the SDP which describes the session.	https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/sdp
 RTCSessionDescription.toJSON()	A										<pre><code>var jsonValue = sd.toJSON();\n</code></pre>The RTCPeerConnection.toJSON() method generates a JSON description of the object. Both properties, type and sdp, are contained in the generated JSON.	https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/toJSON
 RTCSessionDescription.type	A										<pre><code>var value = sessionDescription.type;\nsessionDescription.type = value; \n</code></pre>The property RTCSessionDescription.type is a read-only value of type RTCSdpType which describes the description's type.	https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/type
-RTCSessionDescriptionCallback	A										Tags: API\n      \n        Interface\n      \n        Reference\n      \n        R&#233;f&#233;rence\n      \n        WebRTC	https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescriptionCallback
 RTCStatsReport	A										WebRTC provides a method— RTCPeerConnection.getStats() —which returns a set of statistics about the state of the connection and the data transfers which have taken place. This status report is an object of type RTCStatsReport, and consists of a mapping of strings identifying objects which have had statistics recorded and a dictionary containing all of the corresponding data.	https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport
 Screen	A										The Screen interface represents a screen, usually the one on which the current window is being rendered.	https://developer.mozilla.org/en-US/docs/Web/API/Screen
 Screen.availHeight	A										<pre><code>iAvail = window.screen.availHeight</code></pre>Returns the amount of vertical space available to the window on the screen.	https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight
@@ -2367,6 +2400,8 @@ ServiceWorkerState	A										The ServiceWorkerState is associated with its Serv
 Service Worker API	A										A service worker is an event-driven worker registered against an origin and a path. It takes the form of a JavaScript file that can control the web page/site it is associated with, intercepting and modifying navigation and resource requests, and caching resources in a very granular fashion to give you complete control over how your app behaves in certain situations (the most obvious one being when the network is not available.)	https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
 Using Service Workers	A										One overriding problem that web users have suffered with for years is loss of connectivity. The best web app in the world will provide a terrible user experience if you can’t download it. There have been various attempts to create technologies to solve this problem, as our Offline page shows, and some of the issues have been solved. But the overriding problem is that there still isn’t a good overall control mechanism for asset caching and custom network requests. The previous attempt — AppCache — seemed to be a good idea because it allowed you to specify assets to cache really easily. However, it made many assumptions about what you were trying to do and then broke horribly when your app didn’t follow those assumptions exactly. Read Jake Archibald's Application Cache is a Douchebag for more details.	https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 ShadowRoot	A										The ShadowRoot interface of the Shadow DOM API is the root node of a DOM subtree that is rendered separately from a document's main DOM tree.	https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot
+ShadowRoot.host	A										<pre><code>var element = shadowRoot.host</code></pre>The host read-only property of the ShadowRoot returens the DOM element to which the ShadowRoot is attatched.	https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/host
+ShadowRoot.innerHTML	A										<pre><code>var domString = shadowRoot.innerHTML\nshadowRoot.innerHTML = domString\n</code></pre>The innerHTML property of the ShadowRoot interface sets or returns the DOM tree inside the ShadowRoot.	https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/innerHTML
 SharedKeyframeList	A										The SharedKeyframeList interface of the Web Animations API represents a sequence of keyframes that can be shared between KeyframeEffect objects.	https://developer.mozilla.org/en-US/docs/Web/API/SharedKeyframeList
 SharedKeyframeList.SharedKeyframeList()	A										The SharedKeyframeList() constructor of the SharedKeyframeList interface creates a new SharedKeyframeList object that can be shared across multiple KeyframeEffect objects.	https://developer.mozilla.org/en-US/docs/Web/API/SharedKeyframeList/SharedKeyframeList
 SharedWorker	A										The SharedWorker interface represents a specific kind of worker that can be accessed from several browsing contexts, such as several windows, iframes or even workers. They implement an interface different than dedicated workers and have a different global scope, SharedWorkerGlobalScope.	https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker
@@ -2430,7 +2465,9 @@ SpeechRecognitionAlternative.confidence	A										<pre><code>var myConfidence =
 SpeechRecognitionAlternative.transcript	A										<pre><code>var myTranscript = speechRecognitionAlternativeInstance.transcript;</code></pre>The transcript read-only property of the SpeechRecognitionResult interface returns a string containing the transcript of the recognised word(s).	https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionAlternative/transcript
 SpeechRecognitionError	A										The SpeechRecognitionError interface of the Web Speech API represents error messages from the recognition service.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionError
 SpeechRecognitionError.error	A										<pre><code>var myError = event.error;\n</code></pre>The error read-only property of the SpeechRecognitionError interface returns the type of error raised.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionError/error
+speechrecognitionerror error	R	SpeechRecognitionError.error										
 SpeechRecognitionError.message	A										<pre><code>var myErrorMsg = event.message;\n</code></pre>The message read-only property of the SpeechRecognitionError interface returns a message describing the error in more detail.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionError/message
+speechrecognitionerror message	R	SpeechRecognitionError.message										
 SpeechRecognitionEvent	A										The SpeechRecognitionEvent interface of the Web Speech API represents the event object for the result and nomatch events, and contains all the data associated with an interim or final speech recognition result.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionEvent
 SpeechRecognitionEvent.emma	A										<pre><code>var myEmma = event.emma;\n</code></pre>The emma read-only property of the SpeechRecognitionEvent interface returns an E xtensible MultiModal Annotation markup language (EMMA) — XML — representation of the result.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionEvent/emma
 SpeechRecognitionEvent.interpretation	A										<pre><code>var myInterpretation = event.interpretation;\n</code></pre>The interpretation read-only property of the SpeechRecognitionEvent interface returns the semantic meaning of what the user said.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionEvent/interpretation
@@ -2455,6 +2492,7 @@ SpeechSynthesis.speak()	A										<pre><code>speechSynthesisInstance.speak(utte
 SpeechSynthesis.speaking	A										<pre><code>var amISpeaking = speechSynthesisInstance.speaking;\n</code></pre>The speaking read-only property of the SpeechSynthesis interface is a Boolean that returns true if an utterance is currently in the process of being spoken — even if SpeechSynthesis is in a paused state.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/speaking
 SpeechSynthesisErrorEvent	A										The SpeechSynthesisErrorEvent interface of the Web Speech API contains information about any errors that occur while processing SpeechSynthesisUtterance objects in the speech service.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisErrorEvent
 SpeechSynthesisErrorEvent.error	A										<pre><code>myError = event.error;\n</code></pre>The error property of the SpeechSynthesisErrorEvent interface returns an error code indicating what has gone wrong with a speech synthesis attempt.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisErrorEvent/error
+speechsynthesiserrorevent error	R	SpeechSynthesisErrorEvent.error										
 SpeechSynthesisEvent	A										The SpeechSynthesisEvent interface of the Web Speech API contains information about the current state of SpeechSynthesisUtterance objects that have been processed in the speech service.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent
 SpeechSynthesisEvent.charIndex	A										<pre><code>event.charIndex;\n</code></pre>The charIndex read-only property of the SpeechSynthesisUtterance interface returns the index position of the character in the SpeechSynthesisUtterance.text that was being spoken when the event was triggered.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent/charIndex
 SpeechSynthesisEvent.elapsedTime	A										<pre><code>event.elapsedTime;\n</code></pre>The elapsedTime read-only property of the SpeechSynthesisUtterance interface returns the elapsed time in milliseconds after the SpeechSynthesisUtterance.text started being spoken that the event was triggered at.	https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent/elapsedTime
@@ -2770,7 +2808,7 @@ VRDisplay.requestPresent()	A										<pre><code>vrDisplayInstance.requestPresen
 VRDevice.resetPose()	A										<pre><code>vrDisplayInstance.resetPose();\n</code></pre>The resetPose() method of the VRDisplay interface resets the pose for the VRDisplay, treating its current VRPose.position and VRPose.orientation as the "origin/zero" values.	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplay/resetPose
 VRDisplay.stageParameters	A										<pre><code>var myStageParameters = vrDisplayInstance.stageParameters;\n</code></pre>The stageParameters read-only property of the VRDisplay interface returns a VRStageParameters object containing room-scale parameters, if the VRDisplay is capable of supporting room-scale experiences.	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplay/stageParameters
 VRDisplay.submitFrame()	A										<pre><code>vrDisplayInstance.submitFrame(pose);\n</code></pre>The submitFrame() method of the VRDisplay interface captures the current state of the VRLayer currently being presented and displays it on the VRDisplay.	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplay/submitFrame
-VRDisplayCapabilities	A										The VRDisplayCapabilities interface of the WebVR API describes the capabilities of a VRDisplay — it's features can be used to perform VR device capability tests, for example can it return position information.	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplayCapabilities
+VRDisplayCapabilities	A										The VRDisplayCapabilities interface of the WebVR API describes the capabilities of a VRDisplay — its features can be used to perform VR device capability tests, for example can it return position information.	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplayCapabilities
 VRDisplayCapabilities.canPresent	A										<pre><code>var canIPresent = vrDisplayCapabilitiesInstance.canPresent;</code></pre>The canPresent read-only property of the VRDisplayCapabilities interface returns a Boolean stating whether the VR display is capable of presenting content (e.g. through an HMD).	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplayCapabilities/canPresent
 VRDisplayCapabilities.hasExternalDisplay	A										<pre><code>var hasAnExternalDisplay = vrDisplayCapabilitiesInstance.hasExternalDisplay;</code></pre>The hasExternalDisplay read-only property of the VRDisplayCapabilities interface returns a Boolean stating whether the VR display is separate from the device's primary display.	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplayCapabilities/hasExternalDisplay
 VRDisplayCapabilities.hasOrientation	A										<pre><code>var hasItGotOrientation = vrDisplayCapabilitiesInstance.hasOrientation;</code></pre>The hasOrientation read-only property of the VRDisplayCapabilities interface returns a Boolean stating whether the VR display can track and return orientation information.	https://developer.mozilla.org/en-US/docs/Web/API/VRDisplayCapabilities/hasOrientation
@@ -2952,6 +2990,7 @@ WebGLRenderingContext.getAttribLocation()	A										<pre><code>GLint gl.getAttr
 WebGLRenderingContext.getBufferParameter()	A										<pre><code>any gl.getBufferParameter(target, pname);\n</code></pre>The WebGLRenderingContext.getBufferParameter() method of the WebGL API returns information about the buffer.	https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getBufferParameter
 WebGLRenderingContext.getContextAttributes()	A										<pre><code>gl.getContextAttributes();</code></pre>The WebGLRenderingContext.getContextAttributes() method returns a WebGLContextAttributes object that contains the actual context parameters. Might return null, if the context is lost.	https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getContextAttributes
 WebGLRenderingContext.getError()	A										<pre><code>GLenum gl.getError();\n</code></pre>The WebGLRenderingContext.getError() method of the WebGL API returns error information.	https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getError
+webglrenderingcontext geterror()	R	WebGLRenderingContext.getError()										
 WebGLRenderingContext.getExtension()	A										<pre><code>gl.getExtension(name);</code></pre>The WebGLRenderingContext.getExtension() method enables a WebGL extension.	https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getExtension
 WebGLRenderingContext.getFramebufferAttachmentParameter()	A										<pre><code>any gl.getFramebufferAttachmentParameter(target, attachment, pname);\n</code></pre>The WebGLRenderingContext.getFramebufferAttachmentParameter() method of the WebGL API returns information about a framebuffer's attachment.	https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getFramebufferAttachmentParameter
 WebGLRenderingContext.getParameter()	A										<pre><code>any gl.getParameter(pname);\n</code></pre>The WebGLRenderingContext.getParameter() method of the WebGL API returns a value for the passed parameter name.	https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getParameter
@@ -3088,7 +3127,7 @@ Supported algorithms	A										Different algorithms are supported for the diffe
 Web Speech API	A										The Web Speech API makes web apps able to handle voice data. There are two components to this API:	https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
 Using the Web Speech API	A										The Web Speech API provides two distinct areas of functionality — speech recognition, and speech synthesis (also know as text to speech, or tts) — which open up interesting new possibilities for accessibility, and control mechanisms. This article provides a simple introduction to both areas, along with demos.	https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API
 Web Storage API	A										The Web Storage API provides mechanisms by which browsers can store key/value pairs, in a much more intuitive fashion than using cookies.	https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API
-Using the Web Storage API	A										Storage objects are simple key-value stores, similar to objects, but they stay intact through page loads.  The keys can be strings or integers, but the values are always strings.  You can access these values like an object, or with the getItem() and setItem() methods.  These three lines all set the colorSetting entry in the same way:	https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API
+Using the Web Storage API	A										Storage objects are simple key-value stores, similar to objects, but they stay intact through page loads.  The keys and the values are always strings (note that integer keys will be automatically converted to strings, just like what object do). You can access these values like an object, or with the getItem() and setItem() methods.  These three lines all set the colorSetting entry in the same way:	https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API
 WebVTT	A										WebVTT is a format for displaying timed text tracks (e.g. subtitles or captions) with the track element. The primary purpose of WebVTT files is to add text overlays to a video. WebVTT is a text based format, which must be encoded in UTF-8 format. Where you can use spaces you can also use tabs.	https://developer.mozilla.org/en-US/docs/Web/API/Web_Video_Text_Tracks_Format
 Web Workers API	A										Web Workers are a mechanism by which a script operation can be made to run in a background thread separate from the main execution thread of a web application. The advantage of this is that laborious processing can be performed in a separate thread, allowing the main (usually the UI) thread to run without being blocked/slowed down.	https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API
 Functions and classes available to Web Workers	A										In addition to the standard JavaScript set of functions (such as String, Array, Object, JSON etc), there are a variety of functions available from the DOM to workers. This article provides a list of those.	https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
@@ -3113,7 +3152,7 @@ Window.close()	A										<pre><code>window.close();</code></pre>The Window.clos
 Window.closed	A										<pre><code>isClosed = windowRef.closed;\n</code></pre>This read-only property indicates whether the referenced window is closed or not.	https://developer.mozilla.org/en-US/docs/Web/API/Window/closed
 Window.confirm()	A										<pre><code>result = window.confirm(message);\n</code></pre>The Window.confirm() method displays a modal dialog with an optional message and two buttons, OK and Cancel.	https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm
 Window.console	A										<pre><code>var consoleObj = window.console;\n</code></pre>The Window.console read-only property returns a reference to the Console object, which provides methods for logging information to the browser's console. These methods are intended for debugging purposes only and should not be relied on for presenting information to end users.	https://developer.mozilla.org/en-US/docs/Web/API/Window/console
-Window.content	A										<pre><code>Working with windows in chrome code\n When accessing content documents from privileged code, be aware of XPCNativeWrappers.\n</code></pre>Returns a Window object for the primary content window. This is useful in XUL windows that have a browser (or tabbrowser or iframe) with type="content-primary" attribute on it - the most famous example is Firefox main window, browser.xul. In such cases, content returns a reference to the Window object for the document currently displayed in the browser. It is a shortcut for browserRef.contentWindow.	https://developer.mozilla.org/en-US/docs/Web/API/Window/content
+Window.content	A										Returns a Window object for the primary content window. This is useful in XUL windows that have a browser (or tabbrowser or iframe) with type="content-primary" attribute on it - the most famous example is Firefox main window, browser.xul. In such cases, content returns a reference to the Window object for the document currently displayed in the browser. It is a shortcut for browserRef.contentWindow.	https://developer.mozilla.org/en-US/docs/Web/API/Window/content
 Window.controllers	A										<pre><code>controllers = window.controllers\n</code></pre>Returns the XUL controllers of the chrome window.	https://developer.mozilla.org/en-US/docs/Web/API/Window/controllers
 Window.convertPointFromNodeToPage()	A										The Window.convertPointFromNodeToPage() method converts a Point object from coordinates based on the given CSS node to coordinates based on the page.	https://developer.mozilla.org/en-US/docs/Web/API/Window/convertPointFromNodeToPage
 Window.convertPointFromPageToNode	A										Converts a Point object from coordinates based on the page to coordinates based on the given CSS node.	https://developer.mozilla.org/en-US/docs/Web/API/Window/convertPointFromPageToNode
@@ -3146,12 +3185,13 @@ Window.messageManager	A										<pre><code>messageManager = window.messageManag
 Window.minimize()	A										Sets a window to minimized state (a way to undo it programatically is by calling window.moveTo()).	https://developer.mozilla.org/en-US/docs/Web/API/Window/minimize
 Window.moveBy()	A										<pre><code>window.moveBy(deltaX, deltaY) \n</code></pre>Moves the current window by a specified amount.	https://developer.mozilla.org/en-US/docs/Web/API/Window/moveBy
 Window.moveTo()	A										<pre><code>window.moveTo(x, y) \n</code></pre>Moves the window to the specified coordinates.	https://developer.mozilla.org/en-US/docs/Web/API/Window/moveTo
-Window.mozAnimationStartTime	A										<pre><code>See also:\n  window.mozRequestAnimationFrame()\n window.onmozbeforepaint\n  You should call this method whenever you're ready to update your animation onscreen. This will request that your animation function be called before the browser performs the next repaint. The number of callbacks is usually 60 times per second, but will generally match the display refresh rate in most web browsers as per W3C recommendation. The callback rate may be reduced to a lower rate when running in background tabs.</code></pre>Returns the time, in milliseconds since the epoch, at which animations started now should be considered to have started. This value should be used instead of, for example, Date.now(), because this value will be the same for all animations started in this window during this refresh interval, allowing them to remain in sync with one another.	https://developer.mozilla.org/en-US/docs/Web/API/Window/mozAnimationStartTime
+Window.mozAnimationStartTime	A										Returns the time, in milliseconds since the epoch, at which animations started now should be considered to have started. This value should be used instead of, for example, Date.now(), because this value will be the same for all animations started in this window during this refresh interval, allowing them to remain in sync with one another.	https://developer.mozilla.org/en-US/docs/Web/API/Window/mozAnimationStartTime
 Window.mozInnerScreenX	A										<pre><code>screenX = window.mozInnerScreenX;</code></pre>Gets the X coordinate of the top-left corner of the window's viewport, in screen coordinates.	https://developer.mozilla.org/en-US/docs/Web/API/Window/mozInnerScreenX
 Window.mozInnerScreenY	A										<pre><code>screenY = window.mozInnerScreenY;</code></pre>Gets the Y coordinate of the top-left corner of the window's viewport, in screen coordinates.	https://developer.mozilla.org/en-US/docs/Web/API/Window/mozInnerScreenY
 Window.mozPaintCount	A										<pre><code>var paintCount = window.mozPaintCount;</code></pre>Returns the number of times the current document has been painted to the screen in this window.	https://developer.mozilla.org/en-US/docs/Web/API/Window/mozPaintCount
 Window.name	A										<pre><code>string = window.name;\nwindow.name = string;\n</code></pre>Gets/sets the name of the window.	https://developer.mozilla.org/en-US/docs/Web/API/Window/name
 Window.navigator	A										The Window.navigator read-only property returns a reference to the Navigator object, which can be queried for information about the application running the script.	https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator
+Navigator.connection	A										<pre><code>connectionInfo = navigator.connection</code></pre>The Navigator.connection read-only property represents a NetworkInformation containing information about the system's connection, such as the current bandwidth of the user's device or whether the connection is metered. This could be used to select high definition content or low definition content based on the user's connection.	https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator/connection
 mozNetworkStats	A										The MozNetworkStatsManager interface provides methods and properties to monitor data usage.	https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator/mozNetworkStats
 Window.onbeforeinstallprompt	A										<pre><code>window.addEventListener("beforeinstallprompt", function(event) { ... });\nwindow.onbeforeinstallprompt = function(event) { ...};</code></pre>The Window.onbeforeinstallprompt property is an event handler for processing a beforeinstallprompt, which is dispatched on mobile when a web manifest exists, but before a user is prompted to save a web site to a home screen.	https://developer.mozilla.org/en-US/docs/Web/API/Window/onbeforeinstallprompt
 Window.ondevicelight	A										<pre><code>window.ondevicelight = funcRef</code></pre>Specifies an event listener to receive devicelight events. These events occur when the device's light level sensor detects a change in the intensity of the ambient light level.	https://developer.mozilla.org/en-US/docs/Web/API/Window/ondevicelight
@@ -3235,11 +3275,11 @@ WindowEventHandlers.onrejectionhandled	A										<pre><code>window.addEventList
 WindowEventHandlers.onstorage	A										<pre><code>windowObj.onstorage = function() { ... };</code></pre>The WindowEventHandlers.onstorage property contains an event handler that runs when the storage event fires. This occurs when a storage area is changed (e.g. a new item is stored.)	https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onstorage
 WindowEventHandlers.onunhandledrejection	A										<pre><code>window.addEventListener("unhandledrejection", function(event) { ... });\nwindow.onunhandledrejection = function(event) { ...};</code></pre>The Window.onunhandledrejection property is an event handler for processing unhandledrejection events, which are raised for unhandled Promise rejections.	https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onunhandledrejection
 WindowEventHandlers.onunload	A										<pre><code>window.onunload = funcRef;\n</code></pre>The unload event is raised when the window is unloading its content and resources. The resources removal is processed after the unload event occurs.	https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onunload
-WindowTimers	A										WindowTimers contains utility methods to set and clear timers.	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers
-WindowTimers.clearInterval()	A										<pre><code>window.clearInterval(intervalID)\n</code></pre>Cancels repeated action which was set up using setInterval.	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/clearInterval
-WindowTimers.clearTimeout()	A										<pre><code>window.clearTimeout(timeoutID)\n</code></pre>Clears the delay set by WindowTimers.setTimeout().	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/clearTimeout
+WindowTimers	A										WindowTimers is a mixin used to provide utility methods which set and clear timers. No objects of this type exist; instead, its methods are available on Window for the standard browsing scope, or on WorkerGlobalScope for workers.	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers
+WindowTimers.clearInterval()	A										<pre><code>window.clearInterval(intervalID)\n</code></pre>Cancels a timed, repeating action which was previously established by a call to setInterval().	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/clearInterval
+WindowTimers.clearTimeout()	A										<pre><code>window.clearTimeout(timeoutID)\n</code></pre>Cancels a timeout previously established by calling setTimeout().	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/clearTimeout
 WindowTimers.setInterval()	A										<pre><code>var intervalID = window.setInterval(func, delay[, param1, param2, ...]);\nvar intervalID = window.setInterval(code, delay);\n</code></pre>Repeatedly calls a function or executes a code snippet, with a fixed time delay between each call. Returns an intervalID.	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setInterval
-WindowTimers.setTimeout()	A										<pre><code>var timeoutID = window.setTimeout(func, [delay, param1, param2, ...]);\nvar timeoutID = window.setTimeout(code, [delay]);\n</code></pre>Calls a function or executes a code snippet after a specified delay.	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout
+WindowTimers.setTimeout()	A										<pre><code>var timeoutID = window.setTimeout(func[, delay, param1, param2, ...]);\nvar timeoutID = window.setTimeout(code[, delay]);\n</code></pre>Sets a timer which executes a function or specified piece of code once after the timer expires.	https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout
 Worker	A										The Worker interface of the Web Workers API represents a background task that can be easily created and can send messages back to its creator. Creating a worker is as simple as calling the Worker() constructor and specifying a script to be run in the worker thread.	https://developer.mozilla.org/en-US/docs/Web/API/Worker
 Worker.onmessage	A										<pre><code>myWorker.onmessage = function(e) { ... }</code></pre>The onmessage property of the Worker interface represents an EventHandler, that is a function to be called when the message event occurs. These events are of type MessageEvent and will be called when the worker's parent receives a message (i.e. from the DedicatedWorkerGlobalScope.postMessage method.	https://developer.mozilla.org/en-US/docs/Web/API/Worker/onmessage
 Worker.postMessage()	A										<pre><code>myWorker.postMessage(aMessage, transferList);</code></pre>The postMessage() method of the Worker interface sends a message to the worker's inner scope. This accepts a single parameter, which is the data to send to the worker. The data may be any value or JavaScript object handled by the structured clone algorithm, which includes cyclical references.	https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage
@@ -3262,13 +3302,13 @@ WorkerGlobalScope.self	A										<pre><code>var selfRef = self;</code></pre>The
 WorkerLocation	A										The WorkerLocation interface defines the absolute location of the script executed by the Worker. Such an object is initialized for each worker and is available via the WorkerGlobalScope.location property obtained by calling window.self.location.	https://developer.mozilla.org/en-US/docs/Web/API/WorkerLocation
 WorkerNavigator	A										The WorkerNavigator interface represents a subset of the Navigator interface allowed to be accessed from a Worker. Such an object is initialized for each worker and is available via the WorkerGlobalScope.navigator property obtained by calling window.self.navigator.	https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator
 WorkerNavigator.permissions	A										<pre><code>permissionsObj = self.permissions\n</code></pre>The WorkerNavigator.permissions read-only property returns a Permissions object that can be used to query and update permission status of APIs covered by the Permissions API.	https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator/permissions
-WorkerNavigator.sendBeacon()	A										<pre><code> \nnavigatorself.navigator.sendBeacon(url, data);\n</code></pre>The NavigatorWorker.sendBeacon() method can be used to asynchronously transfer small HTTP data from a worker to a web server.	https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator/sendBeacon
+WorkerNavigator.sendBeacon()	A										<pre><code>self.navigator.sendBeacon(url, data);\n</code></pre>The NavigatorWorker.sendBeacon() method can be used to asynchronously transfer a small amount of data over HTTP from a worker to a web server. This is functionally equivalent to the Navigator.sendBeacon() method; see that article for additional details on what this method can be used for and why.	https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator/sendBeacon
 XMLDocument	A										The XMLDocument interface represent an XML document. It inherits from the generic Document and does not add any specific methods or properties to it: nevertheless, several algorithms behave differently with the two types of documents.	https://developer.mozilla.org/en-US/docs/Web/API/XMLDocument
 XMLDocument.load()	A										document.load() is a part of an old version of the W3C DOM Level 3 Load & Save module. Can be used with document.async to indicate whether the request is synchronous or asynchronous (the default). As of at least Gecko 1.9, this no longer supports cross-site loading of documents (Use XMLHttpRequest instead).	https://developer.mozilla.org/en-US/docs/Web/API/XMLDocument/load
 XMLHttpRequest	A										XMLHttpRequest is an API that provides client functionality for transferring data between a client and a server. It provides an easy way to retrieve data from a URL without having to do a full page refresh. This enables a Web page to update just a part of the page without disrupting what the user is doing.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
 XMLHttpRequest.abort()	A										<pre><code>xhrInstance.abort();</code></pre>The XMLHttpRequest.abort() method aborts the request if it has already been sent. When a request is aborted, its readyState is set to 0 (UNSENT), but the readystatechange event is not fired.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/abort
 XMLHttpRequest.channel	A										XMLHttpRequest.channel is an nsIChannel that used by the object when performing the request. This is null if the channel hasn't been created yet. In the case of a multi-part request, this is the initial channel, not the different parts in the multi-part request. Requires elevated privileges to access.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/channel
-XMLHttpRequest.getAllResponseHeaders()	A										<pre><code>var newRequest = request.clone();</code></pre>The XMLHttpRequest.getAllResponseHeaders() method returns all the response headers, separated by CRLF, as a string, or null if no response has been received.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
+XMLHttpRequest.getAllResponseHeaders()	A										<pre><code>var headers = request.getAllResponseHeaders();</code></pre>The XMLHttpRequest.getAllResponseHeaders() method returns all the response headers, separated by CRLF, as a string, or null if no response has been received.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
 XMLHttpRequest.getResponseHeader()	A										<pre><code>var myHeader = getResponseHeader(name);</code></pre>The XMLHttpRequest.getResponseHeader() method returns the string containing the text of the specified header. If there are multiple response headers with the same name, then their values are returned as a single concatenated string, where each value is separated from the previous one by a pair of comma and space. The getResponseHeader() method returns the value as a UTF byte squence. The search for the header name is case-insensitive.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getResponseHeader
 How to check the security state of an XMLHTTPRequest over SSL	A										Here is a an example Javascript function that prints the security details of an XMLHTTPRequest sent over SSL. The function is passed the channel property of an XMLHTTPRequest to extract the following information:	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/How_to_check_the_secruity_state_of_an_XMLHTTPRequest_over_SSL
 HTML in XMLHttpRequest	A										The W3C XMLHttpRequest specification adds HTML parsing support to XMLHttpRequest, which originally supported only XML parsing. This feature allows Web apps to obtain an HTML resource as a parsed DOM using XMLHttpRequest.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest
@@ -3298,7 +3338,7 @@ Synchronous and asynchronous requests	A										XMLHttpRequest supports both sy
 XMLHttpRequest.timeout	A										The XMLHttpRequest.timeout property is an unsigned long representing the number of milliseconds a request can take before automatically being terminated. The default value is 0, which means there is no timeout. Timeout shouldn't be used for synchronous XMLHttpRequests requests used in a document environment or it will throw an InvalidAccessError exception. When a timeout happens, a timeout event is fired.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout
 XMLHttpRequest.upload	A										The XMLHttpRequest.upload property returns an XMLHttpRequestUpload object, representing the upload process. It is an opaque object, but being an XMLHttpRequestEventTarget, event listeners can be set on it to track its process.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/upload
 Using XMLHttpRequest	A										XMLHttpRequest makes sending HTTP requests very easy.  You simply create an instance of the object, open a URL, and send the request.  The HTTP status of the result, as well as the result's contents, are available in the request object when the transaction is completed. This page outlines some of the common, and even slightly obscure, use cases for this powerful JavaScript object.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest
-Using XMLHttpRequest in IE6	A										<pre><code>See also:\n  Using XMLHttpRequest\n  Using XMLHttpRequest</code></pre>XMLHttpRequest was first introduced by Microsoft in Internet Explorer 5.0 as an ActiveX control. However, in IE7 and other browsers XMLHttpRequest is a native JavaScript object.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest_in_IE6
+Using XMLHttpRequest in IE6	A										XMLHttpRequest was first introduced by Microsoft in Internet Explorer 5.0 as an ActiveX control. However, in IE7 and other browsers XMLHttpRequest is a native JavaScript object.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest_in_IE6
 XMLHttpRequest.withCredentials	A										The XMLHttpRequest.withCredentials property is a Boolean that indicates whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials
 XMLHttpRequest()	A										<pre><code>var myRequest = new XMLHttpRequest();\n</code></pre>For details about how to use XMLHttpRequest, see Using XMLHttpRequest.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/XMLHttpRequest
 init()	A										Initializes the object for use from C++ code.	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/XMLHttpRequest.init()
@@ -3310,7 +3350,7 @@ XMLHttpRequestEventTarget.onloadstart	A										<pre><code>XMLHttpRequest.onloa
 XMLHttpRequestEventTarget.onprogress	A										<pre><code>XMLHttpRequest.onprogress = callback;</code></pre>The XMLHttpRequestEventTarget.onprogress is the function called periodically with information when an XMLHttpRequest before success completely .	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequestEventTarget/onprogress
 XMLSerializer	A										For more information about using XMLSerializer in Firefox extensions, please see the documentation for nsIDOMSerializer.	https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer
 XPathExpression	A										An XPathExpression is a compiled XPath query returned from document.createExpression(). It has a method evaluate() which can be used to execute the compiled XPath.	https://developer.mozilla.org/en-US/docs/Web/API/XPathExpression
-XPathResult	A										<pre><code>See also:\n  Document.evaluate()\n  Returns an XPathResult based on an XPath expression and other given parameters.</code></pre>Tags: XPath	https://developer.mozilla.org/en-US/docs/Web/API/XPathResult
+XPathResult	A										Returns an XPathResult based on an XPath expression and other given parameters.	https://developer.mozilla.org/en-US/docs/Web/API/XPathResult
 XSLTProcessor	A										<pre><code>new XSLTProcessor()</code></pre>An XSLTProcessor applies an XSLT stylesheet transformation to an XML document to produce a new XML document as output. It has methods to load the XSLT stylesheet, to manipulate xsl:param parameter values, and to apply the transformation to documents.	https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor
 XSLT Basic Example	A										This first example demonstrates the basics of setting up an XSLT transformation in a browser. The example will take an XML document that contains information (title, list of authors and body text) about an article and present it in an human readable form.	https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor/Basic_Example
 Browser Differences	A										Netscape 7.x (all platforms) and Internet Explorer 6 (Windows) support the W3C XSLT 1.0 standard (http://www.w3.org/TR/xslt). IE 5.0 and 5.5 (both Windows) supported only the working draft of XSLT, and thus are not compatible with XSLT 1.0 stylesheets. Netscape 6.x only partially supported XSLT 1.0.	https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor/Browser_Differences
@@ -3319,43 +3359,81 @@ Introduction	A										One noticeable trend in W3C standards has been the effor
 XSL Transformations in Mozilla FAQ	A										Make sure the mime type for both source and stylesheet are set to an XML mimetype, namely text/xml or application/xml. The XSLT namespace is http://www.w3.org/1999/XSL/Transform. Use the ?xml-stylesheet ? processing instruction instead of the non-standard xml:stylesheet. The most common cause is the MIME type handling. To find out which MIME type your server sends, look at Page Info, use extensions like LiveHTTPHeaders or a download manager like wget. Mozilla won't load XSLT stylesheets from a different domain for security reasons.	https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor/XSL_Transformations_in_Mozilla_FAQ
 JavaScript error reference	A										Errors, errors everywhere.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors
 Warning: -file- is being assigned a //# sourceMappingURL, but already has one	A										A source map has been specified more than once for a given JavaScript source.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Already_has_pragma
+warning -file- is being assigned a //# sourcemappingurl but already has one	R	Warning: -file- is being assigned a //# sourceMappingURL, but already has one										
 TypeError: invalid Array.prototype.sort argument	A										<pre><code>Invalid Cases:\nValid Cases:\n[1, 3, 2].sort();   // [1, 2, 3]\n\n\nvar cmp = { asc: (x, y) => x >= y, dsc : (x, y) => x <= y };\n[1, 3, 2].sort(cmp[this.key || 'asc']); // [1, 2, 3]\nValid Cases:\n[1, 3, 2].sort();   // [1, 2, 3]\n\n\nvar cmp = { asc: (x, y) => x >= y, dsc : (x, y) => x <= y };\n[1, 3, 2].sort(cmp[this.key || 'asc']); // [1, 2, 3]</code></pre>The argument of Array.prototype.sort() is expected to be either undefined or a function which compares its operands.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Array_sort_argument
+typeerror invalid array prototype sort argument	R	TypeError: invalid Array.prototype.sort argument										
 SyntaxError: "x" is not a legal ECMA-262 octal constant	A										Decimal literals can start with a zero (0) followed by another decimal digit, but If all digits after the leading 0 are smaller than 8, the number is interpreted as an octal number. Because this is not the case with 08 and 09, JavaScript warns about it.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Bad_octal
+syntaxerror x is not a legal ecma-262 octal constant	R	SyntaxError: "x" is not a legal ECMA-262 octal constant										
 RangeError: radix must be an integer	A										<pre><code>Invalid Cases:\nValid Cases:\n(42).toString(2);     // "101010" (binary)\n(13).toString(8);     // "15"     (octal)\n(0x42).toString(10);  // "66"     (decimal)\n(100000).toString(16) // "186a0"  (hexadecimal)\n\nValid Cases:\n(42).toString(2);     // "101010" (binary)\n(13).toString(8);     // "15"     (octal)\n(0x42).toString(10);  // "66"     (decimal)\n(100000).toString(16) // "186a0"  (hexadecimal)\n</code></pre>The optional radix parameter with the Number.prototype.toString() method has been used. This parameter must be an integer (a number) between 2 and 36 specifying the base of the number system to be used for representing numeric values.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Bad_radix
+rangeerror radix must be an integer	R	RangeError: radix must be an integer										
 SyntaxError: return not in function	A										A return or yield statement is called outside of a function. Maybe there are missing curly brackets somewhere? The return and yield statements must be in a function, because they end (or pause and resume) function execution and specify a value to be returned to the function caller.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Bad_return_or_yield
+syntaxerror return not in function	R	SyntaxError: return not in function										
 TypeError: property "x" is non-configurable and can't be deleted	A										It was attempted to delete a property, but that property is non-configurable. The configurable attribute controls whether the property can be deleted from the object and whether its attributes (other than writable) can be changed.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_delete
+typeerror property x is non-configurable and can't be deleted	R	TypeError: property "x" is non-configurable and can't be deleted										
 ReferenceError: deprecated caller or arguments usage	A										In strict mode, the Function.caller or Function.arguments properties are used and shouldn't be. They are deprecated, because they leak the function caller, are non-standard, hard to optimize and potentially a performance-harmful feature.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage
+referenceerror deprecated caller or arguments usage	R	ReferenceError: deprecated caller or arguments usage										
 SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead	A										There is a deprecated source map syntax in a JavaScript source.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
+syntaxerror using //@ to indicate sourceurl pragmas is deprecated use //# instead	R	SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead										
 SyntaxError: test for equality (==) mistyped as assignment (=)?	A										There was an assignment (=) when you would normally expect a test for equality (==). To help debugging, JavaScript (with strict warnings enabled) warns about this pattern.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Equal_as_assign
+syntaxerror test for equality (==) mistyped as assignment (=)?	R	SyntaxError: test for equality (==) mistyped as assignment (=)?										
 Warning: JavaScript 1.6's for-each-in loops are deprecated	A										JavaScript 1.6's for each (variable in obj) statement is deprecated, and will be removed in the near future.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated
+warning javascript 1.6's for-each-in loops are deprecated	R	Warning: JavaScript 1.6's for-each-in loops are deprecated										
 RangeError: invalid array length	A										<pre><code>Invalid Cases:\nValid Cases:\n[ Math.pow(2, 40) ]                     // [ 1099511627776 ]\n[ -1 ]                                  // [ -1 ]\nnew ArrayBuffer(Math.pow(2, 32) - 1)\nnew ArrayBuffer(0)\n\nlet a = [];\na.length = Math.max(0, a.length - 1);\n\nlet b = new Array(Math.pow(2, 32) - 1);\nb.length = Math.min(0xffffffff, b.length + 1);   \n\n// 0xffffffff is the hexadecimal notation for 2^32 - 1\n// which can also be written as (-1 >>> 0)\n\nValid Cases:\n[ Math.pow(2, 40) ]                     // [ 1099511627776 ]\n[ -1 ]                                  // [ -1 ]\nnew ArrayBuffer(Math.pow(2, 32) - 1)\nnew ArrayBuffer(0)\n\nlet a = [];\na.length = Math.max(0, a.length - 1);\n\nlet b = new Array(Math.pow(2, 32) - 1);\nb.length = Math.min(0xffffffff, b.length + 1);   \n\n// 0xffffffff is the hexadecimal notation for 2^32 - 1\n// which can also be written as (-1 >>> 0)\n</code></pre>An invalid array length might appear in these situations:	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length
+rangeerror invalid array length	R	RangeError: invalid array length										
 ReferenceError: invalid assignment left-hand side	A										There was an unexpected assignment somewhere. This might be due to a mismatch of a assignment operator and a comparison operator, for example. While a single "=" sign assigns a value to a variable, the "==" or "===" operators compare a value.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side
+referenceerror invalid assignment left-hand side	R	ReferenceError: invalid assignment left-hand side										
 SyntaxError: JSON.parse: bad parsing	A										JSON.parse() parses a string as JSON. This string has to be valid JSON and will throw this error if incorrect syntax was encountered.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/JSON_bad_parse
+syntaxerror json parse bad parsing	R	SyntaxError: JSON.parse: bad parsing										
 SyntaxError: Malformed formal parameter	A										<pre><code>Invalid Cases:\nValid Cases:\nvar f = Function("x, y", "return x + y;");  // correctly punctuated\n\nvar f = Function("x", "return x;");\n\n// if you can, avoid using Function - this is much faster\nvar f = function (x) { return x; };\n\nValid Cases:\nvar f = Function("x, y", "return x + y;");  // correctly punctuated\n\nvar f = Function("x", "return x;");\n\n// if you can, avoid using Function - this is much faster\nvar f = function (x) { return x; };\n</code></pre>There is a Function() constructor with at least two arguments passed in the code. The last argument is the source code for the new function you're creating. All the rest make up your new function's argument list.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_formal_parameter
+syntaxerror malformed formal parameter	R	SyntaxError: Malformed formal parameter										
 SyntaxError: missing ] after element list	A										There is an error with the array initializer syntax somewhere. Likely there is a closing bracket ("]") or a comma (",") missing.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_bracket_after_list
+syntaxerror missing ] after element list	R	SyntaxError: missing ] after element list										
 SyntaxError: missing } after property list	A										There is a mistake in the object initializer syntax somewhere. Might be in fact a missing curly bracket, but could also be a missing comma, for example. Also check if any closing curly brackets or parenthesis are in the correct order. Indenting or formatting the code a bit nicer might also help you to see through the jungle.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
+syntaxerror missing } after property list	R	SyntaxError: missing } after property list										
 SyntaxError: missing ) after argument list	A										There is an error with how a function is called. This might be a typo, a missing operator, or an unescaped string, for example.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list
+syntaxerror missing ) after argument list	R	SyntaxError: missing ) after argument list										
 SyntaxError: missing ; before statement	A										There is a semicolon (;) missing somewhere. JavaScript statements must be terminated with semicolons. Some of them are affected by automatic semicolon insertion (ASI), but in this case you need to provide a semicolon, so that JavaScript can parse the source code correctly.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement
+syntaxerror missing ; before statement	R	SyntaxError: missing ; before statement										
 TypeError: More arguments needed	A										There is an error with how a function is called. More arguments need to be provided.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/More_arguments_needed
+typeerror more arguments needed	R	TypeError: More arguments needed										
 RangeError: repeat count must be non-negative	A										<pre><code>Invalid Cases:\nValid Cases:\n'abc'.repeat(0);    // ''\n'abc'.repeat(1);    // 'abc'\n'abc'.repeat(2);    // 'abcabc'\n'abc'.repeat(3.5);  // 'abcabcabc' (count will be converted to integer)\n\nValid Cases:\n'abc'.repeat(0);    // ''\n'abc'.repeat(1);    // 'abc'\n'abc'.repeat(2);    // 'abcabc'\n'abc'.repeat(3.5);  // 'abcabcabc' (count will be converted to integer)\n</code></pre>The String.prototype.repeat() method has been used. It has a count parameter indicating the number of times to repeat the string. It must be between 0 and less than positive Infinity and cannot be a negative number. The range of allowed values can be described like this: [0, +&#8734;).	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Negative_repetition_count
+rangeerror repeat count must be non-negative	R	RangeError: repeat count must be non-negative										
 RangeError: argument is not a valid code point	A										<pre><code>Invalid Cases:\nValid Cases:\nString.fromCodePoint(42);       // "*"\nString.fromCodePoint(65, 90);   // "AZ"\nString.fromCodePoint(0x404);    // "\u0404"\nString.fromCodePoint(0x2F804);  // "\uD87E\uDC04"\nString.fromCodePoint(194564);   // "\uD87E\uDC04"\nString.fromCodePoint(0x1D306, 0x61, 0x1D307) // "\uD834\uDF06a\uD834\uDF07"\n\nValid Cases:\nString.fromCodePoint(42);       // "*"\nString.fromCodePoint(65, 90);   // "AZ"\nString.fromCodePoint(0x404);    // "\u0404"\nString.fromCodePoint(0x2F804);  // "\uD87E\uDC04"\nString.fromCodePoint(194564);   // "\uD87E\uDC04"\nString.fromCodePoint(0x1D306, 0x61, 0x1D307) // "\uD834\uDF06a\uD834\uDF07"\n</code></pre>The String.fromCodePoint() method accepts valid code points only.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_a_codepoint
+rangeerror argument is not a valid code point	R	RangeError: argument is not a valid code point										
 TypeError: "x" is not a constructor	A										<pre><code>Invalid Cases:\n\n</code></pre>There was an attempt to use an object or a variable as a constructor, but that object or variable is not a constructor. See constructor or the new operator for more information on what a constructor is.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_a_constructor
+typeerror x is not a constructor	R	TypeError: "x" is not a constructor										
 TypeError: "x" is not a function	A										It was attempted to call a value like a function, but the value is not actually a function. Some code expects you to provide a function, but that didn't happen.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_a_function
+typeerror x is not a function	R	TypeError: "x" is not a function										
 ReferenceError: "x" is not defined	A										There is a non-existent variable referenced somewhere. This variable needs to be declared, or you need make sure it is available in your current script or scope.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_defined
+referenceerror x is not defined	R	ReferenceError: "x" is not defined										
 TypeError: "x" has no properties	A										Both, null and undefined, have no properties you could access.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/No_properties
+typeerror x has no properties	R	TypeError: "x" has no properties										
 RangeError: precision is out of range	A										<pre><code>Invalid Cases:\nValid Cases:\n77.1234.toExponential(4); // 7.7123e+1\n77.1234.toExponential(2); // 7.71e+1\n\n2.34.toFixed(1); // 2.3\n2.35.toFixed(1); // 2.4 (note that it rounds up in this case)\n\n5.123456.toPrecision(5); // 5.1235\n5.123456.toPrecision(2); // 5.1\n5.123456.toPrecision(1); // 5\n\nValid Cases:\n77.1234.toExponential(4); // 7.7123e+1\n77.1234.toExponential(2); // 7.71e+1\n\n2.34.toFixed(1); // 2.3\n2.35.toFixed(1); // 2.4 (note that it rounds up in this case)\n\n5.123456.toPrecision(5); // 5.1235\n5.123456.toPrecision(2); // 5.1\n5.123456.toPrecision(1); // 5\n</code></pre>There was an out of range precision argument in one of these methods:	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Precision_range
+rangeerror precision is out of range	R	RangeError: precision is out of range										
 Error: Permission denied to access property "x"	A										There was attempt to access an object for which you have no permission. This is likely an &lt;iframe&gt; element loaded from a different domain for which you violated the same-origin policy.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
+error permission denied to access property x	R	Error: Permission denied to access property "x"										
 TypeError: "x" is read-only	A										<pre><code>Invalid Cases:\nValid Cases:\n"use strict";\nvar obj = Object.freeze({name: "Score", points: 157});\nobj = {name: obj.name, points: 0};   // replacing it with a new object works\n\n"use strict";\nvar LUNG_COUNT = 2;  // a `var` works, because it's not read-only\nLUNG_COUNT = 3;  // ok (anatomically unlikely, though)\n\nValid Cases:\n"use strict";\nvar obj = Object.freeze({name: "Score", points: 157});\nobj = {name: obj.name, points: 0};   // replacing it with a new object works\n\n"use strict";\nvar LUNG_COUNT = 2;  // a `var` works, because it's not read-only\nLUNG_COUNT = 3;  // ok (anatomically unlikely, though)\n</code></pre>The global variable or object property that was assigned to is a read-only property. (Technically, it is a non-writable data property.)	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only
+typeerror x is read-only	R	TypeError: "x" is read-only										
 SyntaxError: redeclaration of formal parameter "x"	A										The same variable name occurs as a function parameter and is then redeclared using a let assignment in a function body again. Redeclaring the same variable within the same function or block scope using let is not allowed in JavaScript.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Redeclared_parameter
+syntaxerror redeclaration of formal parameter x	R	SyntaxError: redeclaration of formal parameter "x"										
 RangeError: repeat count must be less than infinity	A										<pre><code>Invalid Cases:\nValid Cases:\n'abc'.repeat(0);    // ''\n'abc'.repeat(1);    // 'abc'\n'abc'.repeat(2);    // 'abcabc'\n'abc'.repeat(3.5);  // 'abcabcabc' (count will be converted to integer)\n\nValid Cases:\n'abc'.repeat(0);    // ''\n'abc'.repeat(1);    // 'abc'\n'abc'.repeat(2);    // 'abcabc'\n'abc'.repeat(3.5);  // 'abcabcabc' (count will be converted to integer)\n</code></pre>The String.prototype.repeat() method has been used. It has a count parameter indicating the number of times to repeat the string. It must be between 0 and less than positive Infinity and cannot be a negative number. The range of allowed values can be described like this: [0, +&#8734;).	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Resulting_string_too_large
+rangeerror repeat count must be less than infinity	R	RangeError: repeat count must be less than infinity										
 Warning: unreachable code after return statement	A										<pre><code>Invalid Cases:\nValid Cases:\nfunction f() {\n  var x = 3;\n  x += 4;\n  x -= 3;\n  return x;  // OK: return after all other statements\n}\n\nfunction f() {\n  return 3 + 4  // OK: semicolon-less return with expression on the same line\n}\n\nValid Cases:\nfunction f() {\n  var x = 3;\n  x += 4;\n  x -= 3;\n  return x;  // OK: return after all other statements\n}\n\nfunction f() {\n  return 3 + 4  // OK: semicolon-less return with expression on the same line\n}\n</code></pre>Unreachable code after a return statement might occur in these situations:	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Stmt_after_return
+warning unreachable code after return statement	R	Warning: unreachable code after return statement										
 InternalError: too much recursion	A										A function that calls itself is called a recursive function. In some ways, recursion is analogous to a loop. Both execute the same code multiple times, and both require a condition (to avoid an infinite loop, or rather, infinite recursion in this case). When there is too much or infinite recursion, JavaScript will throw this error.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Too_much_recursion
+internalerror too much recursion	R	InternalError: too much recursion										
 ReferenceError: assignment to undeclared variable "x"	A										<pre><code>Invalid Cases:\nValid Cases:\nfunction foo() {\n  "use strict";\n  var bar = true;\n}\nfoo();\nValid Cases:\nfunction foo() {\n  "use strict";\n  var bar = true;\n}\nfoo();</code></pre>A value has been assigned to an undeclared variable. In other words, there was an assignment without the var keyword. There are some differences between declared and undeclared variables, which might lead to unexpected results and that's why JavaScript presents an error in strict mode.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var
+referenceerror assignment to undeclared variable x	R	ReferenceError: assignment to undeclared variable "x"										
 ReferenceError: reference to undefined property "x"	A										<pre><code>Invalid Cases:\nValid Cases:\n"use strict";\n\nvar foo = {};\n\n// Define the bar property\n\nfoo.bar = "moon";\nconsole.log(foo.bar); // "moon"\n\n// Test to be sure bar exists before accessing it\n\nif (foo.hasOwnProperty("bar") {\n  console.log(foo.bar);\n}\nValid Cases:\n"use strict";\n\nvar foo = {};\n\n// Define the bar property\n\nfoo.bar = "moon";\nconsole.log(foo.bar); // "moon"\n\n// Test to be sure bar exists before accessing it\n\nif (foo.hasOwnProperty("bar") {\n  console.log(foo.bar);\n}</code></pre>The script attempted to access an object property which doesn't exist. There are two ways to access properties; see the property accessors reference page to learn more about them.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undefined_prop
+referenceerror reference to undefined property x	R	ReferenceError: reference to undefined property "x"										
 SyntaxError: Unexpected token	A										A specific language construct was expected, but something else was provided. This might be a simple typo.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Unexpected_token
+syntaxerror unexpected token	R	SyntaxError: Unexpected token										
 TypeError: "x" is (not) "y"	A										<pre><code>Invalid Cases:\n\n</code></pre>There was an unexpected type. This occurs oftentimes with undefined or null values.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Unexpected_type
+typeerror x is (not) y	R	TypeError: "x" is (not) "y"										
 SyntaxError: unterminated string literal	A										There is an unterminated String somewhere. String literals must be enclosed by single (') or double (") quotes. JavaScript makes no distinction between single-quoted strings and double-quoted strings. Escape sequences work in strings created with either single or double quotes. To fix this error, check if:	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Unterminated_string_literal
+syntaxerror unterminated string literal	R	SyntaxError: unterminated string literal										
 TypeError: variable "x" redeclares argument	A										<pre><code>Invalid Cases:\nValid Cases:\n"use strict";\n\nfunction f(arg) {\n  arg = "foo";\n}\n\nValid Cases:\n"use strict";\n\nfunction f(arg) {\n  arg = "foo";\n}\n</code></pre>The same variable name occurs as a function parameter and is then redeclared using a var assignment in a function body again. This might be a naming conflict and thus JavaScript warns about it.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Var_hides_argument
+typeerror variable x redeclares argument	R	TypeError: variable "x" redeclares argument										
 Functions	A										Generally speaking, a function is a "subprogram" that can be called by code external (or internal in the case of recursion) to the function. Like the program itself, a function is composed of a sequence of statements called the function body. Values can be passed to a function, and the function will return a value.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions
 Arguments object	A										<pre><code>arguments</code></pre>The arguments object is an Array -like object corresponding to the arguments passed to a function.\nThe arguments object is a local variable available within all functions. You can refer to a function's arguments within the function by using the arguments object. This object contains an entry for each argument passed to the function, the first entry's index starting at 0. For example, if a function is passed three arguments, you can refer to them as follows:\n<pre><code>arguments[0]\narguments[1]\narguments[2]\n</code></pre>	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
 arguments[@@iterator]()	A										<pre><code>arguments[Symbol.iterator]()</code></pre>The initial value of the @@iterator property is the same function object as the initial value of the Array.prototype.values property.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator
@@ -3481,14 +3559,23 @@ Global.encodeURI	A										<pre><code>Global.encodeURI (uri)</code></pre>The en
 Global.encodeURIComponent	A										<pre><code>Global.encodeURIComponent (uriComponent)</code></pre>The encodeURIComponent() function encodes a Uniform Resource Identifier (URI) component by replacing each instance of certain characters by one, two, three, or four escape sequences representing the UTF-8 encoding of the character (will only be four escape sequences for characters composed of two "surrogate" characters).	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
 Error	A										<pre><code>new Error([message[, fileName[, lineNumber]]])</code></pre>The Error constructor creates an error object. Instances of Error objects are thrown when runtime errors occur. The Error object can also be used as a base object for user-defined exceptions. See below for standard built-in error types.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 Error.prototype.columnNumber	A										The columnNumber property contains the column number in the line of the file that raised this error.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber
+error prototype columnnumber	R	Error.prototype.columnNumber										
 Error.prototype.fileName	A										The fileName property contains the path to the file that raised this error.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName
+error prototype filename	R	Error.prototype.fileName										
 Error.prototype.lineNumber	A										The lineNumber property contains the line number in the file that raised this error.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber
+error prototype linenumber	R	Error.prototype.lineNumber										
 Error.prototype.message	A										<pre><code>Error.prototype.message</code></pre>The message property is a human-readable description of the error.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message
+error prototype message	R	Error.prototype.message										
 Error.prototype.name	A										<pre><code>Error.prototype.name</code></pre>The name property represents a name for the type of error. The initial value is "Error".	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name
+error prototype name	R	Error.prototype.name										
 Error.prototype	A										<pre><code>Error.prototype</code></pre>The Error.prototype property represents the prototype for the Error constructor.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/prototype
+error prototype	R	Error.prototype										
 Error.prototype.stack	A										The non-standard stack property of Error objects offer a trace of which functions were called, in what order, from which line and file, and with what arguments. The stack string proceeds from the most recent calls to earlier ones, leading back to the original global scope call.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack
+error prototype stack	R	Error.prototype.stack										
 Error.prototype.toSource()	A										<pre><code>e.toSource()</code></pre>The toSource() method returns code that could eval to the same error.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toSource
+error prototype tosource()	R	Error.prototype.toSource()										
 Error.prototype.toString	A										<pre><code>Error.prototype.toString ( )</code></pre>The toString() method returns a string representing the specified Error object.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
+error prototype tostring	R	Error.prototype.toString										
 Global.escape	A										<pre><code>Global.escape (string)</code></pre>The deprecated escape() function computes a new string in which certain characters have been replaced by a hexadecimal escape sequence. Use encodeURI or encodeURIComponent instead.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape
 Global.eval	A										<pre><code>Global.eval (x)</code></pre>The eval() function evaluates JavaScript code represented as a string.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
 EvalError	A										<pre><code>new EvalError([message[, fileName[, lineNumber]]])</code></pre>The EvalError object indicates an error regarding the global eval() function. This exception is not thrown by JavaScript anymore, however the EvalError object remains for compatibility.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError
@@ -3560,7 +3647,7 @@ Math.max	A										<pre><code>Math.max ( [ value1 [ , value2 [ , … ] ] ] )</c
 Math.min	A										<pre><code>Math.min ( [ value1 [ , value2 [ , … ] ] ] )</code></pre>The Math.min() function returns the smallest of zero or more numbers.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min
 Math.PI	A										<pre><code>Math.PI</code></pre>The Math.PI property represents the ratio of the circumference of a circle to its diameter, approximately 3.14159:	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/PI
 Math.pow	A										<pre><code>Math.pow (x, y)</code></pre>The Math.pow() function returns the base to the exponent power, that is, base exponent.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow
-Math.random	A										<pre><code>Math.random ( )</code></pre>The Math.random() function returns a floating-point, pseudo-random number in the range (0, 1) that is, from 0 (inclusive) up to but not including 1 (exclusive), which you can then scale to your desired range. The implementation selects the initial seed to the random number generation algorithm; it cannot be chosen or reset by the user.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+Math.random	A										<pre><code>Math.random ( )</code></pre>The Math.random() function returns a floating-point, pseudo-random number in the range [ 0, 1) that is, from 0 (inclusive) up to but not including 1 (exclusive), which you can then scale to your desired range. The implementation selects the initial seed to the random number generation algorithm; it cannot be chosen or reset by the user.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
 Math.round	A										<pre><code>Math.round (x)</code></pre>The Math.round() function returns the value of a number rounded to the nearest integer.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
 Math.sign()	A										<pre><code>Math.sign(x)</code></pre>The Math.sign() function returns the sign of a number, indicating whether the number is positive, negative or zero.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
 Math.sin	A										<pre><code>Math.sin (x)</code></pre>The Math.sin() function returns the sine of a number.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin
@@ -3636,7 +3723,7 @@ Object.prototype.__lookupGetter__()	A										<pre><code>obj.__lookupGetter__(s
 Object.prototype.__lookupSetter__()	A										<pre><code>obj.__lookupSetter__(sprop)</code></pre>The __lookupSetter__ method returns the function bound as a setter to the specified property.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__
 Global.parseFloat	A										<pre><code>Global.parseFloat (string)</code></pre>The parseFloat() function parses a string argument and returns a floating point number.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat
 Global.parseInt	A										<pre><code>Global.parseInt (string , radix)</code></pre>The parseInt() function parses a string argument and returns an integer of the specified radix (the base in mathematical numeral systems).	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
-Promise	A										<pre><code>new Promise( /* executor */ function(resolve, reject) { ... } );</code></pre>The Promise object is used for asynchronous computations. A Promise represents a single asynchronous operation that hasn't completed yet, but is expected in the future.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+Promise	A										<pre><code>new Promise( /* executor */ function(resolve, reject) { ... } );</code></pre>The Promise object is used for asynchronous computations. A Promise represents a value which may be available now, or in the future, or never.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 Proxy	A										<pre><code>var p = new Proxy(target, handler);\n</code></pre>The Proxy object is used to define custom behavior for fundamental operations (e.g. property lookup, assignment, enumeration, function invocation, etc).	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 RangeError	A										<pre><code>new RangeError([message[, fileName[, lineNumber]]])</code></pre>The RangeError object indicates an error when a value is not in the set or range of allowed values.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError
 ReferenceError	A										<pre><code>new ReferenceError([message[, fileName[, lineNumber]]])</code></pre>The ReferenceError object represents an error when a non-existent variable is referenced.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError
@@ -3703,14 +3790,14 @@ String.raw()	A										<pre><code>String.raw(callSite, ...substitutions)\n\nStr
 String.prototype.repeat()	A										<pre><code>str.repeat(count)</code></pre>The repeat() method constructs and returns a new string which contains the specified number of copies of the string on which it was called, concatenated together.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat
 String.prototype.replace	A										<pre><code>String.prototype.replace (searchValue, replaceValue)</code></pre>The replace() method returns a new string with some or all matches of a pattern replaced by a replacement. The pattern can be a string or a RegExp, and the replacement can be a string or a function to be called for each match.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
 String.prototype.search	A										<pre><code>String.prototype.search (regexp)</code></pre>The search() method executes a search for a match between a regular expression and this String object.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search
-String.prototype.slice	A										<pre><code>String.prototype.slice (start, end)</code></pre>The slice() method extracts a section of a string and returns a new string.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
+String.prototype.slice	A										<pre><code>String.prototype.slice (beginSlice[, endSlice])</code></pre>The slice() method extracts a section of a string and returns a new string.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
 String.prototype.small()	A										<pre><code>str.small()</code></pre>The small() method creates a small HTML element that causes a string to be displayed in a small font.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/small
 String.prototype.split	A										<pre><code>String.prototype.split (separator, limit)</code></pre>The split() method splits a String object into an array of strings by separating the string into substrings.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split
 String.prototype.startsWith()	A										<pre><code>str.startsWith(searchString[, position])</code></pre>The startsWith() method determines whether a string begins with the characters of another string, returning true or false as appropriate.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
 String.prototype.strike()	A										<pre><code>str.strike()</code></pre>The strike() method creates a strike HTML element that causes a string to be displayed as struck-out text.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/strike
 String.prototype.sub()	A										<pre><code>str.sub()</code></pre>The sub() method creates a sub HTML element that causes a string to be displayed as subscript.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/sub
-String.prototype.substr	A										<pre><code>String.prototype.substr (start, length)</code></pre>The deprecated substr() method returns the characters in a string beginning at the specified location through the specified number of characters.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
-String.prototype.substring	A										<pre><code>String.prototype.substring (start, end)</code></pre>The substring() method returns a subset of a string between one index and another, or through the end of the string.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring
+String.prototype.substr	A										<pre><code>String.prototype.substr (start, [, length])</code></pre>The deprecated substr() method returns the characters in a string beginning at the specified location through the specified number of characters.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
+String.prototype.substring	A										<pre><code>String.prototype.substring (indexStart[, indexEnd])</code></pre>The substring() method returns a subset of a string between one index and another, or through the end of the string.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring
 String.prototype.sup()	A										<pre><code>str.sup()</code></pre>The sup() method creates a sup HTML element that causes a string to be displayed as superscript.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/sup
 String.prototype.toLocaleLowerCase	A										<pre><code>String.prototype.toLocaleLowerCase ( )</code></pre>The toLocaleLowerCase() method returns the calling string value converted to lower case, according to any locale-specific case mappings.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
 String.prototype.toLocaleUpperCase	A										<pre><code>String.prototype.toLocaleUpperCase ( )</code></pre>The toLocaleUpperCase() method returns the calling string value converted to upper case, according to any locale-specific case mappings.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
@@ -3739,7 +3826,7 @@ uneval()	A										<pre><code>uneval(object)</code></pre>The uneval() function 
 URIError	A										<pre><code>new URIError([message[, fileName[, lineNumber]]])</code></pre>The URIError object represents an error when a global URI handling function was used in a wrong way.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError
 WeakMap	A										<pre><code>new WeakMap([iterable])\n</code></pre>The WeakMap object is a collection of key/value pairs in which the keys are weakly referenced.  The keys must be objects and the values can be arbitrary values.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 WeakSet	A										<pre><code> new WeakSet([iterable]);</code></pre>The WeakSet object lets you store weakly held objects in a collection.	https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
-length	D								*[[AudioBuffer.length]] A float.\n*[[CSSValueList.length]] The length read-only property of the CSSValueList interface represents the number of CSSValue s in the list.\n*[[DataTransferItemList.length]] The DataTransferItemList.\n*[[History.length]] The History.\n*[[HTMLFormElement.length]] The HTMLFormElement.\n*[[NodeList.length]] length returns the number of items in a NodeList.\n*[[OfflineAudoContext.length]] The length property of the OfflineAudioContext interface returns an integer representing the size of the buffer in sample-frames.\n*[[SourceBufferList.length]] The length read-only property of the SourceBufferList interface returns the number of SourceBuffer objects in the list.\n*[[SpeechGrammarList.length]] The length read-only property of the SpeechGrammarList interface returns the number of SpeechGrammar objects contained in the SpeechGrammarList.\n*[[SpeechRecognitionResult.length]] The length read-only property of the SpeechRecognitionResult interface returns the length of the "array" — the number of SpeechRecognitionAlternative objects contained in the result (also referred to as "n-best alternatives".\n*[[SpeechRecognitionResultList.length]] The length read-only property of the SpeechRecognitionResultList interface returns the length of the "array" — the number of SpeechRecognitionResult objects in the list.\n*[[Storage.length]] The length read-only property of the Storage interface returns an integer representing the number of data items stored in the Storage object.\n*[[TimeRanges.length]] The TimeRanges.\n*[[TouchList.length]] This read-only property indicates the number of items (touch points) in a TouchList.\n*[[TrackDefaultList.length]] The length read-only property of the TrackDefaultList interface returns the number of TrackDefault objects in the list.\n*[[Window.length]] Returns the number of frames (either &lt;frame&gt; or &lt;iframe&gt; elements) in the window.\n*[[arguments.length]] The arguments.\n*[[array.length]] The length property represents an unsigned, 32-bit integer that is always numerically greater than the highest index in the array.\n*[[Function.length]] The length property specifies the number of arguments expected by the function.\n*[[String.prototype.length]] The length property represents the length of a string.			
+length	D								*[[AudioBuffer.length]] A float.\n*[[CSSValueList.length]] The length read-only property of the CSSValueList interface represents the number of CSSValue s in the list.\n*[[DataTransferItemList.length]] The read-only DataTransferItemList.\n*[[History.length]] The History.\n*[[HTMLFormElement.length]] The HTMLFormElement.\n*[[NodeList.length]] length returns the number of items in a NodeList.\n*[[OfflineAudoContext.length]] The length property of the OfflineAudioContext interface returns an integer representing the size of the buffer in sample-frames.\n*[[SourceBufferList.length]] The length read-only property of the SourceBufferList interface returns the number of SourceBuffer objects in the list.\n*[[SpeechGrammarList.length]] The length read-only property of the SpeechGrammarList interface returns the number of SpeechGrammar objects contained in the SpeechGrammarList.\n*[[SpeechRecognitionResult.length]] The length read-only property of the SpeechRecognitionResult interface returns the length of the "array" — the number of SpeechRecognitionAlternative objects contained in the result (also referred to as "n-best alternatives".\n*[[SpeechRecognitionResultList.length]] The length read-only property of the SpeechRecognitionResultList interface returns the length of the "array" — the number of SpeechRecognitionResult objects in the list.\n*[[Storage.length]] The length read-only property of the Storage interface returns an integer representing the number of data items stored in the Storage object.\n*[[TimeRanges.length]] The TimeRanges.\n*[[TouchList.length]] This read-only property indicates the number of items (touch points) in a TouchList.\n*[[TrackDefaultList.length]] The length read-only property of the TrackDefaultList interface returns the number of TrackDefault objects in the list.\n*[[Window.length]] Returns the number of frames (either &lt;frame&gt; or &lt;iframe&gt; elements) in the window.\n*[[arguments.length]] The arguments.\n*[[array.length]] The length property represents an unsigned, 32-bit integer that is always numerically greater than the highest index in the array.\n*[[Function.length]] The length property specifies the number of arguments expected by the function.\n*[[String.prototype.length]] The length property represents the length of a string.			
 audiobuffer length	R	AudioBuffer.length										
 cssvaluelist length	R	CSSValueList.length										
 datatransferitemlist length	R	DataTransferItemList.length										
@@ -3760,6 +3847,25 @@ arguments length	R	arguments.length
 array length	R	array.length										
 function length	R	Function.length										
 string length	R	String.prototype.length										
+bluetoothdevice name	R	BluetoothDevice.name										
+broadcastchannel name	R	BroadcastChannel.name										
+credential name	R	name										
+element name	R	Element.name										
+file name	R	File.name										
+htmlformelement name	R	HTMLFormElement.name										
+htmlslotelement name	R	HTMLSlotElement.name										
+idbdatabase name	R	IDBDatabase.name										
+idbindex name	R	IDBIndex.name										
+idbmutablefile name	R	FileHandle.name										
+idbobjectstore name	R	IDBObjectStore.name										
+performanceentry name	R	PerformanceEntry.name										
+global name	R	SharedWorkerGlobalScope.name										
+speechsynthesisevent name	R	SpeechSynthesisEvent.name										
+speechsynthesisvoice name	R	SpeechSynthesisVoice.name										
+webglactiveinfo name	R	WebGLActiveInfo.name										
+window name	R	Window.name										
+error name	R	Error.prototype.name										
+function name	R	Function.name										
 biquadfilternode type	R	BiquadFilterNode.type										
 blob type	R	Blob.type										
 credential type	R	type										
@@ -3778,24 +3884,6 @@ rtcsessiondescription type	R	RTCSessionDescription.type
 stylesheet type	R	StyleSheet.type										
 trackdefault type	R	TrackDefault.type										
 webglactiveinfo type	R	WebGLActiveInfo.type										
-bluetoothdevice name	R	BluetoothDevice.name										
-broadcastchannel name	R	BroadcastChannel.name										
-credential name	R	name										
-element name	R	Element.name										
-file name	R	File.name										
-htmlformelement name	R	HTMLFormElement.name										
-idbdatabase name	R	IDBDatabase.name										
-idbindex name	R	IDBIndex.name										
-idbmutablefile name	R	FileHandle.name										
-idbobjectstore name	R	IDBObjectStore.name										
-performanceentry name	R	PerformanceEntry.name										
-global name	R	SharedWorkerGlobalScope.name										
-speechsynthesisevent name	R	SpeechSynthesisEvent.name										
-speechsynthesisvoice name	R	SpeechSynthesisVoice.name										
-webglactiveinfo name	R	WebGLActiveInfo.name										
-window name	R	Window.name										
-error name	R	Error.prototype.name										
-function name	R	Function.name										
 onerror	D								*[[AbstractWorker.onerror]] The AbstractWorker.\n*[[GlobalEventHandlers.onerror]] An event handler for the error event.\n*[[IDBDatabase.onerror]] This example shows an IDBOpenDBRequest.\n*[[FileHandle.onerror]] Specifies an event listener to receive error events.\n*[[IDBRequest.onerror]] The following example requests a given record title, onsuccess gets the associated record from the IDBObjectStore (made available as objectStoreTitleRequest.\n*[[IDBTransaction.onerror]] In the following code snippet, we open a read/write transaction on our database and add some data to an object store.\n*[[LockedFile.onerror]] Specifies an event listener to receive error events.\n*[[MediaRecorder.onerror]] The MediaRecorder.\n*[[Notification.onerror]] The onerror property of the Notification interface specifies an event listener to receive error events.\n*[[RTCDataChannel.onerror]] The RTCDataChannel.\n*[[ServiceWorkerContainer.onerror]] The onerror property of the ServiceWorkerContainer interface is an event handler fired whenever an error event occurs in the associated service workers.\n*[[SpeechRecognition.onerror]] The onerror property of the SpeechRecognition interface represents an event handler that will run when a speech recognition error occurs (when the error event fires.\n*[[SpeechSynthesisUtterance.onerror]] The onerror property of the SpeechSynthesisUtterance interface represents an event handler that will run when an error occurs that prevents the utterance from being succesfully spoken (when the error event fires.\n*[[WorkerGlobalScope.onerror]] The onerror property of the WorkerGlobalScope interface represents an EventHandler to be called when the error event occurs and bubbles through the Worker.\n*[[XMLHttpRequestEventTarget.onerror]] The XMLHttpRequestEventTarget.			
 abstractworker onerror	R	AbstractWorker.onerror										
 global onerror	R	GlobalEventHandlers.onerror										
@@ -3852,6 +3940,21 @@ navigator id	R	Navigator.id
 presentationconnection id	R	id										
 rtcdatachannel id	R	RTCDataChannel.id										
 syncregistration id	R	id										
+get	D								*[[Clients.get()]] The get () method of the Clients interface gets a service worker client matching a given id and returns it in a Promise.\n*[[CredentialsContainer.get()]] The get() method of the CredentialsContainer interface returns a Promise to a Credential instance that matches the provided parameters.\n*[[FormData.get()]] The get() method of the FormData interface returns the first value associated with a given key from within a FormData object.\n*[[Headers.get()]] The get() method of the Headers interface returns the first value of a given header from within a Headers object.\n*[[IDBIndex.get()]] If a value is successfully found, then a structured clone of it is created and set as the result of the request object: this returns the record the key is associated with.\n*[[IDBObjectStore.get()]] If a value is successfully found, then a structured clone of it is created and set as the result of the request object.\n*[[IdentityManager.get()]] This function enables a web site to use BrowserID to authenticate its users.\n*[[MediaKeyStatusMap.get()]] The get property of the MediaKeyStatusMap interface returns the value associated with the given key or undefined if there is none.\n*[[URLSearchParams.get()]] The get() method of the URLSearchParams interface returns the first value associated to the given search parameter.\n*[[getter]] The get syntax binds an object property to a function that will be called when that property is looked up.			
+clients get	R	Clients.get()										
+credentialscontainer get	R	CredentialsContainer.get()										
+formdata get	R	FormData.get()										
+headers get	R	Headers.get()										
+idbindex get	R	IDBIndex.get()										
+idbobjectstore get	R	IDBObjectStore.get()										
+identitymanager get	R	IdentityManager.get()										
+mediakeystatusmap get	R	MediaKeyStatusMap.get()										
+urlsearchparams get	R	URLSearchParams.get()										
+functions get syntax	R	getter										
+functions get example	R	getter										
+functions syntax	R	getter										
+functions example	R	getter										
+functions get	R	getter										
 width	D								*[[DOMRectReadOnly.width]] The width read-only property of the DOMRectReadOnly interface represents the width of the DOMRect.\n*[[HTMLCanvasElement.width]] The HTMLCanvasElement.\n*[[HTMLTableElement.width]] Where width is a string representing the width in number of pixels or as a percentage value.\n*[[ImageBitmap.width]] The read-only ImageBitmap.\n*[[ImageData.width]] The readonly ImageData.\n*[[OffscreenCanvas.width]] The width property returns and sets the width of an OffscreenCanvas object.\n*[[PointerEvent.width]] The width of the pointer's contact geometry&#160;along the x-axis, measured in CSS pixels.\n*[[Screen.width]] Returns the width of the screen.\n*[[TextMetrics.width]] The readonly TextMetrics.			
 domrectreadonly width	R	DOMRectReadOnly.width										
 htmlcanvaselement width	R	HTMLCanvasElement.width										
@@ -3862,20 +3965,6 @@ offscreencanvas width	R	OffscreenCanvas.width
 pointerevent width	R	PointerEvent.width										
 screen width	R	Screen.width										
 textmetrics width	R	TextMetrics.width										
-get	D								*[[Clients.get()]] The get () method of the Clients interface gets a service worker client matching a given id and returns it in a Promise.\n*[[CredentialsContainer.get()]] The get() method of the CredentialsContainer interface returns a Promise to a Credential instance that matches the provided parameters.\n*[[FormData.get()]] The get() method of the FormData interface returns the first value associated with a given key from within a FormData object.\n*[[Headers.get()]] The get() method of the Headers interface returns the first value of a given header from within a Headers object.\n*[[IDBIndex.get()]] If a value is successfully found, then a structured clone of it is created and set as the result of the request object: this returns the record the key is associated with.\n*[[IDBObjectStore.get()]] If a value is successfully found, then a structured clone of it is created and set as the result of the request object.\n*[[IdentityManager.get()]] This function enables a web site to use BrowserID to authenticate its users.\n*[[URLSearchParams.get()]] The get() method of the URLSearchParams interface returns the first value associated to the given search parameter.\n*[[getter]] The get syntax binds an object property to a function that will be called when that property is looked up.			
-clients get	R	Clients.get()										
-credentialscontainer get	R	CredentialsContainer.get()										
-formdata get	R	FormData.get()										
-headers get	R	Headers.get()										
-idbindex get	R	IDBIndex.get()										
-idbobjectstore get	R	IDBObjectStore.get()										
-identitymanager get	R	IdentityManager.get()										
-urlsearchparams get	R	URLSearchParams.get()										
-functions get syntax	R	getter										
-functions get example	R	getter										
-functions syntax	R	getter										
-functions example	R	getter										
-functions get	R	getter										
 prototype	D								*[[Array.prototype]] The Array.\n*[[Boolean.prototype]] The Boolean.\n*[[Date.prototype]] The Date.\n*[[Error.prototype]] The Error.\n*[[Function.prototype]] The Function.\n*[[Number.prototype]] The Number.\n*[[Object.prototype]] The Object.\n*[[RegExp.prototype]] The RegExp.\n*[[String.prototype]] The String.			
 array prototype	R	Array.prototype										
 boolean prototype	R	Boolean.prototype										
@@ -3923,6 +4012,15 @@ speechgrammarlist item	R	SpeechGrammarList.item()
 speechrecognitionresult item	R	SpeechRecognitionResult.item()										
 speechrecognitionresultlist item	R	SpeechRecognitionResultList.item()										
 touchlist item	R	TouchList.item()										
+keys	D								*[[Cache.keys()]] The keys() method of the Cache interface returns a Promise that resolves to an array of Cache keys.\n*[[CacheStorage.keys()]] The keys () method of the CacheStorage interface returns a Promise that will resolve with an array containing strings corresponding to all of the named Cache objects tracked by the CacheStorage object in the order they were created.\n*[[FormData.keys()]] The FormData.\n*[[Headers.keys()]] The Headers.\n*[[MediaKeyStatusMap.keys()]] The keys property of the MediaKeyStatusMap interface returns a new Iterator object containing keys for each element in the status map, in insertion order.\n*[[URLSearchParams.keys()]] The URLSearchParams.\n*[[Array.prototype.keys()]] The keys() method returns a new Array Iterator that contains the keys for each index in the array.\n*[[Object.keys]] The Object.			
+cache keys	R	Cache.keys()										
+cachestorage keys	R	CacheStorage.keys()										
+formdata keys	R	FormData.keys()										
+headers keys	R	Headers.keys()										
+mediakeystatusmap keys	R	MediaKeyStatusMap.keys()										
+urlsearchparams keys	R	URLSearchParams.keys()										
+array keys	R	Array.prototype.keys()										
+object keys	R	Object.keys										
 readystate	D								*[[Document.readyState]] The Document.\n*[[FileReader.readyState]] Provides the current state of the reading operation.\n*[[HTMLMediaElement.readyState]] The HTMLMediaElement.\n*[[IDBRequest.readyState]] The IDBRequestReadyState of the request, which takes one of the following two values:\n*[[MediaSource.readyState]] The readyState read-only property of the MediaSource interface returns an enum representing the state of the current MediaSource.\n*[[MediaStreamTrack.readyState]] The read-only property MediaStreamTrack.\n*[[RTCDataChannel.readyState]] The read-only RTCDataChannel property readyState returns an enum of type RTCDataChannelState which indicates the state of the data channel's underlying data connection.\n*[[XMLHttpRequest.readyState]] The XMLHttpRequest.			
 document readystate	R	Document.readyState										
 filereader readystate	R	FileReader.readyState										
@@ -3978,14 +4076,6 @@ performanceresourcetiming tojson	R	PerformanceResourceTiming.toJSON()
 pushsubscription tojson	R	PushSubscription.toJSON()										
 rtcsessiondescription tojson	R	RTCSessionDescription.toJSON()										
 date tojson	R	Date.prototype.toJSON										
-keys	D								*[[Cache.keys()]] The keys() method of the Cache interface returns a Promise that resolves to an array of Cache keys.\n*[[CacheStorage.keys()]] The keys () method of the CacheStorage interface returns a Promise that will resolve with an array containing strings corresponding to all of the named Cache objects tracked by the CacheStorage object.\n*[[FormData.keys()]] The FormData.\n*[[Headers.keys()]] The Headers.\n*[[URLSearchParams.keys()]] The URLSearchParams.\n*[[Array.prototype.keys()]] The keys() method returns a new Array Iterator that contains the keys for each index in the array.\n*[[Object.keys]] The Object.			
-cache keys	R	Cache.keys()										
-cachestorage keys	R	CacheStorage.keys()										
-formdata keys	R	FormData.keys()										
-headers keys	R	Headers.keys()										
-urlsearchparams keys	R	URLSearchParams.keys()										
-array keys	R	Array.prototype.keys()										
-object keys	R	Object.keys										
 stop	D								*[[AudioBufferSourceNode.stop()]] The most simple example just stops the audio buffer playing immediately — you don't need to specify any parameters in this case:\n*[[HTMLIFrameElement.stop()]] The stop() method of the HTMLIFrameElement interface is used to stop loading the content of the iframe.\n*[[MediaRecorder.stop()]] The MediaRecorder.\n*[[MediaStreamTrack.stop()]] The MediaStreamTrack.\n*[[OscillatorNode.stop()]] The following example shows basic usage of an AudioContext to create an oscillator node.\n*[[SpeechRecognition.stop()]] The start() method of the Web Speech API stops the speech recognition service from listening to incoming audio, and attempts to return a SpeechRecognitionResult using the audio captured so far.\n*[[Window.stop()]] This method stops window loading.			
 audiobuffersourcenode stop	R	AudioBufferSourceNode.stop()										
 htmliframeelement stop	R	HTMLIFrameElement.stop()										
@@ -4001,6 +4091,20 @@ response url	R	Response.url
 api url	R	URL										
 url url	R	URL()										
 window url	R	Window.URL										
+entries	D								*[[FormData.entries()]] The FormData.\n*[[Headers.entries()]] The Headers.\n*[[MediaKeyStatusMap.entries()]] The entries() read-only property of the MediaKeyStatusMap interface returns a new Iterator object containing an array of [key, value] pairs for each element in the status map, in insertion order.\n*[[URLSearchParams.entries()]] The URLSearchParams.\n*[[Array.prototype.entries()]] The entries() method returns a new Array Iterator object that contains the key/value pairs for each index in the array.\n*[[Object.entries()]] The Object.			
+formdata entries	R	FormData.entries()										
+headers entries	R	Headers.entries()										
+mediakeystatusmap entries	R	MediaKeyStatusMap.entries()										
+urlsearchparams entries	R	URLSearchParams.entries()										
+array entries	R	Array.prototype.entries()										
+object entries	R	Object.entries()										
+values	D								*[[FormData.values()]] The FormData.\n*[[Headers.values()]] The Headers.\n*[[MediaKeyStatusMap.values()]] The values property of the MediaKeyStatusMap interface returns a new Iterator object containing values for each element in the status map, in insertion order.\n*[[URLSearchParams.values()]] The URLSearchParams.\n*[[Array.prototype.values()]] The values() method returns a new Array Iterator object that contains the values for each index in the array.\n*[[Object.values()]] The Object.			
+formdata values	R	FormData.values()										
+headers values	R	Headers.values()										
+mediakeystatusmap values	R	MediaKeyStatusMap.values()										
+urlsearchparams values	R	URLSearchParams.values()										
+array values	R	Array.prototype.values()										
+object values	R	Object.values()										
 data	D								*[[BlobEvent.data]] The BlobEvent.\n*[[ExtendableMessageEvent.data]] The data read-only property of the ExtendableMessageEvent interface returns the event's data.\n*[[ImageData.data]] The readonly ImageData.\n*[[Notification.data]] The data read-only property of the Notification interface returns a structured clone of the notification's data, as specified in the data option of the Notification() constructor.\n*[[PushEvent.data]] The data read-only property of the PushEvent interface returns a reference to a PushMessageData object containing data sent to the PushSubscription.\n*[[ServiceWorkerMessageEvent.data]] The data read-only property of the ServiceWorkerMessageEvent interface returns the event's data.			
 blobevent data	R	BlobEvent.data										
 extendablemessageevent data	R	ExtendableMessageEvent.data										
@@ -4074,23 +4178,17 @@ htmlformelement target	R	HTMLFormElement.target
 keyframeeffectreadonly target	R	KeyframeEffectReadOnly.target										
 svgaelement target	R	SVGAElement.target										
 touch target	R	Touch.target										
+has	D								*[[CacheStorage.has()]] The has() method of the CacheStorage interface returns a Promise that resolves to true if a Cache object matches the cacheName.\n*[[FormData.has()]] The has() method of the FormData interface returns a boolean stating whether a FormData object contains a certain key.\n*[[Headers.has()]] The has() method of the Headers interface returns a boolean stating whether a Headers object contains a certain header.\n*[[MediaKeyStatusMap.has()]] The has property of the MediaKeyStatusMap interface returns a Boolean asserting whether a value has been associated with the given key.\n*[[URLSearchParams.has()]] The has() method of the URLSearchParams interface returns a Boolean that indicates whether a parameter with the specified name exists.			
+cachestorage has	R	CacheStorage.has()										
+formdata has	R	FormData.has()										
+headers has	R	Headers.has()										
+mediakeystatusmap has	R	MediaKeyStatusMap.has()										
+urlsearchparams has	R	URLSearchParams.has()										
 connection onchange	R	Connection.onchange										
 global onchange	R	GlobalEventHandlers.onchange										
 networkinformation onchange	R	NetworkInformation.onchange										
 permissionstatus onchange	R	PermissionStatus.onchange										
 presentationavailability onchange	R	onchange										
-entries	D								*[[FormData.entries()]] The FormData.\n*[[Headers.entries()]] The Headers.\n*[[URLSearchParams.entries()]] The URLSearchParams.\n*[[Array.prototype.entries()]] The entries() method returns a new Array Iterator object that contains the key/value pairs for each index in the array.\n*[[Object.entries()]] The Object.			
-formdata entries	R	FormData.entries()										
-headers entries	R	Headers.entries()										
-urlsearchparams entries	R	URLSearchParams.entries()										
-array entries	R	Array.prototype.entries()										
-object entries	R	Object.entries()										
-values	D								*[[FormData.values()]] The FormData.\n*[[Headers.values()]] The Headers.\n*[[URLSearchParams.values()]] The URLSearchParams.\n*[[Array.prototype.values()]] The values() method returns a new Array Iterator object that contains the values for each index in the array.\n*[[Object.values()]] The Object.			
-formdata values	R	FormData.values()										
-headers values	R	Headers.values()										
-urlsearchparams values	R	URLSearchParams.values()										
-array values	R	Array.prototype.values()										
-object values	R	Object.values()										
 referrerpolicy	D								*[[HTMLAnchorElement.referrerPolicy]] The HTMLAnchorElement.\n*[[HTMLAreaElement.referrerPolicy]] The HTMLAreaElement.\n*[[HTMLIFrameElement.referrerPolicy]] The HTMLIFrameElement.\n*[[HTMLImageElement.referrerPolicy]] The HTMLImageElement.\n*[[Request.referrerPolicy]] The referrerPolicy read-only property of the Request interface contains the referrer policy governing the referrer for the  request.			
 htmlanchorelement referrerpolicy	R	HTMLAnchorElement.referrerPolicy										
 htmlareaelement referrerpolicy	R	HTMLAreaElement.referrerPolicy										
@@ -4136,12 +4234,6 @@ headers append	R	Headers.append()
 lockedfile append	R	LockedFile.append()										
 parentnode append	R	ParentNode.append()										
 urlsearchparams append	R	URLSearchParams.append()										
-currenttime	D								*[[Animation.currentTime]] The Animation.\n*[[AnimationPlaybackEvent.currentTime]] The currentTime read-only property of the AnimationPlaybackEvent interface represents the current time of the animation that generated the event at the moment the event is queued.\n*[[AnimationTimeline.currentTime]] The currentTime read only property of the AnimationTimeline interface returns the current time value for the associated timeline in milliseconds or null if the timeline is inactive.\n*[[AudioContext.currentTime]] Tags: API\n      \n        AudioContext\n      \n        currentTime\n      \n        Property\n      \n        Reference\n      \n        R&#233;f&#233;rence\n      \n        Web Audio API\n*[[HTMLMediaElement.currentTime]] The HTMLMediaElement.			
-animation currenttime	R	Animation.currentTime										
-animationplaybackevent currenttime	R	AnimationPlaybackEvent.currentTime										
-animationtimeline currenttime	R	AnimationTimeline.currentTime										
-audiocontext currenttime	R	AudioContext.currentTime										
-htmlmediaelement currenttime	R	HTMLMediaElement.currentTime										
 getall	D								*[[FormData.getAll()]] The getAll() method of the FormData interface returns all the values associated with a given key from within a FormData object.\n*[[Headers.getAll()]] The getAll() method of the Headers interface returns an array of all the values of a header within a Headers object with a given name.\n*[[IDBIndex.getAll()]] There is a performance cost associated with looking at the value property of a cursor, because the object is created lazily.\n*[[IDBObjectStore.getAll()]] If a value is successfully found, then a structured clone of it is created and set as the result of the request object.\n*[[URLSearchParams.getAll()]] The getAll() method of the URLSearchParams interface returns all the values associated with a given search parameter as an array.			
 formdata getall	R	FormData.getAll()										
 headers getall	R	Headers.getAll()										
@@ -4158,6 +4250,12 @@ mediarecorder state	R	MediaRecorder.state
 permissionstatus state	R	PermissionStatus.state										
 presentationconnection state	R	state										
 serviceworker state	R	ServiceWorker.state										
+onclose	D								*[[GlobalEventHandlers.onclose]] An event handler for close events sent to the window.\n*[[IDBDatabase.onclose]] A function which is called when the close event is fired.\n*[[Notification.onclose]] The onclose property of the Notification interface specifies an event listener to receive close events.\n*[[RTCDataChannel.onclose]] The RTCDataChannel.\n*[[WorkerGlobalScope.onclose]] The onclose property of the WorkerGlobalScope interface represents an EventHandler to be called when the close event occurs and bubbles through the Worker.			
+global onclose	R	GlobalEventHandlers.onclose										
+idbdatabase onclose	R	IDBDatabase.onclose										
+notification onclose	R	Notification.onclose										
+rtcdatachannel onclose	R	RTCDataChannel.onclose										
+global onclose	R	WorkerGlobalScope.onclose										
 resume	D								*[[AudioContext.resume()]] The resume() method of the AudioContext Interface resumes the progression of time in an audio context that has previously been suspended.\n*[[MediaRecorder.resume()]] The MediaRecorder.\n*[[OfflineAudioContext.resume()]] The resume() method of the OfflineAudioContext interface resumes the progression of time in an audio context that has been suspended.\n*[[SpeechSynthesis.resume()]] The resume() method of the SpeechSynthesis interface puts the SpeechSynthesis object into a non-paused state: resumes it if it was already paused.			
 audiocontext resume	R	AudioContext.resume()										
 mediarecorder resume	R	MediaRecorder.resume()										
@@ -4168,16 +4266,16 @@ canvasrenderingcontext2d filter	R	CanvasRenderingContext2D.filter
 nodeiterator filter	R	NodeIterator.filter										
 treewalker filter	R	TreeWalker.filter										
 array filter	R	Array.prototype.filter										
-has	D								*[[CacheStorage.has()]] The has() method of the CacheStorage interface returns a Promise that resolves to true if a Cache object matches the cacheName.\n*[[FormData.has()]] The has() method of the FormData interface returns a boolean stating whether a FormData object contains a certain key.\n*[[Headers.has()]] The has() method of the Headers interface returns a boolean stating whether a Headers object contains a certain header.\n*[[URLSearchParams.has()]] The has() method of the URLSearchParams interface returns a Boolean that indicates whether a parameter with the specified name exists.			
-cachestorage has	R	CacheStorage.has()										
-formdata has	R	FormData.has()										
-headers has	R	Headers.has()										
-urlsearchparams has	R	URLSearchParams.has()										
 protocol	D								*[[HTMLHyperlinkElementUtils.protocol]] The HTMLHyperlinkElementUtils.\n*[[RTCDataChannel.protocol]] The read-only RTCDataChannel property protocol returns a DOMString containing the name of the subprotocol in use.\n*[[RTCIdentityErrorEvent.protocol]] The read-only property RTCIdentityErrorEvent.\n*[[URLUtilsReadOnly.protocol]] The URLUtilsReadOnly.			
 htmlhyperlinkelementutils protocol	R	HTMLHyperlinkElementUtils.protocol										
 rtcdatachannel protocol	R	RTCDataChannel.protocol										
 rtcidentityerrorevent protocol	R	RTCIdentityErrorEvent.protocol										
 urlutilsreadonly protocol	R	URLUtilsReadOnly.protocol										
+clone	D								*[[MediaStream.clone()]] The clone() method of the MediaStream interface creates a duplicate of the MediaStream.\n*[[MediaStreamTrack.clone()]] The clone() method of the MediaStreamTrack interface creates a duplicate of the MediaStreamTrack.\n*[[Request.clone()]] The clone() method of the Request interface creates a copy of the current Request object.\n*[[Response.clone()]] The clone() method of the Response interface creates a clone of a response object, identical in every way, but stored in a different variable.			
+mediastream clone	R	MediaStream.clone()										
+mediastreamtrack clone	R	MediaStreamTrack.clone()										
+request clone	R	Request.clone()										
+response clone	R	Response.clone()										
 mediakeymessageevent message	R	message										
 positionerror message	R	PositionError.message										
 speechrecognitionerror message	R	SpeechRecognitionError.message										
@@ -4223,6 +4321,11 @@ deviceacceleration y	R	DeviceAcceleration.y
 dompointreadonly y	R	DOMPoint.y										
 domrectreadonly y	R	DOMRectReadOnly.y										
 mouseevent y	R	MouseEvent.y										
+currenttime	D								*[[Animation.currentTime]] The Animation.\n*[[AnimationPlaybackEvent.currentTime]] The currentTime read-only property of the AnimationPlaybackEvent interface represents the current time of the animation that generated the event at the moment the event is queued.\n*[[AnimationTimeline.currentTime]] The currentTime read only property of the AnimationTimeline interface returns the current time value for the associated timeline in milliseconds or null if the timeline is inactive.\n*[[HTMLMediaElement.currentTime]] The HTMLMediaElement.			
+animation currenttime	R	Animation.currentTime										
+animationplaybackevent currenttime	R	AnimationPlaybackEvent.currentTime										
+animationtimeline currenttime	R	AnimationTimeline.currentTime										
+htmlmediaelement currenttime	R	HTMLMediaElement.currentTime										
 mode	D								*[[IDBTransaction.mode]] An IDBTransactionMode object defining the mode for isolating access to data in the current object stores:\n*[[LockedFile.mode]] The mode property provides the read/write status of the LockedFile file.\n*[[Request.mode]] The mode read-only property of the Request interface contains the mode of the request (e.\n*[[SourceBuffer.mode]] The mode property of the SourceBuffer interface controls whether media segments can be appended to the SourceBuffer in any order, or in a strict sequence.			
 idbtransaction mode	R	IDBTransaction.mode										
 lockedfile mode	R	LockedFile.mode										
@@ -4237,11 +4340,6 @@ cache add	R	Cache.add()
 datatransferitemlist add	R	DataTransferItemList.add()										
 htmlselectelement add	R	HTMLSelectElement.add()										
 idbobjectstore add	R	IDBObjectStore.add()										
-onclose	D								*[[GlobalEventHandlers.onclose]] An event handler for close events sent to the window.\n*[[Notification.onclose]] The onclose property of the Notification interface specifies an event listener to receive close events.\n*[[RTCDataChannel.onclose]] The RTCDataChannel.\n*[[WorkerGlobalScope.onclose]] The onclose property of the WorkerGlobalScope interface represents an EventHandler to be called when the close event occurs and bubbles through the Worker.			
-global onclose	R	GlobalEventHandlers.onclose										
-notification onclose	R	Notification.onclose										
-rtcdatachannel onclose	R	RTCDataChannel.onclose										
-global onclose	R	WorkerGlobalScope.onclose										
 attr prefix	R	Attr.prefix										
 cssnamespacerule prefix	R	prefix										
 element prefix	R	Element.prefix										
@@ -4252,8 +4350,6 @@ replace	D								*[[DOMTokenList.replace()]] The replace () method of the DOMTok
 domtokenlist replace	R	DOMTokenList.replace()										
 location replace	R	Location.replace()										
 string replace	R	String.prototype.replace										
-using the w3c dom level 1 core example	R	Example										
-history api example	R	Ajax navigation example										
 bluetoothgattdescriptor uuid	R	uuid										
 bluetoothgattservice uuid	R	uuid										
 bluetoothremotegattcharacteristic uuid	R	BluetoothRemoteGATTCharacteristic.uuid										
@@ -4307,10 +4403,6 @@ normalize	D								*[[ConvolverNode.normalize]] A boolean.\n*[[Node.normalize()]
 convolvernode normalize	R	ConvolverNode.normalize										
 node normalize	R	Node.normalize()										
 string normalize	R	String.prototype.normalize()										
-clone	D								*[[MediaStreamTrack.clone()]] The clone() method of the MediaStreamTrack interface creates a duplicate of the MediaStreamTrack.\n*[[Request.clone()]] The clone() method of the Request interface creates a copy of the current Request object.\n*[[Response.clone()]] The clone() method of the Response interface creates a clone of a response object, identical in every way, but stored in a different variable.			
-mediastreamtrack clone	R	MediaStreamTrack.clone()										
-request clone	R	Request.clone()										
-response clone	R	Response.clone()										
 disconnect	D								*[[AudioNode.disconnect()]] undefined\n*[[BluetoothRemoteGATTServer.disconnect()]] The BluetoothRemoteGATTServer.\n*[[PeformanceObserver.disconnect()]] The disconnect() method of the PerformanceObserver interface is used to stop the performance observer from receiving any performance entry events.			
 audionode disconnect	R	AudioNode.disconnect()										
 bluetoothremotegattserver disconnect	R	BluetoothRemoteGATTServer.disconnect()										
@@ -4326,6 +4418,10 @@ canvas	D								*[[CanvasCaptureMediaStream.canvas]] The CanvasCaptureMediaStrea
 canvascapturemediastream canvas	R	CanvasCaptureMediaStream.canvas										
 canvasrenderingcontext2d canvas	R	CanvasRenderingContext2D.canvas										
 webglrenderingcontext canvas	R	WebGLRenderingContext.canvas										
+size	D								*[[Blob.size]] The Blob.\n*[[MediaKeyStatusMap.size]] The size read-only property of the MediaKeyStatusMap interface returns the number of key/value paris in the status map.\n*[[WebGLActiveInfo.size]] The read-only WebGLActiveInfo.			
+blob size	R	Blob.size										
+mediakeystatusmap size	R	MediaKeyStatusMap.size										
+webglactiveinfo size	R	WebGLActiveInfo.size										
 api performance	R	Performance										
 window performance	R	Window.performance										
 global performance	R	WorkerGlobalScope.performance										
@@ -4403,7 +4499,7 @@ htmlformelement encoding	R	HTMLFormElement.encoding
 textdecoder encoding	R	TextDecoder.encoding										
 textencoder encoding	R	TextEncoder.encoding										
 document object model introduction	R	Introduction to the DOM										
-file system api introduction	R	Introduction to the File System API										
+file and directory entries api introduction	R	Introduction to the File and Directory Entries API										
 xsltprocessor introduction	R	Introduction										
 metakey	D								*[[KeyboardEvent.metaKey]] The KeyboardEvent.\n*[[MouseEvent.metaKey]] The MouseEvent.\n*[[TouchEvent.metaKey]] A Boolean value indicating whether or not the Meta key is enabled when the touch event is created.			
 keyboardevent metakey	R	KeyboardEvent.metaKey										
@@ -4424,6 +4520,9 @@ elapsedtime	D								*[[AnimationEvent.elapsedTime]] The AnimationEvent.\n*[[Spe
 animationevent elapsedtime	R	AnimationEvent.elapsedTime										
 speechsynthesisevent elapsedtime	R	SpeechSynthesisEvent.elapsedTime										
 transitionevent elapsedtime	R	TransitionEvent.elapsedTime										
+navigator connection	R	Navigator.connection										
+presentationconnectionavailableevent connection	R	connection										
+navigator connection	R	Navigator.connection										
 load	D								*[[FontFaceSet.load()]] A Promise of an Array of FontFace loaded.\n*[[load()]] The MediaKeySession.\n*[[XMLDocument.load()]] document.			
 fontfaceset load	R	FontFaceSet.load()										
 mediakeysession load	R	load()										
@@ -4503,6 +4602,10 @@ string match	R	String.prototype.match
 node parentnode	R	Node.parentNode										
 api parentnode	R	ParentNode										
 treewalker parentnode	R	TreeWalker.parentNode()										
+host	D								*[[HTMLHyperlinkElementUtils.host]] The HTMLHyperlinkElementUtils.\n*[[ShadowRoot.host]] The host read-only property of the ShadowRoot returens the DOM element to which the ShadowRoot is attatched.\n*[[URLUtilsReadOnly.host]] The URLUtilsReadOnly.			
+htmlhyperlinkelementutils host	R	HTMLHyperlinkElementUtils.host										
+shadowroot host	R	ShadowRoot.host										
+urlutilsreadonly host	R	URLUtilsReadOnly.host										
 promiserejection promise	R	promise										
 promiserejectionevent promise	R	PromiseRejectionEvent.promise										
 global promise	R	Promise										
@@ -4552,6 +4655,8 @@ vrdisplay displayid	R	VRDisplay.displayId
 root	D								*[[NodeIterator.root]] The NodeIterator.\n*[[TreeWalker.root]] The TreeWalker.			
 nodeiterator root	R	NodeIterator.root										
 treewalker root	R	TreeWalker.root										
+example	D								*[[Compositing example]] This sample program demonstrates a number of compositing operations.\n*[[Ajax navigation example]] This is an example of an AJAX web site composed only of three pages (first_page.			
+history api example	R	Ajax navigation example										
 api extendablemessageevent	R	ExtendableMessageEvent										
 extendablemessageevent extendablemessageevent	R	ExtendableMessageEvent.ExtendableMessageEvent()										
 readastext	D								*[[FileReader.readAsText()]] The readAsText method is used to read the contents of the specified Blob or File.\n*[[LockedFile.readAsText()]] The readAsText method is used to read the content of the LockedFile object and provide the result of that reading as a string.			
@@ -4562,7 +4667,7 @@ rtciceserver credential	R	RTCIceServer.credential
 types	D								*[[DataTransfer.types]] The DataTransfer.\n*[[WebGL types]] The following types are used in WebGL interfaces.			
 datatransfer types	R	DataTransfer.types										
 webgl api types	R	WebGL types										
-shippingaddress	D								*[[PaymentRequest.shippingAddress]] The shippingAddress read-only property of the PaymentRequest interface returns a PaymentAddress object containing the shipping address provided by the user.\n*[[PaymentRespoonse.shippingAddress]] The shippingAddress read-only property of the PaymentRequest interface returns a PaymentAddress object containing the shipping address provided by the user.			
+shippingaddress	D								*[[PaymentRequest.shippingAddress]] The shippingAddress read-only property of the PaymentRequest interface returns the shipping address provided by the user.\n*[[PaymentRespoonse.shippingAddress]] The shippingAddress read-only property of the PaymentRequest interface returns a PaymentAddress object containing the shipping address provided by the user.			
 paymentrequest shippingaddress	R	PaymentRequest.shippingAddress										
 paymentresponse shippingaddress	R	PaymentRespoonse.shippingAddress										
 linewidth	D								*[[CanvasRenderingContext2D.lineWidth]] The CanvasRenderingContext2D.\n*[[WebGLRenderingContext.lineWidth()]] The WebGLRenderingContext.			
@@ -4590,8 +4695,6 @@ api urlsearchparams	R	URLSearchParams
 urlsearchparams urlsearchparams	R	URLSearchParams()										
 installtrigger enabled	R	enabled										
 mediastreamtrack enabled	R	MediaStreamTrack.enabled										
-api client	R	Client										
-fetchevent client	R	FetchEvent.client										
 createbuffer	D								*[[AudioContext.createBuffer()]] An AudioBuffer.\n*[[WebGLRenderingContext.createBuffer()]] The WebGLRenderingContext.			
 audiocontext createbuffer	R	AudioContext.createBuffer()										
 webglrenderingcontext createbuffer	R	WebGLRenderingContext.createBuffer()										
@@ -4627,6 +4730,9 @@ document onoffline	R	Document.onoffline
 global onoffline	R	WorkerGlobalScope.onoffline										
 api customevent	R	CustomEvent										
 customevent customevent	R	CustomEvent()										
+innerhtml	D								*[[Element.innerHTML]] The Element.\n*[[ShadowRoot.innerHTML]] The innerHTML property of the ShadowRoot interface sets or returns the DOM tree inside the ShadowRoot.			
+element innerhtml	R	Element.innerHTML										
+shadowroot innerhtml	R	ShadowRoot.innerHTML										
 getmodifierstate	D								*[[KeyboardEvent.getModifierState()]] The KeyboardEvent.\n*[[MouseEvent.getModifierState()]] The MouseEvent.			
 keyboardevent getmodifierstate	R	KeyboardEvent.getModifierState()										
 mouseevent getmodifierstate	R	MouseEvent.getModifierState()										
@@ -4642,6 +4748,8 @@ api document	R	Document
 window document	R	Window.document										
 api sourcebuffer	R	SourceBuffer										
 sourcebufferlist sourcebuffer	R	SourceBufferList.SourceBuffer()										
+api client	R	Client										
+fetchevent client	R	FetchEvent.client										
 left	D								*[[DOMRectReadOnly.left]] The left read-only property of the DOMRectReadOnly interface returns the left coordinate value of the DOMRect.\n*[[Screen.left]] Returns the distance in pixels from the left side of the main screen to the left side of the current screen.			
 domrectreadonly left	R	DOMRectReadOnly.left										
 screen left	R	Screen.left										
@@ -4689,6 +4797,9 @@ xmlhttprequest statustext	R	XMLHttpRequest.statusText
 push	D								*[[Navigator.push]] The Navigator.\n*[[Array.prototype.push]] The push() method adds one or more elements to the end of an array and returns the new length of the array.			
 navigator push	R	Navigator.push										
 array push	R	Array.prototype.push										
+getfrequencyresponse	D								*[[BiquadFilterNode.getFrequencyResponse()]] undefined\n*[[IIRFilterNode.getFrequencyResponse()]] undefined			
+biquadfilternode getfrequencyresponse	R	BiquadFilterNode.getFrequencyResponse()										
+iirfilternode getfrequencyresponse	R	IIRFilterNode.getFrequencyResponse()										
 api rtcsessiondescription	R	RTCSessionDescription										
 rtcsessiondescription rtcsessiondescription	R	RTCSessionDescription()										
 uniform	D								*[[WebGL2RenderingContext.uniform[1234]ui[v]()]] The WebGL2RenderingContext.\n*[[WebGLRenderingContext.uniform[1234][fi][v]()]] The WebGLRenderingContext.			
@@ -4717,6 +4828,9 @@ domexception domexception	R	DOMException()
 write	D								*[[Document.write()]] Writes a string of text to a document stream opened by document.\n*[[LockedFile.write()]] The write method is used to write some data within the file.			
 document write	R	Document.write()										
 lockedfile write	R	LockedFile.write()										
+foreach	D								*[[MediaKeyStatusMap.forEach()]] The forEach property of the MediaKeyStatusMap interface calls callback once for each key-value pair in the status map, in insertion order.\n*[[Array.prototype.forEach]] The forEach() method executes a provided function once per array element.			
+mediakeystatusmap foreach	R	MediaKeyStatusMap.forEach()										
+array foreach	R	Array.prototype.forEach										
 array map	R	Array.prototype.map										
 global map	R	Map										
 max	D								*[[DeviceProximityEvent.max]] The max property provides the maximum sensing distance the sensor is able to report, in centimeters.\n*[[Math.max]] The Math.			
@@ -4755,9 +4869,6 @@ audiocontext suspend	R	AudioContext.suspend()
 offlineaudiocontext suspend	R	suspend										
 storage localstorage	R	LocalStorage										
 window localstorage	R	Window.localStorage										
-size	D								*[[Blob.size]] The Blob.\n*[[WebGLActiveInfo.size]] The read-only WebGLActiveInfo.			
-blob size	R	Blob.size										
-webglactiveinfo size	R	WebGLActiveInfo.size										
 parsefloat	D								*[[Number.parseFloat()]] The Number.\n*[[Global.parseFloat]] The parseFloat() function parses a string argument and returns a floating point number.			
 number parsefloat	R	Number.parseFloat()										
 global parsefloat	R	Global.parseFloat										
@@ -4800,6 +4911,9 @@ document createevent	R	Document.createEvent()
 event createevent	R	Event.createEvent()										
 api screen	R	Screen										
 window screen	R	Window.screen										
+region	D								*[[MouseEvent.region]] The MouseEvent.\n*[[PaymentAddress.region]] The region read-only property of the PaymentAddress interface returns a string containing a top level administrative subdivision of the country, for example, a state, province, oblast, or prefecture.			
+mouseevent region	R	MouseEvent.region										
+paymentaddress region	R	PaymentAddress.region										
 getelementsbytagnamens	D								*[[Document.getElementsByTagNameNS()]] Returns a list of elements with the given tag name belonging to the given namespace.\n*[[Element.getElementsByTagNameNS()]] The Element.			
 document getelementsbytagnamens	R	Document.getElementsByTagNameNS()										
 element getelementsbytagnamens	R	Element.getElementsByTagNameNS()										
@@ -4894,7 +5008,7 @@ mediastreamtrackevent mediastreamtrackevent	R	MediaStreamTrackEvent()
 hash	D								*[[HTMLHyperlinkElementUtils.hash]] The HTMLHyperlinkElementUtils.\n*[[URLUtilsReadOnly.hash]] The URLUtilsReadOnly.			
 htmlhyperlinkelementutils hash	R	HTMLHyperlinkElementUtils.hash										
 urlutilsreadonly hash	R	URLUtilsReadOnly.hash										
-shippingoption	D								*[[PaymentRequest.shippingOption]] The shippingOption read-only property of the PaymentRequest interface returns the ID of the selected shipping option.\n*[[PaymentResponse.shippingOption]] The shippingOption read-only property of the PaymentRequest interface returns the ID attribute of the shipping option selected by the user.			
+shippingoption	D								*[[PaymentRequest.shippingOption]] The shippingOption read-only property of the PaymentRequest interface returns the shipping option selected by the user.\n*[[PaymentResponse.shippingOption]] The shippingOption read-only property of the PaymentRequest interface returns the ID attribute of the shipping option selected by the user.			
 paymentrequest shippingoption	R	PaymentRequest.shippingOption										
 paymentresponse shippingoption	R	PaymentResponse.shippingOption										
 promiserejection reason	R	reason										
@@ -4992,7 +5106,7 @@ sharedworker sharedworker	R	SharedWorker()
 sign	D								*[[SubtleCrypto.sign()]] The SubtleCrypto.\n*[[Math.sign()]] The Math.			
 subtlecrypto sign	R	SubtleCrypto.sign()										
 math sign	R	Math.sign()										
-kind	D								*[[DataTransferItem.kind]] The DataTransferItem.\n*[[MediaStreamTrack.kind]] The read-only property MediaStreamTrack.			
+kind	D								*[[DataTransferItem.kind]] The read-only DataTransferItem.\n*[[MediaStreamTrack.kind]] The read-only property MediaStreamTrack.			
 datatransferitem kind	R	DataTransferItem.kind										
 mediastreamtrack kind	R	MediaStreamTrack.kind										
 api mediarecorder	R	MediaRecorder										
@@ -5059,8 +5173,6 @@ mediastreamtrack muted	R	muted
 reverse	D								*[[Animation.reverse()]] None.\n*[[Array.prototype.reverse]] The reverse() method reverses an array in place.			
 animation reverse	R	Animation.reverse()										
 array reverse	R	Array.prototype.reverse										
-navigator connection	R	Navigator.connection										
-presentationconnectionavailableevent connection	R	connection										
 context	D								*[[AudioNode.context]] An AudioContext object.\n*[[Request.context]] The context read-only property of the Request interface contains the context of the Request (e.			
 audionode context	R	AudioNode.context										
 request context	R	Request.context										
@@ -5093,8 +5205,6 @@ element getelementsbyclassname	R	Element.getElementsByClassName()
 indexof	D								*[[Array.prototype.indexOf]] The indexOf() method returns the first index at which a given element can be found in the array, or -1 if it is not present.\n*[[String.prototype.indexOf]] The indexOf() method returns the index within the calling String object of the first occurrence of the specified value, starting the search at fromIndex.			
 array indexof	R	Array.prototype.indexOf										
 string indexof	R	String.prototype.indexOf										
-api format	R	SVGAltGlyphDefElement										
-svgaltglyphelement format	R	format										
 api passwordcredential	R	PasswordCredential										
 passwordcredential passwordcredential	R	PasswordCredential										
 presentationconnection binarytype	R	binaryType										
@@ -5282,9 +5392,6 @@ string repeat	R	String.prototype.repeat()
 flush	D								*[[LockedFile.flush()]] The flush method is used to ensure any change made to a file is properly written on disk.\n*[[WebGLRenderingContext.flush()]] The WebGLRenderingContext.			
 lockedfile flush	R	LockedFile.flush()										
 webglrenderingcontext flush	R	WebGLRenderingContext.flush()										
-host	D								*[[HTMLHyperlinkElementUtils.host]] The HTMLHyperlinkElementUtils.\n*[[URLUtilsReadOnly.host]] The URLUtilsReadOnly.			
-htmlhyperlinkelementutils host	R	HTMLHyperlinkElementUtils.host										
-urlutilsreadonly host	R	URLUtilsReadOnly.host										
 global registration	R	ServiceWorkerGlobalScope.registration										
 syncevent registration	R	registration										
 api rtcdatachannelevent	R	RTCDataChannelEvent										
@@ -5352,6 +5459,7 @@ vertexattribipointer	R	WebGL2RenderingContext.vertexAttribIPointer()
 rowIndex	R	HTMLTableRowElement.rowIndex										
 htmltablerowelement rowindex	R	HTMLTableRowElement.rowIndex										
 rowindex	R	HTMLTableRowElement.rowIndex										
+api mediatrackconstraints	R	MediaTrackConstraints										
 api vrpose	R	VRPose										
 string tolocaleuppercase	R	String.prototype.toLocaleUpperCase										
 tolocaleuppercase	R	String.prototype.toLocaleUpperCase										
@@ -5501,6 +5609,8 @@ object isfrozen	R	Object.isFrozen
 isfrozen	R	Object.isFrozen										
 console warn	R	Console.warn()										
 warn	R	Console.warn()										
+paymentaddress phone	R	PaymentAddress.phone										
+phone	R	PaymentAddress.phone										
 webgl2renderingcontext endtransformfeedback	R	WebGL2RenderingContext.endTransformFeedback()										
 endtransformfeedback	R	WebGL2RenderingContext.endTransformFeedback()										
 seekable	R	HTMLMediaElement.seekable										
@@ -5521,7 +5631,8 @@ range setstart	R	Range.setStart()
 setstart	R	Range.setStart()										
 document characterset	R	Document.characterSet										
 characterset	R	Document.characterSet										
-api mousewheelevent	R	MouseWheelEvent										
+document doctype	R	Document.doctype										
+doctype	R	Document.doctype										
 ontouchend	R	GlobalEventHandlers.ontouchend										
 global globaleventhandlers.ontouchend	R	GlobalEventHandlers.ontouchend										
 setInterval	R	WindowTimers.setInterval()										
@@ -5553,6 +5664,8 @@ createrange	R	Document.createRange()
 absolute	R	DeviceOrientationEvent.absolute										
 deviceorientationevent absolute	R	DeviceOrientationEvent.absolute										
 absolute	R	DeviceOrientationEvent.absolute										
+rtcpeerconnection connectionstate	R	RTCPeerConnection.connectionState										
+connectionstate	R	RTCPeerConnection.connectionState										
 timeranges end	R	TimeRanges.end()										
 end	R	TimeRanges.end()										
 bluetoothdevice gatt	R	BluetoothDevice.gatt										
@@ -5863,6 +5976,7 @@ api deviceproximityevent	R	DeviceProximityEvent
 webrtc api session lifetime	R	Lifetime of a WebRTC session										
 session lifetime	R	Lifetime of a WebRTC session										
 api imagebitmaprenderingcontext	R	ImageBitmapRenderingContext										
+api mutationobserver	R	MutationObserver										
 api compositionevent	R	CompositionEvent										
 api bluetoothdevice	R	BluetoothDevice										
 errors no properties	R	TypeError: "x" has no properties										
@@ -6079,9 +6193,6 @@ cryptokey extractable	R	CryptoKey.extractable
 extractable	R	CryptoKey.extractable										
 api gainnode	R	GainNode										
 api speechrecognitionevent	R	SpeechRecognitionEvent										
-innerHTML	R	Element.innerHTML										
-element innerhtml	R	Element.innerHTML										
-innerhtml	R	Element.innerHTML										
 requestPointerLock	R	Element.requestPointerLock()										
 element requestpointerlock	R	Element.requestPointerLock()										
 requestpointerlock	R	Element.requestPointerLock()										
@@ -6241,7 +6352,6 @@ webgl2renderingcontext createsampler	R	WebGL2RenderingContext.createSampler()
 createsampler	R	WebGL2RenderingContext.createSampler()										
 date toisostring	R	Date.prototype.toISOString										
 toisostring	R	Date.prototype.toISOString										
-api mutationobserver	R	MutationObserver										
 webglrenderingcontext deletebuffer	R	WebGLRenderingContext.deleteBuffer()										
 deletebuffer	R	WebGLRenderingContext.deleteBuffer()										
 ondblclick	R	GlobalEventHandlers.ondblclick										
@@ -6294,6 +6404,8 @@ paymentresponse methodname	R	PaymentResponse.methodName
 methodname	R	PaymentResponse.methodName										
 idbindex unique	R	IDBIndex.unique										
 unique	R	IDBIndex.unique										
+paymentaddress addressline	R	PaymentAddress.addressLine										
+addressline	R	PaymentAddress.addressLine										
 api mediakeymessageevent	R	MediaKeyMessageEvent										
 zoom	R	HTMLIFrameElement.zoom()										
 htmliframeelement zoom	R	HTMLIFrameElement.zoom()										
@@ -6325,9 +6437,8 @@ document linkcolor	R	Document.linkColor
 linkcolor	R	Document.linkColor										
 document exitpointerlock	R	Document.exitPointerLock()										
 exitpointerlock	R	Document.exitPointerLock()										
-animate	R	Element.animate()										
-element animate	R	Element.animate()										
-animate	R	Element.animate()										
+web workers api functions and classes available to workers	R	Functions and classes available to Web Workers										
+functions and classes available to workers	R	Functions and classes available to Web Workers										
 audiocontext createchannelmerger	R	AudioContext.createChannelMerger()										
 createchannelmerger	R	AudioContext.createChannelMerger()										
 webgl2renderingcontext beginquery	R	WebGL2RenderingContext.beginQuery()										
@@ -6356,6 +6467,8 @@ api speechrecognitionalternative	R	SpeechRecognitionAlternative
 bluetoothremotegattcharacteristic properties	R	BluetoothRemoteGATTCharacteristic.properties										
 properties	R	BluetoothRemoteGATTCharacteristic.properties										
 api idbcursorwithvalue	R	IDBCursorWithValue										
+mediastreamtrack getcapabilities	R	MediaStreamTrack.getCapabilities()										
+getcapabilities	R	MediaStreamTrack.getCapabilities()										
 api broadcast channel api	R	Broadcast Channel API										
 currentTarget	R	Event.currentTarget										
 event currenttarget	R	Event.currentTarget										
@@ -6611,9 +6724,6 @@ global string	R	String
 document elementsfrompoint	R	Document.elementsFromPoint()										
 elementsfrompoint	R	Document.elementsFromPoint()										
 mediakeymessageevent messagetype	R	messageType										
-getFrequencyResponse	R	BiquadFilterNode.getFrequencyResponse()										
-biquadfilternode getfrequencyresponse	R	BiquadFilterNode.getFrequencyResponse()										
-getfrequencyresponse	R	BiquadFilterNode.getFrequencyResponse()										
 insertRow	R	HTMLTableElement.insertRow()										
 htmltableelement insertrow	R	HTMLTableElement.insertRow()										
 insertrow	R	HTMLTableElement.insertRow()										
@@ -6662,8 +6772,7 @@ xmlhttprequest getallresponseheaders	R	XMLHttpRequest.getAllResponseHeaders()
 getallresponseheaders	R	XMLHttpRequest.getAllResponseHeaders()										
 date getutcdate	R	Date.prototype.getUTCDate										
 getutcdate	R	Date.prototype.getUTCDate										
-document doctype	R	Document.doctype										
-doctype	R	Document.doctype										
+api mousewheelevent	R	MouseWheelEvent										
 vrdisplaycapabilities maxlayers	R	VRDisplayCapabilities.maxLayers										
 maxlayers	R	VRDisplayCapabilities.maxLayers										
 idbcursor primarykey	R	IDBCursor.primaryKey										
@@ -6681,11 +6790,15 @@ sourcebuffer appendwindowstart	R	SourceBuffer.appendWindowStart
 appendwindowstart	R	SourceBuffer.appendWindowStart										
 webgl2renderingcontext clearbuffer	R	WebGL2RenderingContext.clearBuffer[fiuv]()										
 clearbuffer	R	WebGL2RenderingContext.clearBuffer[fiuv]()										
+notification badge	R	Notification.badge										
+badge	R	Notification.badge										
 api svganimatedinteger	R	SVGAnimatedInteger										
 isCollapsed	R	Selection.isCollapsed										
 selection iscollapsed	R	Selection.isCollapsed										
 iscollapsed	R	Selection.isCollapsed										
-global globaleventhandlers.onended	R	GlobalEventHandlers.onended										
+slot	R	Element.slot										
+element slot	R	Element.slot										
+slot	R	Element.slot										
 installtrigger install	R	install										
 speechrecognitionresult isfinal	R	SpeechRecognitionResult.isFinal										
 isfinal	R	SpeechRecognitionResult.isFinal										
@@ -6766,13 +6879,15 @@ addelement	R	DataTransfer.addElement()
 idbversionchangerequest setversion	R	IDBVersionChangeRequest.setVersion()										
 setversion	R	IDBVersionChangeRequest.setVersion()										
 api svgmatrix	R	SVGMatrix										
+channelCountMode	R	AudioNode.channelCountMode										
+audionode channelcountmode	R	AudioNode.channelCountMode										
+channelcountmode	R	AudioNode.channelCountMode										
 api svgellipseelement	R	SVGEllipseElement										
 vrpose angularvelocity	R	VRPose.angularVelocity										
 angularvelocity	R	VRPose.angularVelocity										
 requestFullscreen	R	Element.requestFullscreen()										
 element requestfullscreen	R	Element.requestFullscreen()										
 requestfullscreen	R	Element.requestFullscreen()										
-api rtcsessiondescriptioncallback	R	RTCSessionDescriptionCallback										
 api webgl2renderingcontext	R	WebGL2RenderingContext										
 ontouchend	R	GlobalEventHandlers.ontouchend										
 global ontouchend	R	GlobalEventHandlers.ontouchend										
@@ -6826,8 +6941,6 @@ screen lockorientation	R	Screen.lockOrientation()
 lockorientation	R	Screen.lockOrientation()										
 permissions query	R	Permissions.query()										
 query	R	Permissions.query()										
-array foreach	R	Array.prototype.forEach										
-foreach	R	Array.prototype.forEach										
 autofocus	R	HTMLSelectElement.autofocus										
 htmlselectelement autofocus	R	HTMLSelectElement.autofocus										
 autofocus	R	HTMLSelectElement.autofocus										
@@ -6860,7 +6973,6 @@ iscontextlost	R	WebGLRenderingContext.isContextLost()
 Q	R	BiquadFilterNode.Q										
 biquadfilternode q	R	BiquadFilterNode.Q										
 q	R	BiquadFilterNode.Q										
-api notifyaudioavailableevent	R	NotifyAudioAvailableEvent										
 api textmetrics	R	TextMetrics										
 api oes standard derivatives	R	OES_standard_derivatives										
 webgl2renderingcontext begintransformfeedback	R	WebGL2RenderingContext.beginTransformFeedback()										
@@ -7052,6 +7164,8 @@ datetimeformat	R	Intl.DateTimeFormat
 webglrenderingcontext bindtexture	R	WebGLRenderingContext.bindTexture()										
 bindtexture	R	WebGLRenderingContext.bindTexture()										
 api domimplementation	R	DOMImplementation										
+paymentaddress city	R	PaymentAddress.city										
+city	R	PaymentAddress.city										
 initEvent	R	Event.initEvent()										
 event initevent	R	Event.initEvent()										
 initevent	R	Event.initEvent()										
@@ -7071,6 +7185,7 @@ createmediastreamsource	R	AudioContext.createMediaStreamSource()
 speechsynthesis speaking	R	SpeechSynthesis.speaking										
 speaking	R	SpeechSynthesis.speaking										
 api readablebytestream	R	ReadableByteStream										
+api speechsynthesisevent	R	SpeechSynthesisEvent										
 object setprototypeof	R	Object.setPrototypeOf()										
 setprototypeof	R	Object.setPrototypeOf()										
 document createcdatasection	R	Document.createCDATASection()										
@@ -7198,7 +7313,7 @@ threshold	R	DynamicsCompressorNode.threshold
 sourcebuffer videotracks	R	SourceBuffer.videoTracks										
 videotracks	R	SourceBuffer.videoTracks										
 api htmlheadingelement	R	HTMLHeadingElement										
-api htmldocument	R	HTMLDocument										
+global globaleventhandlers.onended	R	GlobalEventHandlers.onended										
 api cryptokey	R	CryptoKey										
 ratio	R	DynamicsCompressorNode.ratio										
 dynamicscompressornode ratio	R	DynamicsCompressorNode.ratio										
@@ -7314,9 +7429,6 @@ drawarraysinstanced	R	WebGL2RenderingContext.drawArraysInstanced()
 range extractcontents	R	Range.extractContents()										
 extractcontents	R	Range.extractContents()										
 api svghkernelement	R	SVGHKernElement										
-region	R	MouseEvent.region										
-mouseevent region	R	MouseEvent.region										
-region	R	MouseEvent.region										
 onpointercancel	R	GlobalEventHandlers.onpointercancel										
 global onpointercancel	R	GlobalEventHandlers.onpointercancel										
 onpointercancel	R	GlobalEventHandlers.onpointercancel										
@@ -7510,6 +7622,8 @@ api idbenvironment	R	IDBEnvironment
 typeMustMatch	R	HTMLObjectElement.typeMustMatch										
 htmlobjectelement typemustmatch	R	HTMLObjectElement.typeMustMatch										
 typemustmatch	R	HTMLObjectElement.typeMustMatch										
+notification actions	R	Notification.actions										
+actions	R	Notification.actions										
 webgl2renderingcontext getindexedparameter	R	WebGL2RenderingContext.getIndexedParameter()										
 getindexedparameter	R	WebGL2RenderingContext.getIndexedParameter()										
 audioparam setvalueattime	R	AudioParam.setValueAtTime()										
@@ -7582,6 +7696,8 @@ console groupend	R	Console.groupEnd()
 groupend	R	Console.groupEnd()										
 idbenvironment indexeddb	R	IDBEnvironment.indexedDB										
 indexeddb	R	IDBEnvironment.indexedDB										
+paymentaddress recipient	R	PaymentAddress.recipient										
+recipient	R	PaymentAddress.recipient										
 api navigatorplugins	R	NavigatorPlugins										
 pointerBeforeReferenceNode	R	NodeIterator.pointerBeforeReferenceNode										
 nodeiterator pointerbeforereferencenode	R	NodeIterator.pointerBeforeReferenceNode										
@@ -7720,7 +7836,8 @@ getdata	R	DataTransfer.getData()
 webglrenderingcontext viewport	R	WebGLRenderingContext.viewport()										
 viewport	R	WebGLRenderingContext.viewport()										
 api domstringmap	R	DOMStringMap										
-audiocontext createiirfilter	R	CreateIIRFilter										
+audiocontext createiirfilter	R	AudioContext.createIIRFilter()										
+createiirfilter	R	AudioContext.createIIRFilter()										
 onunload	R	WindowEventHandlers.onunload										
 windoweventhandlers onunload	R	WindowEventHandlers.onunload										
 onunload	R	WindowEventHandlers.onunload										
@@ -7780,7 +7897,6 @@ onlostpointercapture	R	Element.onlostpointercapture
 initUIEvent	R	UIEvent.initUIEvent()										
 uievent inituievent	R	UIEvent.initUIEvent()										
 inituievent	R	UIEvent.initUIEvent()										
-api portcollection	R	PortCollection										
 mimeTypes	R	NavigatorPlugins.mimeTypes										
 navigatorplugins mimetypes	R	NavigatorPlugins.mimeTypes										
 mimetypes	R	NavigatorPlugins.mimeTypes										
@@ -7830,8 +7946,9 @@ acosh	R	Math.acosh()
 children	R	ParentNode.children										
 parentnode children	R	ParentNode.children										
 children	R	ParentNode.children										
-string fromcharcode	R	String.fromCharCode										
-fromcharcode	R	String.fromCharCode										
+deltaZ	R	WheelEvent.deltaZ										
+wheelevent deltaz	R	WheelEvent.deltaZ										
+deltaz	R	WheelEvent.deltaZ										
 fftSize	R	AnalyserNode.fftSize										
 analysernode fftsize	R	AnalyserNode.fftSize										
 fftsize	R	AnalyserNode.fftSize										
@@ -7958,6 +8075,7 @@ opendialog	R	Window.openDialog()
 api pushregistrationmanager	R	PushRegistrationManager										
 oes vertex array object deletevertexarrayoes	R	OES_vertex_array_object.deleteVertexArrayOES()										
 deletevertexarrayoes	R	OES_vertex_array_object.deleteVertexArrayOES()										
+api file and directory entries api	R	File and Directory Entries API										
 document compatmode	R	Document.compatMode										
 compatmode	R	Document.compatMode										
 mozL10n	R	Navigator.mozL10n										
@@ -8014,9 +8132,7 @@ addfromuri	R	SpeechGrammarList.addFromURI()
 htmlFor	R	HTMLLabelElement.htmlFor										
 htmllabelelement htmlfor	R	HTMLLabelElement.htmlFor										
 htmlfor	R	HTMLLabelElement.htmlFor										
-channelCountMode	R	AudioNode.channelCountMode										
-audionode channelcountmode	R	AudioNode.channelCountMode										
-channelcountmode	R	AudioNode.channelCountMode										
+api css counter styles	R	CSS Counter Styles										
 regexp lastindex	R	regexp.lastIndex										
 lastindex	R	regexp.lastIndex										
 loopEnd	R	AudioBufferSourceNode.loopEnd										
@@ -8063,9 +8179,12 @@ disable	R	WebGLRenderingContext.disable()
 errors missing parenthesis after argument list	R	SyntaxError: missing ) after argument list										
 missing parenthesis after argument list	R	SyntaxError: missing ) after argument list										
 api bluetoothcharacteristicproperties	R	BluetoothCharacteristicProperties										
-api speechsynthesisevent	R	SpeechSynthesisEvent										
+mediastreamtrack applyconstraints	R	MediaStreamTrack.applyConstraints()										
+applyconstraints	R	MediaStreamTrack.applyConstraints()										
 object preventextensions	R	Object.preventExtensions										
 preventextensions	R	Object.preventExtensions										
+paymentaddress organization	R	PaymentAddress.organization										
+organization	R	PaymentAddress.organization										
 webglrenderingcontext stencilfunc	R	WebGLRenderingContext.stencilFunc()										
 stencilfunc	R	WebGLRenderingContext.stencilFunc()										
 ontouchmove	R	GlobalEventHandlers.ontouchmove										
@@ -8166,6 +8285,7 @@ speechgrammar weight	R	SpeechGrammar.weight
 weight	R	SpeechGrammar.weight										
 array reduce	R	Array.prototype.reduce										
 reduce	R	Array.prototype.reduce										
+paymentaddress paymentaddress.country	R	PaymentAddress.country										
 api vrdisplay	R	VRDisplay										
 webglrenderingcontext attachshader	R	WebGLRenderingContext.attachShader()										
 attachshader	R	WebGLRenderingContext.attachShader()										
@@ -8187,6 +8307,8 @@ onfocus	R	GlobalEventHandlers.onfocus
 vrdisplaycapabilities hasexternaldisplay	R	VRDisplayCapabilities.hasExternalDisplay										
 hasexternaldisplay	R	VRDisplayCapabilities.hasExternalDisplay										
 api midioutputmap	R	MIDIOutputMap										
+string fromcharcode	R	String.fromCharCode										
+fromcharcode	R	String.fromCharCode										
 offsetX	R	MouseEvent.offsetX										
 mouseevent offsetx	R	MouseEvent.offsetX										
 offsetx	R	MouseEvent.offsetX										
@@ -8250,8 +8372,6 @@ api linkstyle	R	LinkStyle
 api positionerror	R	PositionError										
 htmloptionelement option	R	Option()										
 option	R	Option()										
-web workers api functions and classes available to workers	R	Functions and classes available to Web Workers										
-functions and classes available to workers	R	Functions and classes available to Web Workers										
 api presentationrequest	R	PresentationRequest										
 api documenttype	R	DocumentType										
 onpointermove	R	GlobalEventHandlers.onpointermove										
@@ -8262,6 +8382,8 @@ getframebufferattachmentparameter	R	WebGLRenderingContext.getFramebufferAttachme
 api eventtarget	R	EventTarget										
 api speechrecognitionresult	R	SpeechRecognitionResult										
 api svggelement	R	SVGGElement										
+paymentaddress careof	R	PaymentAddress.careOf										
+careof	R	PaymentAddress.careOf										
 global undefined	R	Global.undefined										
 undefined	R	Global.undefined										
 devicePixelRatio	R	Window.devicePixelRatio										
@@ -8376,7 +8498,6 @@ errors resulting string too large	R	RangeError: repeat count must be less than i
 resulting string too large	R	RangeError: repeat count must be less than infinity										
 xmlhttprequest withcredentials	R	XMLHttpRequest.withCredentials										
 withcredentials	R	XMLHttpRequest.withCredentials										
-getFrequencyResponse	R	IIRFilterNode.getFrequencyResponse()										
 iirfilternode getfrequencyresponse()	R	IIRFilterNode.getFrequencyResponse()										
 getfrequencyresponse()	R	IIRFilterNode.getFrequencyResponse()										
 webgl2renderingcontext createquery	R	WebGL2RenderingContext.createQuery()										
@@ -8389,6 +8510,9 @@ assertion	R	RTCIdentityEvent.assertion
 rtcidentityevent assertion	R	RTCIdentityEvent.assertion										
 assertion	R	RTCIdentityEvent.assertion										
 api cssstyledeclaration	R	CSSStyleDeclaration										
+deltaX	R	WheelEvent.deltaX										
+wheelevent deltax	R	WheelEvent.deltaX										
+deltax	R	WheelEvent.deltaX										
 speechrecognition serviceuri	R	SpeechRecognition.serviceURI										
 serviceuri	R	SpeechRecognition.serviceURI										
 subtlecrypto wrapkey	R	SubtleCrypto.wrapKey()										
@@ -8470,9 +8594,6 @@ permissions api using the permissions api	R	Using the Permissions API
 api animationeffecttiming	R	AnimationEffectTiming										
 webglrenderingcontext activetexture	R	WebGLRenderingContext.activeTexture()										
 activetexture	R	WebGLRenderingContext.activeTexture()										
-nodePrincipal	R	Node.nodePrincipal										
-node nodeprincipal	R	Node.nodePrincipal										
-nodeprincipal	R	Node.nodePrincipal										
 captureEvents	R	Window.captureEvents()										
 window captureevents	R	Window.captureEvents()										
 captureevents	R	Window.captureEvents()										
@@ -8485,6 +8606,7 @@ document laststylesheetset	R	Document.lastStyleSheetSet
 laststylesheetset	R	Document.lastStyleSheetSet										
 api svganimatedpreserveaspectratio	R	SVGAnimatedPreserveAspectRatio										
 api htmltablerowelement	R	HTMLTableRowElement										
+api presentationconnectionclosedevent	R	PresentationConnectionClosedEvent										
 tutorial applying styles and colors	R	Applying styles and colors										
 api mediakeystatusmap	R	MediaKeyStatusMap										
 audiocontext creategain	R	AudioContext.createGain()										
@@ -8659,6 +8781,7 @@ api validitystate	R	ValidityState
 api htmlhyperlinkelementutils	R	HTMLHyperlinkElementUtils										
 performance onresourcetimingbufferfull	R	Performance.onresourcetimingbufferfull										
 onresourcetimingbufferfull	R	Performance.onresourcetimingbufferfull										
+api htmldocument	R	HTMLDocument										
 ext disjoint timer query createqueryext	R	EXT_disjoint_timer_query.createQueryEXT()										
 createqueryext	R	EXT_disjoint_timer_query.createQueryEXT()										
 pointerLockElement	R	Document.pointerLockElement										
@@ -8675,6 +8798,7 @@ api installtrigger	R	InstallTrigger
 vendor	R	Navigator.vendor										
 navigator vendor	R	Navigator.vendor										
 vendor	R	Navigator.vendor										
+svgaltglyphelement format	R	format										
 touch radiusy	R	Touch.radiusY										
 radiusy	R	Touch.radiusY										
 document evaluate	R	Document.evaluate()										
@@ -8709,6 +8833,8 @@ getDefaultComputedStyle	R	Window.getDefaultComputedStyle()
 window getdefaultcomputedstyle	R	Window.getDefaultComputedStyle()										
 getdefaultcomputedstyle	R	Window.getDefaultComputedStyle()										
 canvas api manipulating video using canvas	R	Manipulating video using canvas										
+paymentaddress dependentlocality	R	PaymentAddress.dependentLocality										
+dependentlocality	R	PaymentAddress.dependentLocality										
 array some	R	Array.prototype.some										
 some	R	Array.prototype.some										
 fetch api using fetch	R	Using Fetch										
@@ -8807,6 +8933,8 @@ simple rtcdatachannel sample	R	A simple RTCDataChannel sample
 importNode	R	Document.importNode()										
 document importnode	R	Document.importNode()										
 importnode	R	Document.importNode()										
+paymentaddress languagecode	R	PaymentAddress.languageCode										
+languagecode	R	PaymentAddress.languageCode										
 rows	R	HTMLTableElement.rows										
 htmltableelement rows	R	HTMLTableElement.rows										
 rows	R	HTMLTableElement.rows										
@@ -8902,8 +9030,8 @@ date tolocaleformat	R	Date.prototype.toLocaleFormat()
 tolocaleformat	R	Date.prototype.toLocaleFormat()										
 xsltprocessor basic example	R	XSLT Basic Example										
 basic example	R	XSLT Basic Example										
-api media streams api	R	MediaStream API										
-media streams api	R	MediaStream API										
+api media streams api	R	Media Capture and Streams API (Media Streams)										
+media streams api	R	Media Capture and Streams API (Media Streams)										
 api htmllielement	R	HTMLLIElement										
 tutorial advanced animations	R	Advanced animations										
 sourcebuffer timestampoffset	R	SourceBuffer.timestampOffset										
@@ -9054,6 +9182,9 @@ pannernode distancemodel	R	PannerNode.distanceModel
 distancemodel	R	PannerNode.distanceModel										
 api gamepadevent	R	GamepadEvent										
 api svgvkernelement	R	SVGVKernElement										
+assignedSlot	R	Element.assignedSlot										
+element assignedslot	R	Element.assignedSlot										
+assignedslot	R	Element.assignedSlot										
 onplay	R	GlobalEventHandlers.onplay										
 global globaleventhandlers.onplay	R	GlobalEventHandlers.onplay										
 download	R	HTMLIFrameElement.download()										
@@ -9095,7 +9226,7 @@ spacing	R	KeyframeEffectReadOnly.spacing
 mediasource activesourcebuffers	R	MediaSource.activeSourceBuffers										
 activesourcebuffers	R	MediaSource.activeSourceBuffers										
 bluetoothadvertisingdata txpower	R	txPower										
-api presentationconnectionclosedevent	R	PresentationConnectionClosedEvent										
+api mediatracksupportedconstraints	R	MediaTrackSupportedConstraints										
 identitymanager logout	R	IdentityManager.logout()										
 logout	R	IdentityManager.logout()										
 datatransfer mozcursor	R	DataTransfer.mozCursor										
@@ -9149,6 +9280,8 @@ api vrlayer	R	VRLayer
 onbeforeprint	R	WindowEventHandlers.onbeforeprint										
 windoweventhandlers onbeforeprint	R	WindowEventHandlers.onbeforeprint										
 onbeforeprint	R	WindowEventHandlers.onbeforeprint										
+paymentaddress postalcode	R	PaymentAddress.postalCode										
+postalcode	R	PaymentAddress.postalCode										
 mediakeys setservercertificate	R	setServerCertificate()										
 setservercertificate	R	setServerCertificate()										
 array sort	R	Array.prototype.sort										
@@ -9328,7 +9461,6 @@ onpointerout	R	GlobalEventHandlers.onpointerout
 keyframeeffect setkeyframes	R	KeyframeEffect.setKeyframes()										
 setkeyframes	R	KeyframeEffect.setKeyframes()										
 api bluetooth	R	Bluetooth										
-api file system api	R	File System API										
 webgl2renderingcontext getbuffersubdata	R	WebGL2RenderingContext.getBufferSubData()										
 getbuffersubdata	R	WebGL2RenderingContext.getBufferSubData()										
 mediaGroup	R	HTMLMediaElement.mediaGroup										
@@ -9341,7 +9473,8 @@ htmliframeelement getcangoback	R	HTMLIFrameElement.getCanGoBack()
 getcangoback	R	HTMLIFrameElement.getCanGoBack()										
 rtcpeerconnection addicecandidate	R	RTCPeerConnection.addIceCandidate()										
 addicecandidate	R	RTCPeerConnection.addIceCandidate()										
-paymentrequest onshippingoptionchange	R	onshippingoptionchange										
+paymentrequest onshippingoptionchange	R	PaymentRequest.onshippingoptionchange										
+onshippingoptionchange	R	PaymentRequest.onshippingoptionchange										
 screen availwidth	R	Screen.availWidth										
 availwidth	R	Screen.availWidth										
 indexeddb api using javascript generators in firefox	R	Using JavaScript Generators in Firefox										
@@ -9377,8 +9510,7 @@ window getcomputedstyle	R	Window.getComputedStyle()
 getcomputedstyle	R	Window.getComputedStyle()										
 webrtc api coding guide	R	WebRTC coding guide										
 coding guide	R	WebRTC coding guide										
-rtcpeerconnection connectionstate	R	RTCPeerConnection.connectionState										
-connectionstate	R	RTCPeerConnection.connectionState										
+api mediatracksettings	R	MediaTrackSettings										
 networkinformation downlinkmax	R	NetworkInformation.downlinkMax										
 downlinkmax	R	NetworkInformation.downlinkMax										
 api svgtransformlist	R	SVGTransformList										
@@ -9440,10 +9572,10 @@ navigator mozpermissionsettings	R	Navigator.mozPermissionSettings
 mozpermissionsettings	R	Navigator.mozPermissionSettings										
 oncuechange	R	GlobalEventHandlers.oncuechange										
 global globaleventhandlers.oncuechange	R	GlobalEventHandlers.oncuechange										
-file mozfullpath	R	File.mozFullPath										
-mozfullpath	R	File.mozFullPath										
 xmlhttprequest overridemimetype	R	XMLHttpRequest.overrideMimeType()										
 overridemimetype	R	XMLHttpRequest.overrideMimeType()										
+paymentaddress country	R	PaymentAddress.country										
+country	R	PaymentAddress.country										
 xmlhttprequest synchronous and asynchronous requests	R	Synchronous and asynchronous requests										
 file getasdataurl	R	File.getAsDataURL()										
 getasdataurl	R	File.getAsDataURL()										
@@ -9483,6 +9615,7 @@ onchargingchange	R	BatteryManager.onchargingchange
 drawRangeElements	R	WebGL2RenderingContext.drawRangeElements()										
 webgl2renderingcontext drawrangeelements	R	WebGL2RenderingContext.drawRangeElements()										
 drawrangeelements	R	WebGL2RenderingContext.drawRangeElements()										
+api htmlslotelement	R	HTMLSlotElement										
 registerElement	R	Document.registerElement()										
 document registerelement	R	Document.registerElement()										
 registerelement	R	Document.registerElement()										
@@ -9556,7 +9689,9 @@ webglrenderingcontext getcontextattributes	R	WebGLRenderingContext.getContextAtt
 getcontextattributes	R	WebGLRenderingContext.getContextAttributes()										
 web audio api porting webkitaudiocontext code to standards based audiocontext	R	Porting webkitAudioContext code to standards based AudioContext										
 api idbdatabasesync	R	IDBDatabaseSync										
-element attachshadow	R	attachShadow										
+attachShadow	R	Element.attachShadow()										
+element attachshadow	R	Element.attachShadow()										
+attachshadow	R	Element.attachShadow()										
 idbkeyrange loweropen	R	IDBKeyRange.lowerOpen										
 loweropen	R	IDBKeyRange.lowerOpen										
 date getdate	R	Date.prototype.getDate										
@@ -9828,15 +9963,14 @@ autoplay	R	HTMLMediaElement.autoplay
 global typedarray	R	TypedArray										
 api htmlcollection	R	HTMLCollection										
 api htmlsourceelement	R	HTMLSourceElement										
-deltaX	R	WheelEvent.deltaX										
-wheelevent deltax	R	WheelEvent.deltaX										
-deltax	R	WheelEvent.deltaX										
+paymentaddress sortingcode	R	PaymentAddress.sortingCode										
+sortingcode	R	PaymentAddress.sortingCode										
 deltaY	R	WheelEvent.deltaY										
 wheelevent deltay	R	WheelEvent.deltaY										
 deltay	R	WheelEvent.deltaY										
-deltaZ	R	WheelEvent.deltaZ										
-wheelevent deltaz	R	WheelEvent.deltaZ										
-deltaz	R	WheelEvent.deltaZ										
+assignedNodes	R	HTMLSlotElement.assignedNodes()										
+htmlslotelement assignednodes	R	HTMLSlotElement.assignedNodes()										
+assignednodes	R	HTMLSlotElement.assignedNodes()										
 clientHeight	R	Element.clientHeight										
 element clientheight	R	Element.clientHeight										
 clientheight	R	Element.clientHeight										


### PR DESCRIPTION

- [x]  issue #372 : Make redirects stripping '.', '"' and ':', and lowercasing the article titles
- [x] Fix for articles without summary|description syntax 

IA Page: http://duck.co/ia/view/mdnjs