### PR TITLE
Fix #436: NodeJS: Updatde Parser to latest API

### DIFF
--- a/lib/fathead/nodejs_ref/parse.js
+++ b/lib/fathead/nodejs_ref/parse.js
@@ -66,7 +66,7 @@ function getURLId(arr, sigs) {
 //   methods
 //   modules
 
-var sectionKeys = ['globals','vars','methods','modules'],
+var sectionKeys = ['globals','vars','modules'],
     childKeys = ['methods','properties','classes','events','classMethods'];
 
 function processNode(node, nodes) {


### PR DESCRIPTION
- Removed "methods" key, which was removed from documentation. 

It's childrens (setTimeout, clearTimeout, setInterval, dns.lookupService) were moved to other sections (globals and module)

---
Fixes #436 
http://duck.co/ia/view/node_js

