### PR TITLE
PyPi: Fix #423 Switch to use new Fathead Template Elements - follow up

### DIFF
--- a/lib/fathead/py_pi/requirements.txt
+++ b/lib/fathead/py_pi/requirements.txt
@@ -1,0 +1,2 @@
+gevent==1.0.1
+requests==2.3.0


### PR DESCRIPTION
## Type of Change

- [ ] New Instant Answer
- [X] Improvement
    - [ ] Bug fix
    - [X] Enhancement
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.)

## Description of new Instant Answer, or changes

<!-- What does this new Instant Answer do? -->
<!-- OR -->
<!-- What changes does this PR introduce? -->
As requested by @moollaza in https://github.com/duckduckgo/zeroclickinfo-fathead/pull/440, add requirements.txt to simplify the setup of the environment needed to execute this fathead.
## Related Issues and Discussions
In the Readme.md file, it is incorrecly stated that you should install the python-dev packet with 'sudo apt-get install python-dev'. But on codio, apt-get cannot be used, so you need to use 'parts install' instead. I don't remember if I had to install the python-dev package manually, or if it was already installed. At least, I needed to install 'pip' using 'parts'.
Is that something I should update in this PR as well?
<!--- If fixing a bug with a related issue -->
<!--- Please link to the issue here: -->
<!-- E.g. "Fixes #1234" -->

## People to notify

<!-- Please @mention any relevant people/organizations here:-->


---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->

IA Page: https://duck.co/ia/view/py_pi

<!-- All new Instant Answers should be related to the Programming Mission -->
<!-- They should also have a related Project on the DuckDuckHack Forum -->
<!-- New Instant Answers related to the Programming Mission, without a forum topic will be put on hold -->

<!-- 	More Info: https://forum.duckduckhack.com/t/duckduckhack-programming-mission-overview/53 -->

Forum Topic:

