### PR TITLE
Fathead Tests: Update to loop over all output.txt

### DIFF
--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -53,6 +53,7 @@ sub _build_output_txt {
     my ( $self ) = @_;
     my $otxt = f->catfile( $self->fathead_dir, q'output.txt' );
     die RED "NO OUTPUT FILE FOUND" unless -f $otxt;
+    die RED "OUTPUT FILE IS EMPTY" unless -s $otxt;
     return $otxt;
 }
 

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -118,7 +118,7 @@ sub _build_categories {
     ];
 }
 
-has disambiguations => ( is => 'lazy');
+has disambiguations => ( is => 'lazy' );
 sub _build_disambiguations {
     my ( $self ) = @_;
 
@@ -260,9 +260,8 @@ sub disambiguations_missing {
         map { /^\*\[\[(.+?)\]\],?\s*.+?\.$/ }
         @{ $self->disambiguations };
 
-    my @titles = keys $self->titles;
-    warn @titles;
-    my @missing = $self->_a_not_in_b( \@disambiguation_titles, @titles );
+    my $titles = keys $self->titles;
+    my @missing = $self->_a_not_in_b( \@disambiguation_titles, $titles );
 
     if (@missing){
         my $count = scalar @missing;

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -284,10 +284,9 @@ sub category_clash {
 
     if (@clash){
         my $count = scalar @clash;
-        diag "$count CATEGORIES NAMES MATCHING ARTICLE TITLES";
+        diag YELLOW "$count CATEGORIES NAMES MATCHING ARTICLE TITLES";
         diag $_ for @clash;
     }
     return @clash ? 0 : 1;
 }
-
 1;

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -32,7 +32,10 @@ has fathead_dir => ( is => 'lazy' );
 sub _build_fathead_dir {
     my ( $self ) = @_;
     my $fdir = f->catdir( $self->project_root, qw/ lib fathead /, $self->fathead );
-    die RED "$fdir does not exist" unless -d $fdir;
+    unless (-d $fdir){
+        diag RED "$fdir does not exist";
+        return;
+    }
     return $fdir;
 }
 
@@ -48,12 +51,16 @@ sub _build_cover_dir {
     return $cdir;
 }
 
-has output_txt => ( is => 'lazy' );
+has output_txt => ( is => 'lazy', predicate => 1 );
 sub _build_output_txt {
     my ( $self ) = @_;
     my $otxt = f->catfile( $self->fathead_dir, q'output.txt' );
-    die RED "NO OUTPUT FILE FOUND" unless -f $otxt;
-    die RED "OUTPUT FILE IS EMPTY" unless -s $otxt;
+
+    unless (-f $otxt && -s $otxt){
+        diag RED "NO OUTPUT FILE FOUND" unless -f $otxt;
+        diag RED "OUTPUT FILE IS EMPTY" unless -s $otxt;
+        return;
+    }
     return $otxt;
 }
 

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -180,8 +180,8 @@ sub duplicates {
 
 sub coverage {
     my ( $self ) = @_;
-    my $titles = $self->lc_titles;
-    my @missing = $self->_a_not_in_b( $self->cover_titles, $titles );
+
+    my @missing = $self->_a_not_in_b( $self->cover_titles, $self->lc_titles );
 
     if (@missing){
         my $count = scalar @missing;
@@ -260,8 +260,9 @@ sub disambiguations_missing {
         map { /^\*\[\[(.+?)\]\],?\s*.+?\.$/ }
         @{ $self->disambiguations };
 
-    my $titles = keys $self->titles;
-    my @missing = $self->_a_not_in_b( \@disambiguation_titles, $titles );
+    my @titles = keys $self->titles;
+
+    my @missing = $self->_a_not_in_b( \@disambiguation_titles, \@titles );
 
     if (@missing){
         my $count = scalar @missing;
@@ -279,8 +280,7 @@ sub category_clash {
         map { s/\b$re\b//gr }
         @{ $self->categories };
 
-    my @titles = $self->lc_titles;
-    my @clash = $self->_a_in_b( \@filtered_categories, \@titles );
+    my @clash = $self->_a_in_b( \@filtered_categories, $self->lc_titles );
 
     if (@clash){
         my $count = scalar @clash;

--- a/t/validate_fathead.t
+++ b/t/validate_fathead.t
@@ -4,24 +4,40 @@ use warnings;
 use Test::More;
 use t::lib::TestUtils;
 
-plan skip_all => 'Set DDG_TEST_FATHEAD to a fathead id to run these tests' unless $ENV{DDG_TEST_FATHEAD};
-my $utils = t::lib::TestUtils->new( fathead => $ENV{DDG_TEST_FATHEAD} );
 
-ok( $utils->duplicates, "Checking for duplicate titles" );
-ok( $utils->types, "Validating types" );
-ok( $utils->field_count, "Validating correct number of fields" );
-ok( $utils->escapes, "Checking for unescaped chars" );
-ok( $utils->disambiguations_format, "Checking disambiguation format" );
-ok( $utils->disambiguations_missing, "Checking for disambiguations with missing titles" );
+my @files;
 
-SKIP: {
-    skip "COVERAGE DATA NOT FOUND", 1 unless $utils->cover_dir;
-    ok( $utils->coverage, "Testing language feature coverage" );
+if ($ENV{DDG_TEST_FATHEAD}) {
+    push @files, $ENV{DDG_TEST_FATHEAD};
+}
+else {
+    @files = File::Find::Rule->file()
+                                ->name("output.txt")
+                                ->in('lib/fathead/');
 }
 
-SKIP: {
-    skip "Trigger words not found", 1 unless $utils->trigger_words;
-    ok( $utils->category_clash, "Testing category / title clashes" );
+foreach my $file (@files) {
+    warn "Basename:";
+    warn File::Basename::dirname($file);
+    warn "Fileparse:";
+    warn File::Basename::fileparse($file);
+    my $utils = t::lib::TestUtils->new( fathead => $ENV{DDG_TEST_FATHEAD} );
+    ok( $utils->duplicates, "Checking for duplicate titles" );
+    ok( $utils->types, "Validating types" );
+    ok( $utils->field_count, "Validating correct number of fields" );
+    ok( $utils->escapes, "Checking for unescaped chars" );
+    ok( $utils->disambiguations_format, "Checking disambiguation format" );
+    ok( $utils->disambiguations_missing, "Checking for disambiguations with missing titles" );
+
+    SKIP: {
+        skip "COVERAGE DATA NOT FOUND", 1 unless $utils->cover_dir;
+        ok( $utils->coverage, "Testing language feature coverage" );
+    }
+
+    SKIP: {
+        skip "Trigger words not found", 1 unless $utils->trigger_words;
+        ok( $utils->category_clash, "Testing category / title clashes" );
+    }
 }
 
 done_testing;

--- a/t/validate_fathead.t
+++ b/t/validate_fathead.t
@@ -29,25 +29,29 @@ foreach my $dir (@folders) {
     diag BOLD BLUE "\nChecking $dir...";
 
     my $utils = t::lib::TestUtils->new( fathead => $dir );
-    ok( $utils->duplicates, "Checking for duplicate titles" );
-    ok( $utils->types, "Validating types" );
-    ok( $utils->field_count, "Validating correct number of fields" );
-    ok( $utils->escapes, "Checking for unescaped chars" );
 
     SKIP: {
-        skip "NO DISAMBIGUATIONS TO CHECK", 2 unless $utils->disambiguations;
-        ok( $utils->disambiguations_format, "Checking disambiguation format" );
-        ok( $utils->disambiguations_missing, "Checking for disambiguations with missing titles" );
-    }
+        skip 'NONEXISTANT OR EMPTY OUTPUT FILE', 8 unless $utils->fathead_dir && $utils->output_txt;
+        ok( $utils->duplicates, "Checking for duplicate titles" );
+        ok( $utils->types, "Validating types" );
+        ok( $utils->field_count, "Validating correct number of fields" );
+        ok( $utils->escapes, "Checking for unescaped chars" );
 
-    SKIP: {
-        skip "COVERAGE DATA NOT FOUND", 1 unless $utils->cover_dir;
-        ok( $utils->coverage, "Testing article coverage" );
-    }
+        SKIP: {
+            skip 'NO DISAMBIGUATIONS TO CHECK', 2 unless $utils->disambiguations;
+            ok( $utils->disambiguations_format, 'Checking disambiguation format' );
+            ok( $utils->disambiguations_missing, 'Checking for disambiguations with missing titles' );
+        }
 
-    SKIP: {
-        skip "TRIGGER WORDS NOT FOUND", 1 unless $utils->trigger_words;
-        ok( $utils->category_clash, "Testing category / title clashes" );
+        SKIP: {
+            skip 'COVERAGE DATA NOT FOUND', 1 unless $utils->cover_dir;
+            ok( $utils->coverage, 'Testing article coverage' );
+        }
+
+        SKIP: {
+            skip 'TRIGGER WORDS NOT FOUND', 1 unless $utils->trigger_words;
+            ok( $utils->category_clash, 'Testing category / title clashes' );
+        }
     }
 
     diag "\n";

--- a/t/validate_fathead.t
+++ b/t/validate_fathead.t
@@ -22,11 +22,11 @@ else {
     @folders = map { basename(dirname($_)) } @files;
 }
 
-plan tests => scalar @folders;
+plan tests => (scalar @folders) * 8;
 
 foreach my $dir (@folders) {
     local $Term::ANSIColor::AUTORESET = 1;
-    diag BOLD GREEN "\nChecking output.txt in 'lib/fathead/$dir'...\n";
+    diag BOLD WHITE "\nChecking $dir:";
 
     my $utils = t::lib::TestUtils->new( fathead => $dir );
     ok( $utils->duplicates, "Checking for duplicate titles" );
@@ -45,8 +45,6 @@ foreach my $dir (@folders) {
         skip "TRIGGER WORDS NOT FOUND", 1 unless $utils->trigger_words;
         ok( $utils->category_clash, "Testing category / title clashes" );
     }
-
-    diag "\n\n"
 }
 
-done_testing;
+done_testing();

--- a/t/validate_fathead.t
+++ b/t/validate_fathead.t
@@ -6,9 +6,9 @@ use File::Find::Rule;
 use File::Basename;
 use Path::Tiny;
 use Term::ANSIColor qw(:constants);
-use t::lib::TestUtils;
-
 use Data::Printer;
+
+use t::lib::TestUtils;
 
 my @folders;
 
@@ -26,15 +26,19 @@ plan tests => (scalar @folders) * 8;
 
 foreach my $dir (@folders) {
     local $Term::ANSIColor::AUTORESET = 1;
-    diag BOLD WHITE "\nChecking $dir:";
+    diag BOLD WHITE "\nChecking $dir...";
 
     my $utils = t::lib::TestUtils->new( fathead => $dir );
     ok( $utils->duplicates, "Checking for duplicate titles" );
     ok( $utils->types, "Validating types" );
     ok( $utils->field_count, "Validating correct number of fields" );
     ok( $utils->escapes, "Checking for unescaped chars" );
-    ok( $utils->disambiguations_format, "Checking disambiguation format" );
-    ok( $utils->disambiguations_missing, "Checking for disambiguations with missing titles" );
+
+    SKIP: {
+        skip "NO DISAMBIGUATIONS TO CHECK", 2 unless $utils->disambiguations;
+        ok( $utils->disambiguations_format, "Checking disambiguation format" );
+        ok( $utils->disambiguations_missing, "Checking for disambiguations with missing titles" );
+    }
 
     SKIP: {
         skip "COVERAGE DATA NOT FOUND", 1 unless $utils->cover_dir;
@@ -45,6 +49,10 @@ foreach my $dir (@folders) {
         skip "TRIGGER WORDS NOT FOUND", 1 unless $utils->trigger_words;
         ok( $utils->category_clash, "Testing category / title clashes" );
     }
+
+    diag "\n";
+    diag BOLD WHITE "...Finished";
+    diag "\n";
 }
 
 done_testing();

--- a/t/validate_fathead.t
+++ b/t/validate_fathead.t
@@ -26,7 +26,7 @@ plan tests => (scalar @folders) * 8;
 
 foreach my $dir (@folders) {
     local $Term::ANSIColor::AUTORESET = 1;
-    diag BOLD WHITE "\nChecking $dir...";
+    diag BOLD BLUE "\nChecking $dir...";
 
     my $utils = t::lib::TestUtils->new( fathead => $dir );
     ok( $utils->duplicates, "Checking for duplicate titles" );
@@ -51,7 +51,7 @@ foreach my $dir (@folders) {
     }
 
     diag "\n";
-    diag BOLD WHITE "...Finished";
+    diag BOLD BLUE "...Finished";
     diag "\n";
 }
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Fixed several small bugs in tests
- Skip disambiguation checks when none exist
- Update output to list our problematic titles/duplicates/disambigs, etc
- Allow `validate_fatheads.t` to take single Fathead from ENV or default to checking all output.txt in the repo

## Related
#567 - Adding Travis support to Repo

## People to notify
@jbarrett 