### PR TITLE
Add httplib2 Fathead (closes #452)

### DIFF
--- a/lib/fathead/httplib2/README.txt
+++ b/lib/fathead/httplib2/README.txt
@@ -1,0 +1,6 @@
+Dependencies
+
+- python3
+- beautifulsoup4==4.5.1
+- wget
+

--- a/lib/fathead/httplib2/fetch.sh
+++ b/lib/fathead/httplib2/fetch.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p download
+cd download
+wget https://httplib2.readthedocs.io/en/latest/libhttplib2.html

--- a/lib/fathead/httplib2/parse.py
+++ b/lib/fathead/httplib2/parse.py
@@ -25,7 +25,7 @@ def parse_dl(dl):
     description = re.sub(r'\s', ' ', description, flags=flags).strip()
     description = '<p>{}</p>'.format(description)
 
-    abstract = '<div class="prog__container">{}{}</div>'.format(signature,
+    abstract = '<section class="prog__container">{}{}</section>'.format(signature,
                                                                 description)
 
     return (abstract, link)

--- a/lib/fathead/httplib2/parse.py
+++ b/lib/fathead/httplib2/parse.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+import re
+from bs4 import BeautifulSoup
+
+doc_file = "download/libhttplib2.html"
+external_link = "https://httplib2.readthedocs.io/en/latest/libhttplib2.html"
+
+
+# Makes the abstract formatted from a definition line, returns a tuple
+# with the abstract and the source url
+def parse_dl(dl):
+    # extract the link before the signature to crop the pilcrow (¶)
+    link = dl.dt.find("a", {'class': 'headerlink'}).extract()
+    link = '{}{}'.format(external_link, link['href'])
+
+    flags = re.MULTILINE | re.UNICODE
+
+    signature = dl.dt.text
+    signature = re.sub(r'\s', ' ', signature, flags=flags).strip()
+    signature = '<pre><code>{}</code></pre>'.format(signature)
+
+    description = dl.dd.p.text
+    description = re.sub(r'\s', ' ', description, flags=flags).strip()
+    description = '<p>{}</p>'.format(description)
+
+    abstract = '<div class="prog__container">{}{}</div>'.format(signature,
+                                                                description)
+
+    return (abstract, link)
+
+
+with open(doc_file, 'r') as doc:
+    html = doc.read()
+
+soup_data = BeautifulSoup(html, 'html.parser')
+# remove unrelevant descriptions
+for dl in soup_data.find_all('dl', {'class': 'describe'}):
+    dl.extract()
+# remove version information
+soup_data.find('div', {'class': 'rst-versions'}).extract()
+
+# All the definition lines from the documentation page
+dls = soup_data.find_all('dl')
+
+lines = []
+for dl in dls:
+    abstract, url = parse_dl(dl)
+    line = [
+        dl.dt['id'],    # full article title
+        'A',            # type of article
+        '',             # not redirect, ignored
+        '',             # ignore
+        '',             # no category
+        '',             # ignore
+        '',             # related topics
+        '',             # ignore
+        external_link,  # external links
+        '',             # not disambiguation, ignored
+        '',             # no image
+        abstract,       # abstract
+        url             # url
+    ]
+    lines.append(u'\t'.join(line))
+
+
+print('\n'.join(lines))

--- a/lib/fathead/httplib2/parse.sh
+++ b/lib/fathead/httplib2/parse.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 parse.py > output.txt
+

--- a/lib/fathead/httplib2/requirements.txt
+++ b/lib/fathead/httplib2/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4==4.5.1 


### PR DESCRIPTION
To help me for this issue, I've watched how it was done for the [beautifulsoup fathead](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/lib/fathead/beautifulsoup/parse.py).
In particular, I didn't add any categories because it didn't seem appropriate.

For the abstract, there are two other things I'm not sure about:
- There were no examples of codes for the lib functions, so I've put the complete signature in the code part and the first paragraph of the description as the abstract.
- I've removed the HTML tags of the description and took only the first paragraph, but it might be problematic, for example [here](https://httplib2.readthedocs.io/en/latest/libhttplib2.html#httplib2.Http.force_exception_to_status_code) and [there](https://httplib2.readthedocs.io/en/latest/libhttplib2.html#httplib2.ProxyInfo) because the description is incomplete without the second paragraph, but it was either that or putting the entire description, which can be a bit long, like [here](https://httplib2.readthedocs.io/en/latest/libhttplib2.html#httplib2.Http.request).

Lastly, it doesn't work with python2 because of a mixup between byte strings and unicode strings that I wasn't able to resolve.

Let me know if I can improve anything.

Fixes #452 

cc @pjhampton 

---

Instant Answer Page: https://duck.co/ia/view/httplib2
