### PR TITLE
Create NEW_IA_TEMPLATE.md, based off PJHampton's template

### DIFF
--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -1,5 +1,5 @@
 # New {IA Name} Fathead Instant Answer
-Help DuckDuckGo become the best Search Engine for {Language} developers!
+Help us make DuckDuckGo the best search engine for programmers!
 
 
 ### What do I need to know?
@@ -15,10 +15,10 @@ You can learn more about Fathead, and the `output.txt` syntax [**here**](https:/
 
 ### The data source :rocket:
 {URL to Data Source}
-
+<!-- ^^^ FILL THIS IN ^^^ -->
 
 ### What is the Goal?
-As part of our Programming Mission, we're aiming to reach 100% Instant Answer (IA) coverage for searches related to programmiing languages by creating new Instant Answers, and improving existing ones.
+As part of our [Programming Mission](https://forum.duckduckhack.com/t/duckduckhack-programming-mission-overview/53), we're aiming to reach 100% Instant Answer (IA) coverage for searches related to programming languages by creating new Instant Answers, and improving existing ones.
 
 Here are some Fathead examples:
 
@@ -34,16 +34,16 @@ Here are some Fathead examples:
 
 
 ## Get Started
-- [ ] 1) Claim this issue (Comment Below)
+- [ ] 1) Claim this issue by commenting below
 - [ ] 2) Review our [Contributing Guide](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/CONTRIBUTING.md)
-- [ ] 3) [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html), then fork this repository
-- [ ] 4) Create the Fathead
-- [ ] 5) Create a Pull Request
-- [ ] 6) Ping @{Language Leader Handle} for a review
+- [ ] 3) [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html), and fork this repository
+- [ ] 4) Create a new Instant Answer Page: https://duck.co/ia/new_ia
+- [ ] 5) Create the Fathead
+- [ ] 6) Create a Pull Request
+- [ ] 7) Ping @{Language Leader Handle} for a review
+<!-- ^^^ FILL THIS IN ^^^ -->
 
-
-## Questions?
-- Join [DuckDuckHack Slack](https://quackslack.herokuapp.com/) and ask questions
-- Ping one of the [Community Leaders](https://duck.co/help/community/community-leaders)
-- Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/)
+## Resources
+- Join [DuckDuckHack Slack](https://quackslack.herokuapp.com/) to ask questions
+- Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/) to discuss project planning and Instant Answer metrics
 - Read the [DuckDuckHack Documentation](https://docs.duckduckhack.com/) for technical help

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -2,12 +2,16 @@
 Help DuckDuckGo become the best Search Engine for {Language} developers!
 
 
+### What is the Goal?
+As part of our Programming Mission, we're aiming to reach 100% Instant Answer (IA) coverage for {Language Name}-related searches by creating new Instant Answers, and improving existing ones.
+
+
 ### What do I need to know?
-Fathead developers need to know how to code in **Python**, **Ruby**, **Perl**, or **JavaScript**. 
+You'll need to know how to code in **Python**, **Ruby**, **Perl**, or **JavaScript**.
 
 
 ### What am I doing?
-Write a script that scrapes or downloads the {Name of Documentation Source} docs, parses it, and generates an **output.txt** file containing the parsed documentation.
+You will write a script that scrapes or downloads the {Name of Documentation Source} docs, and generates an **output.txt** file containing the parsed documentation.
 
 You can learn more about Fathead Instant Answers, and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html)!
 
@@ -16,29 +20,26 @@ You can learn more about Fathead Instant Answers, and the `output.txt` syntax [*
 {URL to Data Source}
 
 
-## The Goal
-Help *improve {Language Name} language search results* on DuckDuckGo as part of our Programming Mission! We're trying to reach 100% Instant Answer (IA) coverage for {Language Name}-related searches by creating new Instant Answers, and improving existing ones.
+### Example Instant Answer:
 
-
-#### Example Instant Answer:
-<!-- Visit https://duck.co/ia?repo=fathead and filter by Topic to find examples -->
-
-{Instant Answer Name}
-- [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/{ID})
-- [Example Query](https://duckduckgo.com?q=example+query)
-- [IA Page](https://duck.co/ia/view/{ID})
+- Ruby Docs Fathead
+    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/ruby) | [Example Query](https://duckduckgo.com/?q=array+bsearch&ia=about) | [IA Page](https://duck.co/ia/view/ruby)
+- Perl Docs Fathead
+    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/perl_doc) | [Example Query](https://duckduckgo.com/?q=perl+foreach&t=vivaldi&ia=about) | [IA Page](https://duck.co/ia/view/perl_doc)
+- Python Docs Fathead
+    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/python) | [Example Query](https://duckduckgo.com/?q=python+print&ia=about) | [IA Page](https://duck.co/ia/view/python)
 
 [See more related Instant Answers](https://duck.co/ia?repo=fathead)
 
 
 ## Get Started
 
-- [ ] Claim this issue (Comment Below)
-- [ ] Please review our [Contributing Guide](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/CONTRIBUTING.md)
-- [ ] [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html)), then fork this repository
-- [ ] Create the Fathead
-- [ ] Create a Pull Request
-- [ ] Ping @{Language Leader Handle} for a review
+- [ ] 1) Claim this issue (Comment Below)
+- [ ] 2) Review our [Contributing Guide](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/CONTRIBUTING.md)
+- [ ] 3) [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html)), then fork this repository
+- [ ] 4) Create the Fathead
+- [ ] 5) Create a Pull Request
+- [ ] 6) Ping @{Language Leader Handle} for a review
 
 ## Questions?
 

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -1,0 +1,50 @@
+# New {IA Name} Fathead
+Help DuckDuckGo become the best Search Engine for {Language} developers!
+
+
+### What do I need to know?
+In order to complete this task, you'll need to know how to code in **Python**, **Ruby**, **Perl**, or **JavaScript**. 
+
+
+### What am I doing?
+Your task is to write a script that scrapes or downloads the {Name of Documentation Source} docs, and generates an **output.txt** file containing the parsed documentation.
+
+Learn more about Fatheads, and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html)!
+
+
+### The data source :rocket:
+{URL to Data Source}
+
+
+## The Goal
+Help *improve {Language Name} language search results* on DuckDuckGo as part of our Programming Mission! We're trying to reach 100% Instant Answer (IA) coverage for {Language Name}-related searches by creating new Instant Answers, and improving existing ones.
+
+
+#### Some relevant examples:
+<!-- Visit https://duck.co/ia?repo=fathead and filter by Topic to find examples -->
+
+- Instant Answer Number One
+    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/{ID})
+    - [Example Query](https://duckduckgo.com?q=example+query)
+    - [IA Page](https://duck.co/ia/view/{ID})
+- Instant Answer Number Two
+    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/{ID})
+    - [Example Query](https://duckduckgo.com?q=example+query)
+    - [IA Page](https://duck.co/ia/view/{ID})
+
+
+## Get Started
+
+- [ ] Claim this issue (Comment Below)
+- [ ] Please review our [Contributing Guide](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/CONTRIBUTING.md)
+- [ ] [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html)), then fork this repository
+- [ ] Create the Fathead
+- [ ] Create a Pull Request
+- [ ] Ping @{Language Leader Handle} for a review
+
+## Questions?
+
+- Join [DuckDuckHack Slack](https://quackslack.herokuapp.com/) and ask questions
+- Ping one of the [Community Leaders](https://duck.co/help/community/community-leaders) or @{Language Leader Handle}
+- Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/c/programming/{language})
+- Read the [DuckDuckHack Documentation](https://docs.duckduckhack.com/) for technical help

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -10,7 +10,7 @@ You'll need to know how to code in **Perl**, **Python**, **Ruby**, or **JavaScri
 ### What am I doing?
 You will write a script that scrapes or downloads the data source below, and generates an **output.txt** file containing the parsed documentation.
 
-You can learn more about Fathead, and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html)!
+You can learn more about Fatheads and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html).
 
 
 ### The data source :rocket:

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -8,6 +8,7 @@ As part of our Programming Mission, we're aiming to reach 100% Instant Answer (I
 
 ### What do I need to know?
 You'll need to know how to code in **Perl**, **Python**, **Ruby**, or **JavaScript**.
+![fathead languages](https://cloud.githubusercontent.com/assets/873785/19787916/57b4c31a-9c73-11e6-9bd9-f85c8893ec93.jpg)
 
 
 ### What am I doing?
@@ -22,7 +23,7 @@ You can learn more about Fathead, and the `output.txt` syntax [**here**](https:/
 
 ### Example Instant Answers:
 
-- - Ruby Docs Fathead
+- Ruby Docs Fathead
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/ruby) | [Example Query](https://duckduckgo.com/?q=array+bsearch&ia=about) | [IA Page](https://duck.co/ia/view/ruby)
 - Perl Docs Fathead
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/perl_doc) | [Example Query](https://duckduckgo.com/?q=perl+foreach&t=vivaldi&ia=about) | [IA Page](https://duck.co/ia/view/perl_doc)

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -2,10 +2,6 @@
 Help DuckDuckGo become the best Search Engine for {Language} developers!
 
 
-### What is the Goal?
-As part of our Programming Mission, we're aiming to reach 100% Instant Answer (IA) coverage for searches related to programmiing languages by creating new Instant Answers, and improving existing ones.
-
-
 ### What do I need to know?
 You'll need to know how to code in **Perl**, **Python**, **Ruby**, or **JavaScript**.
 ![fathead languages](https://cloud.githubusercontent.com/assets/873785/19787916/57b4c31a-9c73-11e6-9bd9-f85c8893ec93.jpg)
@@ -21,15 +17,16 @@ You can learn more about Fathead, and the `output.txt` syntax [**here**](https:/
 {URL to Data Source}
 
 
-### Example Instant Answers:
+### What is the Goal?
+As part of our Programming Mission, we're aiming to reach 100% Instant Answer (IA) coverage for searches related to programmiing languages by creating new Instant Answers, and improving existing ones.
 
-- Ruby Docs Fathead
+Here are some Fathead examples:
+
+- Ruby Docs
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/ruby) | [Example Query](https://duckduckgo.com/?q=array+bsearch&ia=about) | [IA Page](https://duck.co/ia/view/ruby)
-- CSS Fathead
+- MDN CSS
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/mdn_css) | [Example Query](https://duckduckgo.com/?q=css+background-position&ia=about) | [IA Page](https://duck.co/ia/view/mdn_css)
-
-**Here's how it looks!**
-![css background-position search](https://cloud.githubusercontent.com/assets/873785/19787980/cdf51566-9c73-11e6-9ef2-ac44dede62c7.png)
+    ![css background-position search](https://cloud.githubusercontent.com/assets/873785/19787980/cdf51566-9c73-11e6-9ef2-ac44dede62c7.png)
 
 
 [See more related Instant Answers](https://duck.co/ia?repo=fathead)

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -1,39 +1,44 @@
-# New {IA Name} Fathead
+# New {IA Name} Fathead Instant Answer
 Help DuckDuckGo become the best Search Engine for {Language} developers!
 
 
 ### What is the Goal?
-As part of our Programming Mission, we're aiming to reach 100% Instant Answer (IA) coverage for {Language Name}-related searches by creating new Instant Answers, and improving existing ones.
+As part of our Programming Mission, we're aiming to reach 100% Instant Answer (IA) coverage for searches related to programmiing languages by creating new Instant Answers, and improving existing ones.
 
 
 ### What do I need to know?
-You'll need to know how to code in **Python**, **Ruby**, **Perl**, or **JavaScript**.
+You'll need to know how to code in **Perl**, **Python**, **Ruby**, or **JavaScript**.
 
 
 ### What am I doing?
-You will write a script that scrapes or downloads the {Name of Documentation Source} docs, and generates an **output.txt** file containing the parsed documentation.
+You will write a script that scrapes or downloads the data source below, and generates an **output.txt** file containing the parsed documentation.
 
-You can learn more about Fathead Instant Answers, and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html)!
+You can learn more about Fathead, and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html)!
 
 
 ### The data source :rocket:
 {URL to Data Source}
 
 
-### Example Instant Answer:
+### Example Instant Answers:
 
-- Ruby Docs Fathead
+- - Ruby Docs Fathead
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/ruby) | [Example Query](https://duckduckgo.com/?q=array+bsearch&ia=about) | [IA Page](https://duck.co/ia/view/ruby)
 - Perl Docs Fathead
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/perl_doc) | [Example Query](https://duckduckgo.com/?q=perl+foreach&t=vivaldi&ia=about) | [IA Page](https://duck.co/ia/view/perl_doc)
 - Python Docs Fathead
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/python) | [Example Query](https://duckduckgo.com/?q=python+print&ia=about) | [IA Page](https://duck.co/ia/view/python)
+- CSS Fathead
+    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/mdn_css) | [Example Query](https://duckduckgo.com/?q=css+background-position&ia=about) | [IA Page](https://duck.co/ia/view/mdn_css)
+
+**Here's how it looks!**
+![css_background-position on DuckDuckGo](https://cloud.githubusercontent.com/assets/873785/19787197/7da67c5c-9c6f-11e6-85f5-c79c505c7875.png)
+
 
 [See more related Instant Answers](https://duck.co/ia?repo=fathead)
 
 
 ## Get Started
-
 - [ ] 1) Claim this issue (Comment Below)
 - [ ] 2) Review our [Contributing Guide](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/CONTRIBUTING.md)
 - [ ] 3) [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html)), then fork this repository
@@ -41,8 +46,8 @@ You can learn more about Fathead Instant Answers, and the `output.txt` syntax [*
 - [ ] 5) Create a Pull Request
 - [ ] 6) Ping @{Language Leader Handle} for a review
 
-## Questions?
 
+## Questions?
 - Join [DuckDuckHack Slack](https://quackslack.herokuapp.com/) and ask questions
 - Ping one of the [Community Leaders](https://duck.co/help/community/community-leaders) or @{Language Leader Handle}
 - Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/c/programming/{language})

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -25,10 +25,6 @@ You can learn more about Fathead, and the `output.txt` syntax [**here**](https:/
 
 - Ruby Docs Fathead
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/ruby) | [Example Query](https://duckduckgo.com/?q=array+bsearch&ia=about) | [IA Page](https://duck.co/ia/view/ruby)
-- Perl Docs Fathead
-    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/perl_doc) | [Example Query](https://duckduckgo.com/?q=perl+foreach&t=vivaldi&ia=about) | [IA Page](https://duck.co/ia/view/perl_doc)
-- Python Docs Fathead
-    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/python) | [Example Query](https://duckduckgo.com/?q=python+print&ia=about) | [IA Page](https://duck.co/ia/view/python)
 - CSS Fathead
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/mdn_css) | [Example Query](https://duckduckgo.com/?q=css+background-position&ia=about) | [IA Page](https://duck.co/ia/view/mdn_css)
 
@@ -50,6 +46,6 @@ You can learn more about Fathead, and the `output.txt` syntax [**here**](https:/
 
 ## Questions?
 - Join [DuckDuckHack Slack](https://quackslack.herokuapp.com/) and ask questions
-- Ping one of the [Community Leaders](https://duck.co/help/community/community-leaders) or @{Language Leader Handle}
+- Ping one of the [Community Leaders](https://duck.co/help/community/community-leaders)
 - Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/c/programming/{language})
 - Read the [DuckDuckHack Documentation](https://docs.duckduckhack.com/) for technical help

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -33,7 +33,7 @@ You can learn more about Fathead, and the `output.txt` syntax [**here**](https:/
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/mdn_css) | [Example Query](https://duckduckgo.com/?q=css+background-position&ia=about) | [IA Page](https://duck.co/ia/view/mdn_css)
 
 **Here's how it looks!**
-![css_background-position on DuckDuckGo](https://cloud.githubusercontent.com/assets/873785/19787197/7da67c5c-9c6f-11e6-85f5-c79c505c7875.png)
+![css background-position search](https://cloud.githubusercontent.com/assets/873785/19787980/cdf51566-9c73-11e6-9ef2-ac44dede62c7.png)
 
 
 [See more related Instant Answers](https://duck.co/ia?repo=fathead)

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -3,13 +3,13 @@ Help DuckDuckGo become the best Search Engine for {Language} developers!
 
 
 ### What do I need to know?
-In order to complete this task, you'll need to know how to code in **Python**, **Ruby**, **Perl**, or **JavaScript**. 
+Fathead developers need to know how to code in **Python**, **Ruby**, **Perl**, or **JavaScript**. 
 
 
 ### What am I doing?
-Your task is to write a script that scrapes or downloads the {Name of Documentation Source} docs, and generates an **output.txt** file containing the parsed documentation.
+Write a script that scrapes or downloads the {Name of Documentation Source} docs, parses it, and generates an **output.txt** file containing the parsed documentation.
 
-Learn more about Fatheads, and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html)!
+You can learn more about Fathead Instant Answers, and the `output.txt` syntax [**here**](https://docs.duckduckhack.com/resources/fathead-overview.html)!
 
 
 ### The data source :rocket:
@@ -20,17 +20,15 @@ Learn more about Fatheads, and the `output.txt` syntax [**here**](https://docs.d
 Help *improve {Language Name} language search results* on DuckDuckGo as part of our Programming Mission! We're trying to reach 100% Instant Answer (IA) coverage for {Language Name}-related searches by creating new Instant Answers, and improving existing ones.
 
 
-#### Some relevant examples:
+#### Example Instant Answer:
 <!-- Visit https://duck.co/ia?repo=fathead and filter by Topic to find examples -->
 
-- Instant Answer Number One
-    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/{ID})
-    - [Example Query](https://duckduckgo.com?q=example+query)
-    - [IA Page](https://duck.co/ia/view/{ID})
-- Instant Answer Number Two
-    - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/{ID})
-    - [Example Query](https://duckduckgo.com?q=example+query)
-    - [IA Page](https://duck.co/ia/view/{ID})
+{Instant Answer Name}
+- [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/{ID})
+- [Example Query](https://duckduckgo.com?q=example+query)
+- [IA Page](https://duck.co/ia/view/{ID})
+
+[See more related Instant Answers](https://duck.co/ia?repo=fathead)
 
 
 ## Get Started

--- a/.github/NEW_IA_TEMPLATE.md
+++ b/.github/NEW_IA_TEMPLATE.md
@@ -26,7 +26,8 @@ Here are some Fathead examples:
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/ruby) | [Example Query](https://duckduckgo.com/?q=array+bsearch&ia=about) | [IA Page](https://duck.co/ia/view/ruby)
 - MDN CSS
     - [Code](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/lib/fathead/mdn_css) | [Example Query](https://duckduckgo.com/?q=css+background-position&ia=about) | [IA Page](https://duck.co/ia/view/mdn_css)
-    ![css background-position search](https://cloud.githubusercontent.com/assets/873785/19787980/cdf51566-9c73-11e6-9ef2-ac44dede62c7.png)
+
+  ![css background-position search](https://cloud.githubusercontent.com/assets/873785/19787980/cdf51566-9c73-11e6-9ef2-ac44dede62c7.png)
 
 
 [See more related Instant Answers](https://duck.co/ia?repo=fathead)
@@ -35,7 +36,7 @@ Here are some Fathead examples:
 ## Get Started
 - [ ] 1) Claim this issue (Comment Below)
 - [ ] 2) Review our [Contributing Guide](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/CONTRIBUTING.md)
-- [ ] 3) [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html)), then fork this repository
+- [ ] 3) [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html), then fork this repository
 - [ ] 4) Create the Fathead
 - [ ] 5) Create a Pull Request
 - [ ] 6) Ping @{Language Leader Handle} for a review
@@ -44,5 +45,5 @@ Here are some Fathead examples:
 ## Questions?
 - Join [DuckDuckHack Slack](https://quackslack.herokuapp.com/) and ask questions
 - Ping one of the [Community Leaders](https://duck.co/help/community/community-leaders)
-- Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/c/programming/{language})
+- Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/)
 - Read the [DuckDuckHack Documentation](https://docs.duckduckhack.com/) for technical help


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Adds a template for New Instant Answers. It cannot be used automatically by GitHub, but we may replace the standard issue template with this.

For now I'm putting this here to flesh out the details and have a copy somewhere public.
## People to notify

@MariagraziaAlastra @tagawa @russellholt 
