### PR TITLE
Perl6Doc: Switch fetch URL to https

### DIFF
--- a/lib/fathead/perl6doc/fetch.sh
+++ b/lib/fathead/perl6doc/fetch.sh
@@ -4,5 +4,5 @@
 # production usage).
 mkdir -p download
 cd download
-wget -np -nc -r -l 2 https://doc.perl6.org/
+wget -np -nc -r -l 2 https://docs.perl6.org/
 cd ..

--- a/lib/fathead/perl6doc/fetch.sh
+++ b/lib/fathead/perl6doc/fetch.sh
@@ -4,5 +4,5 @@
 # production usage).
 mkdir -p download
 cd download
-wget -np -nc -r -l 2 http://doc.perl6.org/
+wget -np -nc -r -l 2 https://doc.perl6.org/
 cd ..


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Ensure the fetch URL for perl6.org uses `https`.

## People to notify
@sahildua2305  @GuiltyDolphin 

<!-- DO NOT REMOVE -->

---

Instant Answer Page: https://duck.co/ia/view/perl6doc