### PR TITLE
Python - Remove deprecated workaround forcing UTF-8 encoding

### DIFF
--- a/lib/fathead/python/parse.py
+++ b/lib/fathead/python/parse.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import csv
-import sys
 from bs4 import BeautifulSoup
-
-reload(sys)
-sys.setdefaultencoding('utf8')
 
 PYTHON_VERSIONS = {
     'python3': {'download_path': 'download/python-3.5.2-docs-html', 'doc_base_url': 'https://docs.python.org/3.5{}',

--- a/lib/fathead/python/parse.sh
+++ b/lib/fathead/python/parse.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export PYTHONIOENCODING=utf8
 python parse.py
 python redirect.py
 mv output2.txt output.txt

--- a/lib/fathead/python/redirect.py
+++ b/lib/fathead/python/redirect.py
@@ -2,10 +2,6 @@
 # -*- coding: utf-8 -*-
 import itertools
 import re
-import sys
-
-reload(sys)
-sys.setdefaultencoding('utf8')
 
 built_in = ['abs','dict','help','min','setattr','all','dir','hex','next',
 'slice','any','divmod','id','object','sorted','ascii','enumerate','input',


### PR DESCRIPTION
## Description 
I was trying to generate the output file for Python in my instance, using python 3.5.2 as recommended in the README, and I got an error both in parse.py and redirect.py, on the [lines trying to force UTF-8 encoding](https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/lib/fathead/python/redirect.py#L5-L8).

I replaced it with a line in parse.sh, and now it works smoothly.


## People to notify
@pjhampton 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/python
<!-- FILL THIS IN:                           ^^^^ -->