### PR TITLE
Fix #418: Swift Docs - Switched to new fathead template. 

### DIFF
--- a/lib/fathead/swiftdocs/swift/src/parse.js
+++ b/lib/fathead/swiftdocs/swift/src/parse.js
@@ -100,6 +100,7 @@ fetch(links => {
         let html = sanitize($(selector)) || '';
         // The first entry is always the code snippet. We wrap that in a <pre> tag.
         if(index === 0 && html) { html = preWrap(html); }
+        if(index === 1 && html) { html = '<p>' + html + '</p>'}
         article.description += html;
       });
 
@@ -172,7 +173,7 @@ fetch(links => {
       //
       // Finally, we write the contents to output.txt
       Fathead.articles.forEach(a => {
-        fs.appendFileSync("output.txt", `${a.title}\tA\t\t\t\t\t\t\t\t\t\t${a.description}\t${a.url}\n`);
+        fs.appendFileSync("output.txt", `${a.title}\tA\t\t\t\t\t\t\t\t\t\t<section class="prog__container">${a.description}</section>\t${a.url}\n`);
       });
 
       Fathead.redirects.forEach(r => {


### PR DESCRIPTION
## Type of Change
<!-- Place and 'X' in the correct box (E.g `[X] Improvement`) -->

- [ ] New Instant Answer
- [ ] Improvement
    - [ ] Bug fix
    - [ ] Enhancement
- [x] Non–Instant Answer
    - [x] Other (Role, Template, Test, Documentation, etc.)


## Description of new Instant Answer, or changes
Switched to new fathead template.


## Related Issues and Discussions
Fixes #418 


## People to notify
@moollaza 

---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->

IA Page: http://duck.co/ia/view/swiftdocs


<!-- For Instant Answers related to a forum topic -->

Forum Topic: 

