### PR TITLE
Java: Fixes #201 - Updated parser to exclude type parameters in class names

### DIFF
--- a/lib/fathead/java/parse_utils.py
+++ b/lib/fathead/java/parse_utils.py
@@ -3,6 +3,7 @@ from bs4 import BeautifulSoup
 import os
 import sys
 import string
+import re
 
 BASE_JAVADOC_URL = "https://docs.oracle.com/javase/8/docs/api/index.html?"
 BASE_LOCAL_JAVADOC_DIR = "./docs/api/"
@@ -38,6 +39,7 @@ def cutlength(description):
 
 def remove_keywords(line):
   if isinstance(line, basestring):
+    line = re.sub(r'<\w,?\w?>', '', line)
     return line.replace('Class ', '').replace('Enum ', '').replace('Interface ', '').replace('Annotation Type ', '')
   else:
     return ''

--- a/lib/fathead/java/test_parse_utils.py
+++ b/lib/fathead/java/test_parse_utils.py
@@ -12,6 +12,9 @@ class TestParse(unittest.TestCase):
     self.assertEqual("StandardCopyOption", parse_utils.remove_keywords("Enum StandardCopyOption"))
     self.assertEqual("DriverAction", parse_utils.remove_keywords("Interface DriverAction"))
     self.assertEqual("Native", parse_utils.remove_keywords("Annotation Type Native"))
+    self.assertEqual("ArrayList", parse_utils.remove_keywords("ArrayList<E>"))
+    self.assertEqual("DefaultRowSorter", parse_utils.remove_keywords("DefaultRowSorter<M,I>"))
+    self.assertEqual("ThreadLocal", parse_utils.remove_keywords("ThreadLocal<T>"))
 
     self.assertEqual('', parse_utils.remove_keywords([]))
 


### PR DESCRIPTION
Fixes #201: Java: Doesn't trigger on some terms
This fix contains 2 changes.  
1. parse_utils.py is updated to exclude type parameters in class names.  As an example, `'ArrayList<E>'` is now included as 'ArrayList' in the output file.  This ensures users searching for 'ArrayList' will get a result back from this java fathead IA.  
2. test_parse_utils.py is updated with relevant test cases for this change.

IA Page: http://duck.co/ia/view/java
Maintainer: @boyter
Cc: @marti1125 