### PR TITLE
Fix  #423: PyPi: Switch to use new Fathead Template Elements

### DIFF
--- a/lib/fathead/py_pi/parse.py
+++ b/lib/fathead/py_pi/parse.py
@@ -17,15 +17,18 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
         summary = package_info['summary']
         if not summary or summary == 'UNKNOWN':
             continue
+        
+        abstract_lines.append('<section class="prog__container"><p>')
         abstract_lines.append(re.sub(r'\s', ' ', summary, flags=re.MULTILINE | re.UNICODE))
-        #abstract_lines.append('Downloads in the last month: %s' % package_info['downloads']['last_month'])
+        abstract_lines.append('</p>')
 
         for classifier in package_info['classifiers']:
             if classifier.startswith('Development Status'):
-                abstract_lines.append('Development status: %s' % classifier.split(' - ')[-1])
+                abstract_lines.append('<p>Development status: %s</p>' % classifier.split(' - ')[-1])
                 break
 
         abstract_lines.append("<pre><code>pip install " + package_info['name'] + "</code></pre>")
+        abstract_lines.append("</section>")
 
         official_site = ''
         # check for real links. We can get stuff like 'unknown', '404' in here
@@ -44,7 +47,7 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
             official_site,  # External links (ignored)
             '',  # Disambiguation (ignored)
             '',  # No images
-            '<br>'.join(abstract_lines),
+            ''.join(abstract_lines),
             urllib.quote(package_info['package_url'], safe='/:'),  # Source url
         ]))
         out_file.write('\n')


### PR DESCRIPTION
Fixes  #423
Use the fathead template for formatting the output. Details in https://docs.duckduckhack.com/resources/fathead-overview.html#formatting-the-abstract.
Old output:
`Create CovJSON files from common scientific data formats<br>Development status:
 Beta<br><pre><code>pip install pycovjson</code></pre>`
New output:
`<section class="prog__container"><p>Create CovJSON files from common scientific
 data formats</p><p>Development status: Beta</p><pre><code>pip install pycovjson</code></pre></section>`
Issue:https://github.com/duckduckgo/zeroclickinfo-fathead/issues/423
IA Page: http://duck.co/ia/view/py_pi
Maintainer: @ezgraphs

CC: @pjhampton 