### PR TITLE
Fixes #598: Increase number of pypi packages from pypi-rankings to 15,000

### DIFF
--- a/lib/fathead/py_pi/parse.py
+++ b/lib/fathead/py_pi/parse.py
@@ -12,7 +12,7 @@ from urllib2 import urlopen
 popular_packages = []
 
 def get_popular_packages():
-    limit = 200 #10000 Packages
+    limit = 300 #15000 Packages
     package = 1
     seed = 'http://pypi-ranking.info/alltime?page='
     print("Getting Popular Packages ...")


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Increases the number of pypi packages from [pypi-rankings](http://pypi-ranking.info/) from 10,000 to 15,000


## Related Issues and Discussions
Fixes #598 


## People to notify
@moollaza @jdorweiler @tagawa 


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/py_pi
<!-- FILL THIS IN:                           ^^^^ -->