### PR TITLE
Include Get Started & Resources in Issue Template; Minor changes to PR Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,41 +1,41 @@
-<!--- Please use the appropriate format for your Issue title: -->
+<!-- Please use the appropriate issue title format:
 
-<!-- For a Bug Fix: -->
-<!-- {IA Name} Bug: {Short description of bug} -->
+    BUG FIX
+    {IA Name} Bug: {Short description of bug}
 
-<!-- For a Suggestion:-->
-<!-- {IA Name} Suggestion: {Short description of suggestion}" -->
+    SUGGESTION
+    {IA Name} Suggestion: {Short description of suggestion}"
 
-<!-- For Everything Else: -->
-<!-- {IA Name}: {Short description} -->
+    OTHER
+    {IA Name}: {Short description} -->
 
 
-## Type of Issue
+### Description
+<!-- Describe the bug or suggestion in detail -->
 
-<!-- Place and 'X' in the correct box (E.g `[X] Triggering`) -->
-
-- [ ] Bug (incorrect behavior)
-    - [ ] Triggering
-    - [ ] Relevancy
-    - [ ] Internal (issue with code)
-- [ ] Feature Request
-    - [ ] Triggers (new triggers)
-    - [ ] Design Change
-
-## Description
-
-<!-- Describe the bug, or suggestion in detail -->
 
 ## Steps to recreate
-
 <!-- Describe the steps, or provide a link to an example search -->
 
-## People to notify
 
+## People to notify
 <!-- Please @mention any relevant people/organizations here:-->
 
+<!-- LANGUAGE LEADERS ONLY: REMOVE THIS LINE
+## Get Started
+- [ ] 1) Claim this issue by commenting below
+- [ ] 2) Review our [Contributing Guide](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/CONTRIBUTING.md)
+- [ ] 3) [Set up your development environment](https://docs.duckduckhack.com/welcome/setup-dev-environment.html), and fork this repository
+- [ ] 4) Create a Pull Request
 
+## Resources
+- Join [DuckDuckHack Slack](https://quackslack.herokuapp.com/) to ask questions
+- Join the [DuckDuckHack Forum](https://forum.duckduckhack.com/) to discuss project planning and Instant Answer metrics
+- Read the [DuckDuckHack Documentation](https://docs.duckduckhack.com/) for technical help
+
+<!-- DO NOT REMOVE -->
 ---
 
 <!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
 Instant Answer Page: https://duck.co/ia/view/{ID}
+<!-- FILL THIS IN:                           ^^^^ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,13 @@
 <!-- Use the appropriate format for your Pull Request title:
 
-    For a Bug Fix: 
-    {IA Name}: {Description of change} 
+    For a Bug Fix:
+    {IA Name}: {Description of change}
 
-    For a New Instant Answer: 
-    New {IA Name} Fathead" 
+    For a New Instant Answer:
+    New {IA Name} Fathead
 
-    For anything else: 
+    For anything else:
     {Tests/Docs/Other}: {Short Description} -->
-
-
-## Type of Change
-<!-- Place and 'X' in the correct box (E.g `[X] Improvement`) -->
-
-- [ ] New Instant Answer
-- [ ] Improvement
-    - [ ] Bug fix
-    - [ ] Enhancement
-- [ ] Non–Instant Answer
-    - [ ] Other (Role, Template, Test, Documentation, etc.)
 
 
 ## Description of new Instant Answer, or changes
@@ -31,15 +20,11 @@
 
 
 ## People to notify
-<!-- Please @mention any relevant people/organizations here:-->
+<!-- Please @mention any relevant people/organizations here: -->
 
+<!-- DO NOT REMOVE -->
 ---
 
 <!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
-
-IA Page: https://duck.co/ia/view/{ID}
-
-
-<!-- For Instant Answers related to a forum topic -->
-
-Forum Topic: 
+Instant Answer Page: https://duck.co/ia/view/{ID}
+<!-- FILL THIS IN:                           ^^^^ -->


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Make Issue Template HTML comments easier to read
- Add in "Get Started" and "Resources" to be included when Language Leaders are creating issues (meaning they are approved to be worked on)
- Remove "Type of Issue" selection box. Takes up lots of space, and information can be conveyed by title + labels

## People to notify
@tagawa @MariagraziaAlastra 

