### PR TITLE
PerlDoc: Remove leading (empty) <p> tags from functions

### DIFF
--- a/lib/fathead/perl_doc/Parsers/parse.pl
+++ b/lib/fathead/perl_doc/Parsers/parse.pl
@@ -538,6 +538,8 @@ sub build_description_functions {
     my $syntax = Mojo::DOM->new("<pre>$syntaxes[0]</pre>");
     map { $syntax->at('pre')->append_content("<br />$_") }
         @syntaxes[1..$#syntaxes];
+    # Remove empty <p> tags that are sometimes included
+    $description =~ s{<p>\s*</p>}{}g;
     $description = $syntax->to_string . $description;
     return $description;
 }


### PR DESCRIPTION
<!--- Please use the appropriate format for your Pull Request title: -->

<!-- For a Bug Fix: -->
<!-- {IA Name}: {Description of change} -->

<!-- For a New Instant Answer: -->
<!-- New {IA Name} Fathead" -->

<!-- For anything else: -->
<!-- {Tests/Docs/Other}: {Short Description} -->


## Type of Change

<!-- Place and 'X' in the correct box (E.g `[X] Improvement`) -->

- [ ] New Instant Answer
- [x] Improvement
    - [ ] Bug fix
    - [ ] Enhancement
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.)

## Description of new Instant Answer, or changes

Removes leading `<p>` tags after function syntax.

<!-- What does this new Instant Answer do? -->
<!-- OR -->
<!-- What changes does this PR introduce? -->

## Related Issues and Discussions

<!--- If fixing a bug with a related issue -->
<!--- Please link to the issue here: -->
<!-- E.g. "Fixes #1234" -->

## People to notify

@moollaza 

<!-- Please @mention any relevant people/organizations here:-->


---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->

IA Page: https://duck.co/ia/view/perl_doc

<!-- All new Instant Answers should be related to the Programming Mission -->
<!-- They should also have a related Project on the DuckDuckHack Forum -->
<!-- New Instant Answers related to the Programming Mission, without a forum topic will be put on hold -->

<!-- 	More Info: https://forum.duckduckhack.com/t/duckduckhack-programming-mission-overview/53 -->

Forum Topic:

