### PR TITLE
Java: Fixes #409: Switch to use new Fathead Template Elements and Increase Length of Abstract

### DIFF
--- a/lib/fathead/java/parse_utils.py
+++ b/lib/fathead/java/parse_utils.py
@@ -34,7 +34,7 @@ def getDocs(filename):
 
 def cutlength(description):
 #  if len(description) > 100:
-  description = description[0:description.rfind('.', 0, 100) + 1]
+  description = description[0:description.rfind('.', 0, 300) + 1]
   return description.replace("\n", "")
 
 def remove_keywords(line):

--- a/lib/fathead/java/parse_utils.py
+++ b/lib/fathead/java/parse_utils.py
@@ -69,6 +69,7 @@ def concat(clazz, description, url):
   ten = ''
   image = ''
   abstract = description.replace("\n", "\\n").replace("\t", "\\t") or "No abstract found"
+  abstract = '<section class="prog__container">' + abstract + '</section>'
   url = url or "No URL found"
 
   data = [title, typez, redirect, four, categories, six, related_topics, eight, external_links, ten, image, abstract, url]


### PR DESCRIPTION
## Type of Change

<!-- Place and 'X' in the correct box (E.g `[X] Improvement`) -->
- [ ] New Instant Answer
- [X] Improvement
  - [ ] Bug fix
  - [X] Enhancement
- [ ] Non–Instant Answer
  - [ ] Other (Role, Template, Test, Documentation, etc.)
## Description of new Instant Answer, or changes

<!-- What does this new Instant Answer do? What changes does this PR introduce? -->

This change is to switch the java fathead IA to use the new fathead template elements.
It also increases the abstract length (from 100 to 300) to display more details to the user from oracle docs.
## Related Issues and Discussions

<!--  Link related issues here to automatically close them when PR is merged
      E.g. "Fixes #1234" -->

Fixes #409: Java: Switch to use new Fathead Template Elements 
## People to notify

<!-- Please @mention any relevant people/organizations here:-->
@marti1125 @moollaza @boyter 


<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->

IA Page: http://duck.co/ia/view/java 

<!-- For Instant Answers related to a forum topic -->

Forum Topic: 
