### PR TITLE
Python: Fix #526 add coverage for more classes

### DIFF
--- a/lib/fathead/python/redirect.py
+++ b/lib/fathead/python/redirect.py
@@ -197,6 +197,7 @@ def generate_redirects(f):
             disambiguation_key = entry.get_key()
             splitted_key = disambiguation_key.split('.')
             package_name = '.'.join(splitted_key[0:len(splitted_key)-1])
+            #temp doesn't sound like a good variable name
             temp = "'" + package_name + "'"
 
             if len(splitted_key) >= 2:

--- a/lib/fathead/python/redirect.py
+++ b/lib/fathead/python/redirect.py
@@ -203,8 +203,6 @@ def generate_redirects(f):
             if len(splitted_key) >= 2:
                 if temp in output and output[temp].startswith(package_name + '\t' + 'A'):
                     output[temp] = str(package_name) + '\t' + 'D' +'\t\t\t\t\t\t\t\t' + '*' + '[['+str(disambiguation_key)+']] ' + str(entry.get_abstract()) + '\\n'
-                    if output[temp].startswith(package_name + '\t' + 'A'): #didn't we just replace the output[temp] with a disambiguation?
-                        del output[temp]
                     disambiguations += 1
                 elif temp in output and disambiguation_key not in output[temp] and output[temp].startswith(package_name + '\t' + 'D'):
                     output[temp] += '*' + '[['+str(disambiguation_key)+']] ' + str(entry.get_abstract()) + '\\n'

--- a/lib/fathead/python/redirect.py
+++ b/lib/fathead/python/redirect.py
@@ -203,7 +203,7 @@ def generate_redirects(f):
             if len(splitted_key) >= 2:
                 if temp in output and output[temp].startswith(package_name + '\t' + 'A'):
                     output[temp] = str(package_name) + '\t' + 'D' +'\t\t\t\t\t\t\t\t' + '*' + '[['+str(disambiguation_key)+']] ' + str(entry.get_abstract()) + '\\n'
-                    if output[temp].startswith(package_name + '\t' + 'A'):
+                    if output[temp].startswith(package_name + '\t' + 'A'): #didn't we just replace the output[temp] with a disambiguation?
                         del output[temp]
                     disambiguations += 1
                 elif temp in output and disambiguation_key not in output[temp] and output[temp].startswith(package_name + '\t' + 'D'):
@@ -220,7 +220,7 @@ def generate_redirects(f):
                     if key not in output and built_in_key not in built_in:
                         output[key] = str(redirect.get_entry())
                     else:
-                        del output[key]
+                        del output[key] #This looks strange to me, if we have exactly two redirects with the same content, won't we remove that key on the second run?
                         duplicate_count += 1
 
         except BadEntryException as e:


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title:

    For a Bug Fix:
    {IA Name}: {Description of change}

    For a New Instant Answer:
    New {IA Name} Fathead

    For anything else:
    {Tests/Docs/Other}: {Short Description} -->


## Related Issues and Discussions
Issue #526 
I have created this PR to discuss what we should do, and comment on the code.
@souravbadami I see you have touched the code last. Maybe you would like to take this issue, if you have time. I don't want us to do double work =).
From my initial investigation, I have found that the view that is shown in the search result in #526 example comes from a Disambiguation entry created in redirect.py.
Does anybody have an example where a Disambiguation is the correct thing to show? If we strip out some stuff, we wouldn't want to destroy cases where disambiguations should be used.
I have found more cases where I think we would like to change the view, as @jdorweiler suggested in the #526:
https://duckduckgo.com/?q=python+shlex&t=ffsb&ia=meanings&iai=%2F35%2Fshlex.quote
https://duckduckgo.com/?q=python+pickletools&t=ffsb&ia=meanings&iai=%2F35%2Fpickletools.genops
https://duckduckgo.com/?q=python+msvcrt&t=ffsb&ia=meanings

The two solutions I can think of after my brief investigation are

1. Manually specify which classes should not be displayed as disambiguations.
2. Device a way to mine classes from the python docs that don't destroy the disambiguations that should be displayed as disambiguations.


## People to notify
@jdorweiler @souravbadami 

<!-- DO NOT REMOVE -->

---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/python
<!-- FILL THIS IN:                           ^^^^ -->

