### PR TITLE
Update link to DuckDuckHack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For now, we are **only accepting Pull Requests and Issues related to the Program
 
 - [**Create new Fatheads, and improve existing ones**](https://github.com/duckduckgo/zeroclickinfo-fathead/issues?q=is%3Aopen+is%3Aissue+label%3A"Mission%3A+Programming")
     - **Note**: Fatheads are written in Perl, Python, Ruby, or JavaScript (Node.js)
-- [**Visit DuckDuckHack**](https://duckduckhack.com/#get-help) to learn more about the Programming Mission, and how you can help us **analyze Instant Answer performance data** to determine new projects
+- [**Visit DuckDuckHack**](https://duckduckhack.com/#get-help) to learn more about the Programming Mission, and how you can help!
 
 
 ### What are Fathead Instant Answers?

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For now, we are **only accepting Pull Requests and Issues related to the Program
 
 - [**Create new Fatheads, and improve existing ones**](https://github.com/duckduckgo/zeroclickinfo-fathead/issues?q=is%3Aopen+is%3Aissue+label%3A"Mission%3A+Programming")
     - **Note**: Fatheads are written in Perl, Python, Ruby, or JavaScript (Node.js)
-- [**Visit our Forum**](https://forum.duckduckhack.com/t/duckduckhack-getting-started/53) to learn more about the Programming Mission, and how you can help us **analyze Instant Answer performance data** to determine new projects
+- [**Visit DuckDuckHack**](https://duckduckhack.com/#get-help) to learn more about the Programming Mission, and how you can help us **analyze Instant Answer performance data** to determine new projects
 
 
 ### What are Fathead Instant Answers?


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Change "Learn more"  link to DDH.com instead of Forum

/cc @tagawa 