### PR TITLE
Py_pi:Fix detection of package home page links

### DIFF
--- a/lib/fathead/py_pi/parse.py
+++ b/lib/fathead/py_pi/parse.py
@@ -31,8 +31,10 @@ with codecs.open('download/package-jsons', encoding='utf-8') as in_file, \
         abstract_lines.append("</section>")
 
         official_site = ''
-        # check for real links. We can get stuff like 'unknown', '404' in here
-        if package_info['home_page'] and re.search(r'www.', package_info['home_page']):
+        # Check for real links. We can get stuff like 'UNKNOWN', 'N/A' etc. here
+        # The regex-es look for the beginning starting with either 'www.', 'http://' or 'https://'
+        if package_info['home_page'] and (re.search(r'^www.', package_info['home_page']) or \
+                                          re.search(r'^http[s]?://', package_info['home_page'])):
             official_site = '[' + package_info['home_page'] + ' Official site]\\\\n'
 
         out_file.write('\t'.join([


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title:

    For a Bug Fix:
    {IA Name}: {Description of change}

    For a New Instant Answer:
    New {IA Name} Fathead

    For anything else:
    {Tests/Docs/Other}: {Short Description} -->


## Description of changes
As pointed out by Jason in https://forum.duckduckhack.com/t/py-pi-fathead-ux-improvements/194/7?u=hestben that links to package home page should be showed. I found that there is actually already links to home pages shown, but it only showed links starting with 'www.'. This fix also allows links starting with 'http://' and 'https://'.
Before this search correctly showed a link to the home page: https://duckduckgo.com/?q=python+numpy
While this search did not: https://duckduckgo.com/?q=python+pandas&ia=about

Now, both should work.

## Related Issues and Discussions
<!--  Link related issues here to automatically close them when PR is merged
      E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
Maintainer: @ezgraphs @pjhampton 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/py_pi
<!-- FILL THIS IN:                           ^^^^ -->