### PR TITLE
Fathead Tests: Update regex to properly catch \n \r \t and \[0-9x]

### DIFF
--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -189,7 +189,7 @@ sub escapes {
     while ( my ( $number, $line ) = each @{ $self->content } ) {
         my $abstract = ( split /\t/, $line )[11];
         next unless $abstract;
-        if ( my @matches = $abstract =~ /([^\\]\\[0-9]|[\n\r\t\x])/g ) {
+        if ( my @matches = $abstract =~ /([^\\]\\[0-9x]|[\n\r\t])/g ) {
             warn sprintf "Line %d appears to contain unescaped characters : %s",
                 $number + 1, join( ', ', @matches );
             $r = 0;

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -189,7 +189,7 @@ sub escapes {
     while ( my ( $number, $line ) = each @{ $self->content } ) {
         my $abstract = ( split /\t/, $line )[11];
         next unless $abstract;
-        if ( my @matches = $abstract =~ /((?:[^\\]\\[0-9]|\n\r\t\x]))/g ) {
+        if ( my @matches = $abstract =~ /([^\\]\\[0-9]|[\n\r\t\x])/g ) {
             warn sprintf "Line %d appears to contain unescaped characters : %s",
                 $number + 1, join( ', ', @matches );
             $r = 0;

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -189,7 +189,7 @@ sub escapes {
     while ( my ( $number, $line ) = each @{ $self->content } ) {
         my $abstract = ( split /\t/, $line )[11];
         next unless $abstract;
-        if ( my @matches = $abstract =~ /([^\\]\\[0-9nrtx])/g ) {
+        if ( my @matches = $abstract =~ /((?:[^\\]\\[0-9]|\n\r\t\x]))/g ) {
             warn sprintf "Line %d appears to contain unescaped characters : %s",
                 $number + 1, join( ', ', @matches );
             $r = 0;


### PR DESCRIPTION
## Description of new Instant Answer, or changes

- improve regex to catch `/\n\r\t/` instead of `/\\n, \\r, \\t/`