### PR TITLE
jQuery: Update fetch.sh to contain the download URL Fix #636

### DIFF
--- a/lib/fathead/jquery/fetch.sh
+++ b/lib/fathead/jquery/fetch.sh
@@ -2,7 +2,6 @@
 
 dir=$(dirname $0)
 
-url=$(<"${dir}/data.url")
 download_dir=${dir}/download
 archive=$(mktemp)
 docs_rel_dir=api.jquery.com-master/entries
@@ -11,7 +10,7 @@ curl \
   --silent \
   --create-dirs \
   --output "${archive}" \
-  "${url}"
+  "https://codeload.github.com/jquery/api.jquery.com/zip/master"
 
 mkdir -p "${download_dir}"
 

--- a/lib/fathead/jquery/output.txt
+++ b/lib/fathead/jquery/output.txt
@@ -1,1919 +1,1919 @@
-.add()	A			jQuery methods							<section class="prog__container"><p>Create a new jQuery object with elements added to the set of matched elements.</p><pre><code>$(selector).add(selector) → jQuery\n$(selector).add(elements) → jQuery\n$(selector).add(html) → jQuery\n$(selector).add(selection) → jQuery\n$(selector).add(selector, context) → jQuery</code></pre></section>	https://api.jquery.com/add/
-.addBack()	A			jQuery methods							<section class="prog__container"><p>Add the previous set of elements on the stack to the current set, optionally filtered by a selector.</p><pre><code>$(selector).addBack(selector) → jQuery</code></pre></section>	https://api.jquery.com/addBack/
-add back	R	.addBack()										
-addback	R	.addBack()										
-.addBack	R	.addBack()										
-addBack()	R	.addBack()										
-addBack	R	.addBack()										
-.addClass()	A			jQuery methods							<section class="prog__container"><p>Adds the specified class(es) to each element in the set of matched elements.</p><pre><code>$(selector).addClass(className) → jQuery\n$(selector).addClass(function) → jQuery</code></pre></section>	https://api.jquery.com/addClass/
-add class	R	.addClass()										
-addclass	R	.addClass()										
-.addClass	R	.addClass()										
-addClass()	R	.addClass()										
-addClass	R	.addClass()										
-.add	R	.add()										
-add()	R	.add()										
-add	R	.add()										
-.after()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, after each element in the set of matched elements.</p><pre><code>$(selector).after(content, content) → jQuery\n$(selector).after(function) → jQuery\n$(selector).after(function-html) → jQuery</code></pre></section>	https://api.jquery.com/after/
-.after	R	.after()										
-after()	R	.after()										
-after	R	.after()										
-.ajaxComplete()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when Ajax requests complete. This is an AjaxEvent.</p><pre><code>$(selector).ajaxComplete(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxComplete/
-ajax complete	R	.ajaxComplete()										
-ajaxcomplete	R	.ajaxComplete()										
-.ajaxComplete	R	.ajaxComplete()										
-ajaxComplete()	R	.ajaxComplete()										
-ajaxComplete	R	.ajaxComplete()										
-.ajaxError()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.</p><pre><code>$(selector).ajaxError(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxError/
-ajax error	R	.ajaxError()										
-ajaxerror	R	.ajaxError()										
-.ajaxError	R	.ajaxError()										
-ajaxError()	R	.ajaxError()										
-ajaxError	R	.ajaxError()										
-ajax prefilter	R	jQuery.ajaxPrefilter()										
-ajaxprefilter	R	jQuery.ajaxPrefilter()										
-.ajaxPrefilter()	R	jQuery.ajaxPrefilter()										
-.ajaxPrefilter	R	jQuery.ajaxPrefilter()										
-$.ajaxPrefilter()	R	jQuery.ajaxPrefilter()										
-$.ajaxPrefilter	R	jQuery.ajaxPrefilter()										
-ajaxPrefilter()	R	jQuery.ajaxPrefilter()										
-ajaxPrefilter	R	jQuery.ajaxPrefilter()										
-.ajax()	R	jQuery.ajax()										
-.ajax	R	jQuery.ajax()										
-$.ajax()	R	jQuery.ajax()										
-$.ajax	R	jQuery.ajax()										
-ajax()	R	jQuery.ajax()										
-ajax	R	jQuery.ajax()										
-.ajaxSend()	A			jQuery methods							<section class="prog__container"><p>Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.</p><pre><code>$(selector).ajaxSend(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxSend/
-ajax send	R	.ajaxSend()										
-ajaxsend	R	.ajaxSend()										
-.ajaxSend	R	.ajaxSend()										
-ajaxSend()	R	.ajaxSend()										
-ajaxSend	R	.ajaxSend()										
-ajax setup	R	jQuery.ajaxSetup()										
-ajaxsetup	R	jQuery.ajaxSetup()										
-.ajaxSetup()	R	jQuery.ajaxSetup()										
-.ajaxSetup	R	jQuery.ajaxSetup()										
-$.ajaxSetup()	R	jQuery.ajaxSetup()										
-$.ajaxSetup	R	jQuery.ajaxSetup()										
-ajaxSetup()	R	jQuery.ajaxSetup()										
-ajaxSetup	R	jQuery.ajaxSetup()										
-.ajaxStart()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when the first Ajax request begins. This is an Ajax Event.</p><pre><code>$(selector).ajaxStart(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxStart/
-ajax start	R	.ajaxStart()										
-ajaxstart	R	.ajaxStart()										
-.ajaxStart	R	.ajaxStart()										
-ajaxStart()	R	.ajaxStart()										
-ajaxStart	R	.ajaxStart()										
-.ajaxStop()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when all Ajax requests have completed. This is an Ajax Event.</p><pre><code>$(selector).ajaxStop(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxStop/
-ajax stop	R	.ajaxStop()										
-ajaxstop	R	.ajaxStop()										
-.ajaxStop	R	.ajaxStop()										
-ajaxStop()	R	.ajaxStop()										
-ajaxStop	R	.ajaxStop()										
-.ajaxSuccess()	A			jQuery methods							<section class="prog__container"><p>Attach a function to be executed whenever an Ajax request completes successfully. This is an Ajax Event.</p><pre><code>$(selector).ajaxSuccess(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxSuccess/
-ajax success	R	.ajaxSuccess()										
-ajaxsuccess	R	.ajaxSuccess()										
-.ajaxSuccess	R	.ajaxSuccess()										
-ajaxSuccess()	R	.ajaxSuccess()										
-ajaxSuccess	R	.ajaxSuccess()										
-ajax transport	R	jQuery.ajaxTransport()										
-ajaxtransport	R	jQuery.ajaxTransport()										
-.ajaxTransport()	R	jQuery.ajaxTransport()										
-.ajaxTransport	R	jQuery.ajaxTransport()										
-$.ajaxTransport()	R	jQuery.ajaxTransport()										
-$.ajaxTransport	R	jQuery.ajaxTransport()										
-ajaxTransport()	R	jQuery.ajaxTransport()										
-ajaxTransport	R	jQuery.ajaxTransport()										
-All Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements.</p><pre><code>$("*") → jQuery</code></pre></section>	https://api.jquery.com/all-selector/
-all selector	R	All Selector										
-.always()	R	deferred.always()										
-.always	R	deferred.always()										
-always()	R	deferred.always()										
-always	R	deferred.always()										
-.andSelf()	A			jQuery methods							<section class="prog__container"><p>Add the previous set of elements on the stack to the current set.</p><pre><code>$(selector).andSelf() → jQuery</code></pre></section>	https://api.jquery.com/andSelf/
-and self	R	.andSelf()										
-andself	R	.andSelf()										
-.andSelf	R	.andSelf()										
-andSelf()	R	.andSelf()										
-andSelf	R	.andSelf()										
-.animate()	A			jQuery methods							<section class="prog__container"><p>Perform a custom animation of a set of CSS properties.</p><pre><code>$(selector).animate(properties, duration, easing, complete) → jQuery\n$(selector).animate(properties, options) → jQuery</code></pre></section>	https://api.jquery.com/animate/
-:animated Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that are in the progress of an animation at the time the selector is run.</p><pre><code>$(":animated") → jQuery</code></pre></section>	https://api.jquery.com/animated-selector/
-animated selector	R	:animated Selector										
-.animate	R	.animate()										
-animate()	R	.animate()										
-animate	R	.animate()										
-.append()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, to the end of each element in the set of matched elements.</p><pre><code>$(selector).append(content, content) → jQuery\n$(selector).append(function) → jQuery</code></pre></section>	https://api.jquery.com/append/
-.append	R	.append()										
-append()	R	.append()										
-append	R	.append()										
-.appendTo()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements to the end of the target.</p><pre><code>$(selector).appendTo(target) → jQuery</code></pre></section>	https://api.jquery.com/appendTo/
-append to	R	.appendTo()										
-appendto	R	.appendTo()										
-.appendTo	R	.appendTo()										
-appendTo()	R	.appendTo()										
-appendTo	R	.appendTo()										
-.attr()	A			jQuery methods							<section class="prog__container"><p>Get the value of an attribute for the first element in the set of matched elements.</p><pre><code>$(selector).attr(attributeName) → String</code></pre>\n<p>Set one or more attributes for the set of matched elements.</p><pre><code>$(selector).attr(attributeName, value) → jQuery\n$(selector).attr(attributes) → jQuery\n$(selector).attr(attributeName, function) → jQuery</code></pre></section>	https://api.jquery.com/attr/
-Attribute Contains Prefix Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value either equal to a given string or starting with that string followed by a hyphen (-).</p><pre><code>$("[attribute|='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-contains-prefix-selector/
-attribute contains prefix selector	R	Attribute Contains Prefix Selector										
-Attribute Contains Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value containing a given substring.</p><pre><code>$("[attribute*='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-contains-selector/
-attribute contains selector	R	Attribute Contains Selector										
-Attribute Contains Word Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value containing a given word, delimited by spaces.</p><pre><code>$("[attribute~='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-contains-word-selector/
-attribute contains word selector	R	Attribute Contains Word Selector										
-Attribute Ends With Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value ending exactly with a given string. The comparison is case sensitive.</p><pre><code>$("[attribute$='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-ends-with-selector/
-attribute ends with selector	R	Attribute Ends With Selector										
-Attribute Equals Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value exactly equal to a certain value.</p><pre><code>$("[attribute='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-equals-selector/
-attribute equals selector	R	Attribute Equals Selector										
-Attribute Not Equal Selector	A			jQuery selectors							<section class="prog__container"><p>Select elements that either don't have the specified attribute, or do have the specified attribute but not with a certain value.</p><pre><code>$("[attribute!='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-not-equal-selector/
-attribute not equal selector	R	Attribute Not Equal Selector										
-Attribute Starts With Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value beginning exactly with a given string.</p><pre><code>$("[attribute^='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-starts-with-selector/
-attribute starts with selector	R	Attribute Starts With Selector										
-.attr	R	.attr()										
-attr()	R	.attr()										
-attr	R	.attr()										
-.before()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, before each element in the set of matched elements.</p><pre><code>$(selector).before(content, content) → jQuery\n$(selector).before(function) → jQuery\n$(selector).before(function-html) → jQuery</code></pre></section>	https://api.jquery.com/before/
-.before	R	.before()										
-before()	R	.before()										
-before	R	.before()										
-.bind()	A			jQuery methods							<section class="prog__container"><p>Attach a handler to an event for the elements.</p><pre><code>$(selector).bind(eventType, eventData, handler) → jQuery\n$(selector).bind(eventType, eventData, preventBubble) → jQuery\n$(selector).bind(events) → jQuery</code></pre></section>	https://api.jquery.com/bind/
-.bind event	R	.bind()										
-.bind() event	R	.bind()										
-bind event	R	.bind()										
-bind() event	R	.bind()										
-.bind	R	.bind()										
-bind()	R	.bind()										
-bind	R	.bind()										
-.blur()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).blur(handler) → jQuery\n$(selector).blur(eventData, handler) → jQuery\n$(selector).blur() → jQuery</code></pre></section>	https://api.jquery.com/blur/
-.blur event	R	.blur()										
-.blur() event	R	.blur()										
-blur event	R	.blur()										
-blur() event	R	.blur()										
-.blur	R	.blur()										
-blur()	R	.blur()										
-blur	R	.blur()										
-box model	R	jQuery.boxModel										
-boxmodel	R	jQuery.boxModel										
-.boxModel	R	jQuery.boxModel										
-$.boxModel	R	jQuery.boxModel										
-boxModel	R	jQuery.boxModel										
-.browser	R	jQuery.browser										
-$.browser	R	jQuery.browser										
-browser	R	jQuery.browser										
-:button Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all button elements and elements of type button.</p><pre><code>$(":button") → jQuery</code></pre></section>	https://api.jquery.com/button-selector/
-button selector	R	:button Selector										
-callbacks.add()	A			jQuery methods							<section class="prog__container"><p>Add a callback or a collection of callbacks to a callback list.</p><pre><code>callbacks.add(callbacks) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.add/
-callbacks add	R	callbacks.add()										
-callbacks.add	R	callbacks.add()										
-callbacks.disable()	A			jQuery methods							<section class="prog__container"><p>Disable a callback list from doing anything more.</p><pre><code>callbacks.disable() → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.disable/
-callbacks.disabled()	A			jQuery methods							<section class="prog__container"><p>Determine if the callbacks list has been disabled.</p><pre><code>callbacks.disabled() → Boolean</code></pre></section>	https://api.jquery.com/callbacks.disabled/
-callbacks disabled	R	callbacks.disabled()										
-callbacks.disabled	R	callbacks.disabled()										
-callbacks disable	R	callbacks.disable()										
-callbacks.disable	R	callbacks.disable()										
-callbacks.empty()	A			jQuery methods							<section class="prog__container"><p>Remove all of the callbacks from a list.</p><pre><code>callbacks.empty() → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.empty/
-callbacks empty	R	callbacks.empty()										
-callbacks.empty	R	callbacks.empty()										
-callbacks.fire()	A			jQuery methods							<section class="prog__container"><p>Call all of the callbacks with the given arguments.</p><pre><code>callbacks.fire(arguments) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.fire/
-callbacks.fired()	A			jQuery methods							<section class="prog__container"><p>Determine if the callbacks have already been called at least once.</p><pre><code>callbacks.fired() → Boolean</code></pre></section>	https://api.jquery.com/callbacks.fired/
-callbacks fired	R	callbacks.fired()										
-callbacks.fired	R	callbacks.fired()										
-callbacks fire	R	callbacks.fire()										
-callbacks.fire	R	callbacks.fire()										
-callbacks.fireWith()	A			jQuery methods							<section class="prog__container"><p>Call all callbacks in a list with the given context and arguments.</p><pre><code>callbacks.fireWith(context, args) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.fireWith/
-callbacks fire with	R	callbacks.fireWith()										
-callbacks firewith	R	callbacks.fireWith()										
-callbacks.fireWith	R	callbacks.fireWith()										
-callbacks.has()	A			jQuery methods							<section class="prog__container"><p>Determine whether or not the list has any callbacks attached. If a callback is provided as an argument, determine whether it is in a list.</p><pre><code>callbacks.has(callback) → Boolean</code></pre></section>	https://api.jquery.com/callbacks.has/
-callbacks has	R	callbacks.has()										
-callbacks.has	R	callbacks.has()										
-callbacks.lock()	A			jQuery methods							<section class="prog__container"><p>Lock a callback list in its current state.</p><pre><code>callbacks.lock() → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.lock/
-callbacks.locked()	A			jQuery methods							<section class="prog__container"><p>Determine if the callbacks list has been locked.</p><pre><code>callbacks.locked() → Boolean</code></pre></section>	https://api.jquery.com/callbacks.locked/
-callbacks locked	R	callbacks.locked()										
-callbacks.locked	R	callbacks.locked()										
-callbacks lock	R	callbacks.lock()										
-callbacks.lock	R	callbacks.lock()										
-callbacks.remove()	A			jQuery methods							<section class="prog__container"><p>Remove a callback or a collection of callbacks from a callback list.</p><pre><code>callbacks.remove(callbacks) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.remove/
-callbacks remove	R	callbacks.remove()										
-callbacks.remove	R	callbacks.remove()										
-callbacks	R	jQuery.Callbacks()										
-.Callbacks()	R	jQuery.Callbacks()										
-.Callbacks	R	jQuery.Callbacks()										
-$.Callbacks()	R	jQuery.Callbacks()										
+	R	jQuery()										
+$.)	R	jQuery()										
 $.Callbacks	R	jQuery.Callbacks()										
-Callbacks()	R	jQuery.Callbacks()										
-Callbacks	R	jQuery.Callbacks()										
-.catch()	R	deferred.catch()										
-.catch	R	deferred.catch()										
-catch()	R	deferred.catch()										
-catch	R	deferred.catch()										
-.change()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "change" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).change(handler) → jQuery\n$(selector).change(eventData, handler) → jQuery\n$(selector).change() → jQuery</code></pre></section>	https://api.jquery.com/change/
-.change event	R	.change()										
-.change() event	R	.change()										
-change event	R	.change()										
-change() event	R	.change()										
-.change	R	.change()										
-change()	R	.change()										
-change	R	.change()										
-:checkbox Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type checkbox.</p><pre><code>$(":checkbox") → jQuery</code></pre></section>	https://api.jquery.com/checkbox-selector/
-checkbox selector	R	:checkbox Selector										
-:checked Selector	A			jQuery selectors							<section class="prog__container"><p>Matches all elements that are checked or selected.</p><pre><code>$(":checked") → jQuery</code></pre></section>	https://api.jquery.com/checked-selector/
-checked selector	R	:checked Selector										
-.children()	A			jQuery methods							<section class="prog__container"><p>Get the children of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).children(selector) → jQuery</code></pre></section>	https://api.jquery.com/children/
-.children	R	.children()										
-children()	R	.children()										
-children	R	.children()										
-Child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all direct child elements specified by "child" of elements specified by "parent".</p><pre><code>$("parent > child") → jQuery</code></pre></section>	https://api.jquery.com/child-selector/
-child selector	R	Child Selector										
-Class Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements with the given class. </p><pre><code>$(".class") → jQuery</code></pre></section>	https://api.jquery.com/class-selector/
-class selector	R	Class Selector										
-.clearQueue()	A			jQuery methods							<section class="prog__container"><p>Remove from the queue all items that have not yet been run.</p><pre><code>$(selector).clearQueue(queueName) → jQuery</code></pre></section>	https://api.jquery.com/clearQueue/
-clear queue	R	.clearQueue()										
-clearqueue	R	.clearQueue()										
-.clearQueue	R	.clearQueue()										
-clearQueue()	R	.clearQueue()										
-clearQueue	R	.clearQueue()										
-.click()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "click" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).click(handler) → jQuery\n$(selector).click(eventData, handler) → jQuery\n$(selector).click() → jQuery</code></pre></section>	https://api.jquery.com/click/
-.click event	R	.click()										
-.click() event	R	.click()										
-click event	R	.click()										
-click() event	R	.click()										
-.click	R	.click()										
-click()	R	.click()										
-click	R	.click()										
-.clone()	A			jQuery methods							<section class="prog__container"><p>Create a deep copy of the set of matched elements.</p><pre><code>$(selector).clone(withDataAndEvents) → jQuery\n$(selector).clone(withDataAndEvents, deepWithDataAndEvents) → jQuery</code></pre></section>	https://api.jquery.com/clone/
-.clone	R	.clone()										
-clone()	R	.clone()										
-clone	R	.clone()										
-.closest()	A			jQuery methods							<section class="prog__container"><p>For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.</p><pre><code>$(selector).closest(selector) → jQuery\n$(selector).closest(selector, context) → jQuery\n$(selector).closest(selection) → jQuery\n$(selector).closest(element) → jQuery</code></pre>\n<p>Get an array of all the elements and selectors matched against the current element up through the DOM tree.</p><pre><code>$(selector).closest(selectors, context) → Array</code></pre></section>	https://api.jquery.com/closest/
-.closest	R	.closest()										
-closest()	R	.closest()										
-closest	R	.closest()										
-.contains()	R	jQuery.contains()										
-.contains	R	jQuery.contains()										
-$.contains()	R	jQuery.contains()										
+$.Callbacks()	R	jQuery.Callbacks()										
+$.Deferred	R	jQuery.Deferred()										
+$.Deferred()	R	jQuery.Deferred()										
+$.ajax	R	jQuery.ajax()										
+$.ajax()	R	jQuery.ajax()										
+$.ajaxPrefilter	R	jQuery.ajaxPrefilter()										
+$.ajaxPrefilter()	R	jQuery.ajaxPrefilter()										
+$.ajaxSetup	R	jQuery.ajaxSetup()										
+$.ajaxSetup()	R	jQuery.ajaxSetup()										
+$.ajaxTransport	R	jQuery.ajaxTransport()										
+$.ajaxTransport()	R	jQuery.ajaxTransport()										
+$.boxModel	R	jQuery.boxModel										
+$.browser	R	jQuery.browser										
 $.contains	R	jQuery.contains()										
-contains()	R	jQuery.contains()										
-contains	R	jQuery.contains()										
-:contains() Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that contain the specified text.</p><pre><code>$(":contains(text)") → jQuery</code></pre></section>	https://api.jquery.com/contains-selector/
-contains selector	R	:contains() Selector										
-.contents()	A			jQuery methods							<section class="prog__container"><p>Get the children of each element in the set of matched elements, including text and comment nodes.</p><pre><code>$(selector).contents() → jQuery</code></pre></section>	https://api.jquery.com/contents/
-.contents	R	.contents()										
-contents()	R	.contents()										
-contents	R	.contents()										
-.context	A			jQuery properties							<section class="prog__container"><p>The DOM node context originally passed to jQuery(); if none was passed then context will likely be the document.</p><pre><code>$(selector).context → Element</code></pre></section>	https://api.jquery.com/context/
-.contextmenu()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).contextmenu(handler) → jQuery\n$(selector).contextmenu(eventData, handler) → jQuery\n$(selector).contextmenu() → jQuery</code></pre></section>	https://api.jquery.com/contextmenu/
-.contextmenu event	R	.contextmenu()										
-.contextmenu() event	R	.contextmenu()										
-contextmenu event	R	.contextmenu()										
-contextmenu() event	R	.contextmenu()										
-.contextmenu	R	.contextmenu()										
-contextmenu()	R	.contextmenu()										
-contextmenu	R	.contextmenu()										
-context	R	.context										
-.css()	A			jQuery methods							<section class="prog__container"><p>Get the computed style properties for the first element in the set of matched elements.</p><pre><code>$(selector).css(propertyName) → String\n$(selector).css(propertyNames) → String</code></pre>\n<p>Set one or more CSS properties for the set of matched elements.</p><pre><code>$(selector).css(propertyName, value) → jQuery\n$(selector).css(propertyName, function) → jQuery\n$(selector).css(properties) → jQuery</code></pre></section>	https://api.jquery.com/css/
-css hooks	R	jQuery.cssHooks										
-csshooks	R	jQuery.cssHooks										
-.cssHooks	R	jQuery.cssHooks										
+$.contains()	R	jQuery.contains()										
 $.cssHooks	R	jQuery.cssHooks										
-cssHooks	R	jQuery.cssHooks										
-css number	R	jQuery.cssNumber										
-cssnumber	R	jQuery.cssNumber										
-.cssNumber	R	jQuery.cssNumber										
 $.cssNumber	R	jQuery.cssNumber										
-cssNumber	R	jQuery.cssNumber										
-.css	R	.css()										
-css()	R	.css()										
-css	R	.css()										
-current target	R	event.currentTarget										
-currenttarget	R	event.currentTarget										
-.currentTarget	R	event.currentTarget										
-currentTarget	R	event.currentTarget										
-.data()	A			jQuery methods							<section class="prog__container"><p>Store arbitrary data associated with the matched elements.</p><pre><code>$(selector).data(key, value) → jQuery\n$(selector).data(obj) → jQuery</code></pre>\n<p>Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.</p><pre><code>$(selector).data(key) → Object\n$(selector).data() → Object</code></pre></section>	https://api.jquery.com/data/
-.data	R	.data()										
-data()	R	.data()										
-data	R	.data()										
-$.data()	R	jQuery.data()										
 $.data	R	jQuery.data()										
-.dblclick()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).dblclick(handler) → jQuery\n$(selector).dblclick(eventData, handler) → jQuery\n$(selector).dblclick() → jQuery</code></pre></section>	https://api.jquery.com/dblclick/
-.dblclick event	R	.dblclick()										
-.dblclick() event	R	.dblclick()										
-dblclick event	R	.dblclick()										
-dblclick() event	R	.dblclick()										
+$.data()	R	jQuery.data()										
+$.dequeue	R	jQuery.dequeue()										
+$.dequeue()	R	jQuery.dequeue()										
+$.each	R	jQuery.each()										
+$.each()	R	jQuery.each()										
+$.error	R	jQuery.error()										
+$.error()	R	jQuery.error()										
+$.escapeSelector	R	jQuery.escapeSelector()										
+$.escapeSelector()	R	jQuery.escapeSelector()										
+$.extend	R	jQuery.extend()										
+$.extend()	R	jQuery.extend()										
+$.fn.extend	R	jQuery.fn.extend()										
+$.fn.extend()	R	jQuery.fn.extend()										
+$.fx.interval	R	jQuery.fx.interval										
+$.fx.off	R	jQuery.fx.off										
+$.get	R	jQuery.get()										
+$.get()	R	jQuery.get()										
+$.getJSON	R	jQuery.getJSON()										
+$.getJSON()	R	jQuery.getJSON()										
+$.getScript	R	jQuery.getScript()										
+$.getScript()	R	jQuery.getScript()										
+$.globalEval	R	jQuery.globalEval()										
+$.globalEval()	R	jQuery.globalEval()										
+$.grep	R	jQuery.grep()										
+$.grep()	R	jQuery.grep()										
+$.hasData	R	jQuery.hasData()										
+$.hasData()	R	jQuery.hasData()										
+$.holdReady	R	jQuery.holdReady()										
+$.holdReady()	R	jQuery.holdReady()										
+$.htmlPrefilter	R	jQuery.htmlPrefilter()										
+$.htmlPrefilter()	R	jQuery.htmlPrefilter()										
+$.inArray	R	jQuery.inArray()										
+$.inArray()	R	jQuery.inArray()										
+$.isArray	R	jQuery.isArray()										
+$.isArray()	R	jQuery.isArray()										
+$.isEmptyObject	R	jQuery.isEmptyObject()										
+$.isEmptyObject()	R	jQuery.isEmptyObject()										
+$.isFunction	R	jQuery.isFunction()										
+$.isFunction()	R	jQuery.isFunction()										
+$.isNumeric	R	jQuery.isNumeric()										
+$.isNumeric()	R	jQuery.isNumeric()										
+$.isPlainObject	R	jQuery.isPlainObject()										
+$.isPlainObject()	R	jQuery.isPlainObject()										
+$.isWindow	R	jQuery.isWindow()										
+$.isWindow()	R	jQuery.isWindow()										
+$.isXMLDoc	R	jQuery.isXMLDoc()										
+$.isXMLDoc()	R	jQuery.isXMLDoc()										
+$.makeArray	R	jQuery.makeArray()										
+$.makeArray()	R	jQuery.makeArray()										
+$.map	R	jQuery.map()										
+$.map()	R	jQuery.map()										
+$.merge	R	jQuery.merge()										
+$.merge()	R	jQuery.merge()										
+$.noConflict	R	jQuery.noConflict()										
+$.noConflict()	R	jQuery.noConflict()										
+$.noop	R	jQuery.noop()										
+$.noop()	R	jQuery.noop()										
+$.now	R	jQuery.now()										
+$.now()	R	jQuery.now()										
+$.param	R	jQuery.param()										
+$.param()	R	jQuery.param()										
+$.parseHTML	R	jQuery.parseHTML()										
+$.parseHTML()	R	jQuery.parseHTML()										
+$.parseJSON	R	jQuery.parseJSON()										
+$.parseJSON()	R	jQuery.parseJSON()										
+$.parseXML	R	jQuery.parseXML()										
+$.parseXML()	R	jQuery.parseXML()										
+$.post	R	jQuery.post()										
+$.post()	R	jQuery.post()										
+$.proxy	R	jQuery.proxy()										
+$.proxy()	R	jQuery.proxy()										
+$.queue	R	jQuery.queue()										
+$.queue()	R	jQuery.queue()										
+$.readyException	R	jQuery.readyException()										
+$.readyException()	R	jQuery.readyException()										
+$.removeData	R	jQuery.removeData()										
+$.removeData()	R	jQuery.removeData()										
+$.speed	R	jQuery.speed										
+$.sub	R	jQuery.sub()										
+$.sub()	R	jQuery.sub()										
+$.support	R	jQuery.support										
+$.trim	R	jQuery.trim()										
+$.trim()	R	jQuery.trim()										
+$.type	R	jQuery.type()										
+$.type()	R	jQuery.type()										
+$.unique	R	jQuery.unique()										
+$.unique()	R	jQuery.unique()										
+$.uniqueSort	R	jQuery.uniqueSort()										
+$.uniqueSort()	R	jQuery.uniqueSort()										
+$.when	R	jQuery.when()										
+$.when()	R	jQuery.when()										
+.Callbacks	R	jQuery.Callbacks()										
+.Callbacks()	R	jQuery.Callbacks()										
+.Deferred	R	jQuery.Deferred()										
+.Deferred()	R	jQuery.Deferred()										
+.add	R	.add()										
+.add()	A			jQuery methods							<section class="prog__container"><p>Create a new jQuery object with elements added to the set of matched elements.</p><pre><code>$(selector).add(selector) → jQuery\n$(selector).add(elements) → jQuery\n$(selector).add(html) → jQuery\n$(selector).add(selection) → jQuery\n$(selector).add(selector, context) → jQuery</code></pre></section>	https://api.jquery.com/add/
+.addBack	R	.addBack()										
+.addBack()	A			jQuery methods							<section class="prog__container"><p>Add the previous set of elements on the stack to the current set, optionally filtered by a selector.</p><pre><code>$(selector).addBack(selector) → jQuery</code></pre></section>	https://api.jquery.com/addBack/
+.addClass	R	.addClass()										
+.addClass()	A			jQuery methods							<section class="prog__container"><p>Adds the specified class(es) to each element in the set of matched elements.</p><pre><code>$(selector).addClass(className) → jQuery\n$(selector).addClass(function) → jQuery</code></pre></section>	https://api.jquery.com/addClass/
+.after	R	.after()										
+.after()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, after each element in the set of matched elements.</p><pre><code>$(selector).after(content, content) → jQuery\n$(selector).after(function) → jQuery\n$(selector).after(function-html) → jQuery</code></pre></section>	https://api.jquery.com/after/
+.ajax	R	jQuery.ajax()										
+.ajax()	R	jQuery.ajax()										
+.ajaxComplete	R	.ajaxComplete()										
+.ajaxComplete()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when Ajax requests complete. This is an AjaxEvent.</p><pre><code>$(selector).ajaxComplete(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxComplete/
+.ajaxError	R	.ajaxError()										
+.ajaxError()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.</p><pre><code>$(selector).ajaxError(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxError/
+.ajaxPrefilter	R	jQuery.ajaxPrefilter()										
+.ajaxPrefilter()	R	jQuery.ajaxPrefilter()										
+.ajaxSend	R	.ajaxSend()										
+.ajaxSend()	A			jQuery methods							<section class="prog__container"><p>Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.</p><pre><code>$(selector).ajaxSend(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxSend/
+.ajaxSetup	R	jQuery.ajaxSetup()										
+.ajaxSetup()	R	jQuery.ajaxSetup()										
+.ajaxStart	R	.ajaxStart()										
+.ajaxStart()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when the first Ajax request begins. This is an Ajax Event.</p><pre><code>$(selector).ajaxStart(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxStart/
+.ajaxStop	R	.ajaxStop()										
+.ajaxStop()	A			jQuery methods							<section class="prog__container"><p>Register a handler to be called when all Ajax requests have completed. This is an Ajax Event.</p><pre><code>$(selector).ajaxStop(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxStop/
+.ajaxSuccess	R	.ajaxSuccess()										
+.ajaxSuccess()	A			jQuery methods							<section class="prog__container"><p>Attach a function to be executed whenever an Ajax request completes successfully. This is an Ajax Event.</p><pre><code>$(selector).ajaxSuccess(handler) → jQuery</code></pre></section>	https://api.jquery.com/ajaxSuccess/
+.ajaxTransport	R	jQuery.ajaxTransport()										
+.ajaxTransport()	R	jQuery.ajaxTransport()										
+.always	R	deferred.always()										
+.always()	R	deferred.always()										
+.andSelf	R	.andSelf()										
+.andSelf()	A			jQuery methods							<section class="prog__container"><p>Add the previous set of elements on the stack to the current set.</p><pre><code>$(selector).andSelf() → jQuery</code></pre></section>	https://api.jquery.com/andSelf/
+.animate	R	.animate()										
+.animate()	A			jQuery methods							<section class="prog__container"><p>Perform a custom animation of a set of CSS properties.</p><pre><code>$(selector).animate(properties, duration, easing, complete) → jQuery\n$(selector).animate(properties, options) → jQuery</code></pre></section>	https://api.jquery.com/animate/
+.append	R	.append()										
+.append()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, to the end of each element in the set of matched elements.</p><pre><code>$(selector).append(content, content) → jQuery\n$(selector).append(function) → jQuery</code></pre></section>	https://api.jquery.com/append/
+.appendTo	R	.appendTo()										
+.appendTo()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements to the end of the target.</p><pre><code>$(selector).appendTo(target) → jQuery</code></pre></section>	https://api.jquery.com/appendTo/
+.attr	R	.attr()										
+.attr()	A			jQuery methods							<section class="prog__container"><p>Get the value of an attribute for the first element in the set of matched elements.</p><pre><code>$(selector).attr(attributeName) → String</code></pre>\n<p>Set one or more attributes for the set of matched elements.</p><pre><code>$(selector).attr(attributeName, value) → jQuery\n$(selector).attr(attributes) → jQuery\n$(selector).attr(attributeName, function) → jQuery</code></pre></section>	https://api.jquery.com/attr/
+.before	R	.before()										
+.before()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, before each element in the set of matched elements.</p><pre><code>$(selector).before(content, content) → jQuery\n$(selector).before(function) → jQuery\n$(selector).before(function-html) → jQuery</code></pre></section>	https://api.jquery.com/before/
+.bind	R	.bind()										
+.bind event	R	.bind()										
+.bind()	A			jQuery methods							<section class="prog__container"><p>Attach a handler to an event for the elements.</p><pre><code>$(selector).bind(eventType, eventData, handler) → jQuery\n$(selector).bind(eventType, eventData, preventBubble) → jQuery\n$(selector).bind(events) → jQuery</code></pre></section>	https://api.jquery.com/bind/
+.bind() event	R	.bind()										
+.blur	R	.blur()										
+.blur event	R	.blur()										
+.blur()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).blur(handler) → jQuery\n$(selector).blur(eventData, handler) → jQuery\n$(selector).blur() → jQuery</code></pre></section>	https://api.jquery.com/blur/
+.blur() event	R	.blur()										
+.boxModel	R	jQuery.boxModel										
+.browser	R	jQuery.browser										
+.catch	R	deferred.catch()										
+.catch()	R	deferred.catch()										
+.change	R	.change()										
+.change event	R	.change()										
+.change()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "change" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).change(handler) → jQuery\n$(selector).change(eventData, handler) → jQuery\n$(selector).change() → jQuery</code></pre></section>	https://api.jquery.com/change/
+.change() event	R	.change()										
+.children	R	.children()										
+.children()	A			jQuery methods							<section class="prog__container"><p>Get the children of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).children(selector) → jQuery</code></pre></section>	https://api.jquery.com/children/
+.clearQueue	R	.clearQueue()										
+.clearQueue()	A			jQuery methods							<section class="prog__container"><p>Remove from the queue all items that have not yet been run.</p><pre><code>$(selector).clearQueue(queueName) → jQuery</code></pre></section>	https://api.jquery.com/clearQueue/
+.click	R	.click()										
+.click event	R	.click()										
+.click()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "click" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).click(handler) → jQuery\n$(selector).click(eventData, handler) → jQuery\n$(selector).click() → jQuery</code></pre></section>	https://api.jquery.com/click/
+.click() event	R	.click()										
+.clone	R	.clone()										
+.clone()	A			jQuery methods							<section class="prog__container"><p>Create a deep copy of the set of matched elements.</p><pre><code>$(selector).clone(withDataAndEvents) → jQuery\n$(selector).clone(withDataAndEvents, deepWithDataAndEvents) → jQuery</code></pre></section>	https://api.jquery.com/clone/
+.closest	R	.closest()										
+.closest()	A			jQuery methods							<section class="prog__container"><p>For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.</p><pre><code>$(selector).closest(selector) → jQuery\n$(selector).closest(selector, context) → jQuery\n$(selector).closest(selection) → jQuery\n$(selector).closest(element) → jQuery</code></pre>\n<p>Get an array of all the elements and selectors matched against the current element up through the DOM tree.</p><pre><code>$(selector).closest(selectors, context) → Array</code></pre></section>	https://api.jquery.com/closest/
+.contains	R	jQuery.contains()										
+.contains()	R	jQuery.contains()										
+.contents	R	.contents()										
+.contents()	A			jQuery methods							<section class="prog__container"><p>Get the children of each element in the set of matched elements, including text and comment nodes.</p><pre><code>$(selector).contents() → jQuery</code></pre></section>	https://api.jquery.com/contents/
+.context	A			jQuery properties							<section class="prog__container"><p>The DOM node context originally passed to jQuery(); if none was passed then context will likely be the document.</p><pre><code>$(selector).context → Element</code></pre></section>	https://api.jquery.com/context/
+.contextmenu	R	.contextmenu()										
+.contextmenu event	R	.contextmenu()										
+.contextmenu()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).contextmenu(handler) → jQuery\n$(selector).contextmenu(eventData, handler) → jQuery\n$(selector).contextmenu() → jQuery</code></pre></section>	https://api.jquery.com/contextmenu/
+.contextmenu() event	R	.contextmenu()										
+.css	R	.css()										
+.css()	A			jQuery methods							<section class="prog__container"><p>Get the computed style properties for the first element in the set of matched elements.</p><pre><code>$(selector).css(propertyName) → String\n$(selector).css(propertyNames) → String</code></pre>\n<p>Set one or more CSS properties for the set of matched elements.</p><pre><code>$(selector).css(propertyName, value) → jQuery\n$(selector).css(propertyName, function) → jQuery\n$(selector).css(properties) → jQuery</code></pre></section>	https://api.jquery.com/css/
+.cssHooks	R	jQuery.cssHooks										
+.cssNumber	R	jQuery.cssNumber										
+.currentTarget	R	event.currentTarget										
+.data	R	.data()										
+.data()	A			jQuery methods							<section class="prog__container"><p>Store arbitrary data associated with the matched elements.</p><pre><code>$(selector).data(key, value) → jQuery\n$(selector).data(obj) → jQuery</code></pre>\n<p>Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.</p><pre><code>$(selector).data(key) → Object\n$(selector).data() → Object</code></pre></section>	https://api.jquery.com/data/
 .dblclick	R	.dblclick()										
-dblclick()	R	.dblclick()										
+.dblclick event	R	.dblclick()										
+.dblclick()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).dblclick(handler) → jQuery\n$(selector).dblclick(eventData, handler) → jQuery\n$(selector).dblclick() → jQuery</code></pre></section>	https://api.jquery.com/dblclick/
+.dblclick() event	R	.dblclick()										
+.delay	R	.delay()										
+.delay()	A			jQuery methods							<section class="prog__container"><p>Set a timer to delay execution of subsequent items in the queue.</p><pre><code>$(selector).delay(duration, queueName) → jQuery</code></pre></section>	https://api.jquery.com/delay/
+.delegate	R	.delegate()										
+.delegate event	R	.delegate()										
+.delegate()	A			jQuery methods							<section class="prog__container"><p>Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.</p><pre><code>$(selector).delegate(selector, eventType, handler) → jQuery\n$(selector).delegate(selector, eventType, eventData, handler) → jQuery\n$(selector).delegate(selector, events) → jQuery</code></pre></section>	https://api.jquery.com/delegate/
+.delegate() event	R	.delegate()										
+.delegateTarget	R	event.delegateTarget										
+.dequeue	R	.dequeue()										
+.dequeue()	A			jQuery methods							<section class="prog__container"><p>Execute the next function on the queue for the matched elements.</p><pre><code>$(selector).dequeue(queueName) → jQuery</code></pre></section>	https://api.jquery.com/dequeue/
+.detach	R	.detach()										
+.detach()	A			jQuery methods							<section class="prog__container"><p>Remove the set of matched elements from the DOM.</p><pre><code>$(selector).detach(selector) → jQuery</code></pre></section>	https://api.jquery.com/detach/
+.die	R	.die()										
+.die event	R	.die()										
+.die()	A			jQuery methods							<section class="prog__container"><p>Remove event handlers previously attached using .live() from the elements.</p><pre><code>$(selector).die() → jQuery\n$(selector).die(eventType, handler) → jQuery\n$(selector).die(events) → jQuery</code></pre></section>	https://api.jquery.com/die/
+.die() event	R	.die()										
+.disable	R	callbacks.disable()										
+.disable()	R	callbacks.disable()										
+.disabled	R	callbacks.disabled()										
+.disabled()	R	callbacks.disabled()										
+.done	R	deferred.done()										
+.done()	R	deferred.done()										
+.each	R	.each()										
+.each()	A			jQuery methods							<section class="prog__container"><p>Iterate over a jQuery object, executing a function for each matched element. </p><pre><code>$(selector).each(function) → jQuery</code></pre></section>	https://api.jquery.com/each/
+.empty	R	.empty()										
+.empty()	A			jQuery methods							<section class="prog__container"><p>Remove all child nodes of the set of matched elements from the DOM.</p><pre><code>$(selector).empty() → jQuery</code></pre></section>	https://api.jquery.com/empty/
+.end	R	.end()										
+.end()	A			jQuery methods							<section class="prog__container"><p>End the most recent filtering operation in the current chain and return the set of matched elements to its previous state.</p><pre><code>$(selector).end() → jQuery</code></pre></section>	https://api.jquery.com/end/
+.eq	R	.eq()										
+.eq()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to the one at the specified index.</p><pre><code>$(selector).eq(index) → jQuery\n$(selector).eq(indexFromEnd) → jQuery</code></pre></section>	https://api.jquery.com/eq/
+.error	R	.error()										
+.error event	R	.error()										
+.error()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "error" JavaScript event.</p><pre><code>$(selector).error(handler) → jQuery\n$(selector).error(eventData, handler) → jQuery</code></pre></section>	https://api.jquery.com/error/
+.error() event	R	.error()										
+.escapeSelector	R	jQuery.escapeSelector()										
+.escapeSelector()	R	jQuery.escapeSelector()										
+.extend	R	jQuery.extend()										
+.extend()	R	jQuery.extend()										
+.fadeIn	R	.fadeIn()										
+.fadeIn()	A			jQuery methods							<section class="prog__container"><p>Display the matched elements by fading them to opaque.</p><pre><code>$(selector).fadeIn(duration, complete) → jQuery\n$(selector).fadeIn(options) → jQuery\n$(selector).fadeIn(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/fadeIn/
+.fadeOut	R	.fadeOut()										
+.fadeOut()	A			jQuery methods							<section class="prog__container"><p>Hide the matched elements by fading them to transparent.</p><pre><code>$(selector).fadeOut(duration, complete) → jQuery\n$(selector).fadeOut(options) → jQuery\n$(selector).fadeOut(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/fadeOut/
+.fadeTo	R	.fadeTo()										
+.fadeTo()	A			jQuery methods							<section class="prog__container"><p>Adjust the opacity of the matched elements.</p><pre><code>$(selector).fadeTo(duration, opacity, complete) → jQuery\n$(selector).fadeTo(duration, opacity, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/fadeTo/
+.fadeToggle	R	.fadeToggle()										
+.fadeToggle()	A			jQuery methods							<section class="prog__container"><p>Display or hide the matched elements by animating their opacity.</p><pre><code>$(selector).fadeToggle(duration, easing, complete) → jQuery\n$(selector).fadeToggle(options) → jQuery</code></pre></section>	https://api.jquery.com/fadeToggle/
+.fail	R	deferred.fail()										
+.fail()	R	deferred.fail()										
+.filter	R	.filter()										
+.filter()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to those that match the selector or pass the function's test. </p><pre><code>$(selector).filter(selector) → jQuery\n$(selector).filter(function) → jQuery\n$(selector).filter(elements) → jQuery\n$(selector).filter(selection) → jQuery</code></pre></section>	https://api.jquery.com/filter/
+.find	R	.find()										
+.find()	A			jQuery methods							<section class="prog__container"><p>Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.</p><pre><code>$(selector).find(selector) → jQuery\n$(selector).find(element) → jQuery</code></pre></section>	https://api.jquery.com/find/
+.finish	R	.finish()										
+.finish()	A			jQuery methods							<section class="prog__container"><p>Stop the currently-running animation, remove all queued animations, and complete all animations for the matched elements.</p><pre><code>$(selector).finish(queue) → jQuery</code></pre></section>	https://api.jquery.com/finish/
+.fire	R	callbacks.fire()										
+.fire()	R	callbacks.fire()										
+.fireWith	R	callbacks.fireWith()										
+.fireWith()	R	callbacks.fireWith()										
+.fired	R	callbacks.fired()										
+.fired()	R	callbacks.fired()										
+.first	R	.first()										
+.first()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to the first in the set.</p><pre><code>$(selector).first() → jQuery</code></pre></section>	https://api.jquery.com/first/
+.fn.extend	R	jQuery.fn.extend()										
+.fn.extend()	R	jQuery.fn.extend()										
+.focus	R	.focus()										
+.focus event	R	.focus()										
+.focus()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).focus(handler) → jQuery\n$(selector).focus(eventData, handler) → jQuery\n$(selector).focus() → jQuery</code></pre></section>	https://api.jquery.com/focus/
+.focus() event	R	.focus()										
+.focusin	R	.focusin()										
+.focusin event	R	.focusin()										
+.focusin()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "focusin" event.</p><pre><code>$(selector).focusin(handler) → jQuery\n$(selector).focusin(eventData, handler) → jQuery\n$(selector).focusin() → jQuery</code></pre></section>	https://api.jquery.com/focusin/
+.focusin() event	R	.focusin()										
+.focusout	R	.focusout()										
+.focusout event	R	.focusout()										
+.focusout()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "focusout" JavaScript event.</p><pre><code>$(selector).focusout(handler) → jQuery\n$(selector).focusout(eventData, handler) → jQuery\n$(selector).focusout() → jQuery</code></pre></section>	https://api.jquery.com/focusout/
+.focusout() event	R	.focusout()										
+.fx.interval	R	jQuery.fx.interval										
+.fx.off	R	jQuery.fx.off										
+.get	R	.get()										
+.get()	A			jQuery methods							<section class="prog__container"><p>Retrieve one of the elements matched by the jQuery object.</p><pre><code>$(selector).get(index) → Element</code></pre>\n<p>Retrieve the elements matched by the jQuery object.</p><pre><code>$(selector).get() → Array</code></pre></section>	https://api.jquery.com/get/
+.getJSON	R	jQuery.getJSON()										
+.getJSON()	R	jQuery.getJSON()										
+.getScript	R	jQuery.getScript()										
+.getScript()	R	jQuery.getScript()										
+.globalEval	R	jQuery.globalEval()										
+.globalEval()	R	jQuery.globalEval()										
+.grep	R	jQuery.grep()										
+.grep()	R	jQuery.grep()										
+.has	R	.has()										
+.has()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to those that have a descendant that matches the selector or DOM element.</p><pre><code>$(selector).has(selector) → jQuery\n$(selector).has(contained) → jQuery</code></pre></section>	https://api.jquery.com/has/
+.hasClass	R	.hasClass()										
+.hasClass()	A			jQuery methods							<section class="prog__container"><p>Determine whether any of the matched elements are assigned the given class.</p><pre><code>$(selector).hasClass(className) → Boolean</code></pre></section>	https://api.jquery.com/hasClass/
+.hasData	R	jQuery.hasData()										
+.hasData()	R	jQuery.hasData()										
+.height	R	.height()										
+.height()	A			jQuery methods							<section class="prog__container"><p>Get the current computed height for the first element in the set of matched elements.</p><pre><code>$(selector).height() → Number</code></pre>\n<p>Set the CSS height of every matched element.</p><pre><code>$(selector).height(value) → jQuery\n$(selector).height(function) → jQuery</code></pre></section>	https://api.jquery.com/height/
+.hide	R	.hide()										
+.hide()	A			jQuery methods							<section class="prog__container"><p>Hide the matched elements.</p><pre><code>$(selector).hide() → jQuery\n$(selector).hide(duration, complete) → jQuery\n$(selector).hide(options) → jQuery\n$(selector).hide(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/hide/
+.holdReady	R	jQuery.holdReady()										
+.holdReady()	R	jQuery.holdReady()										
+.hover	R	.hover()										
+.hover event	R	.hover()										
+.hover()	A			jQuery methods							<section class="prog__container"><p>Bind two handlers to the matched elements, to be executed when the mouse pointer enters and leaves the elements.</p><pre><code>$(selector).hover(handlerIn, handlerOut) → jQuery</code></pre>\n<p>Bind a single handler to the matched elements, to be executed when the mouse pointer enters or leaves the elements.</p><pre><code>$(selector).hover(handlerInOut) → jQuery</code></pre></section>	https://api.jquery.com/hover/
+.hover() event	R	.hover()										
+.html	R	.html()										
+.html()	A			jQuery methods							<section class="prog__container"><p>Get the HTML contents of the first element in the set of matched elements.</p><pre><code>$(selector).html() → String</code></pre>\n<p>Set the HTML contents of each element in the set of matched elements.</p><pre><code>$(selector).html(htmlString) → jQuery\n$(selector).html(function) → jQuery</code></pre></section>	https://api.jquery.com/html/
+.htmlPrefilter	R	jQuery.htmlPrefilter()										
+.htmlPrefilter()	R	jQuery.htmlPrefilter()										
+.inArray	R	jQuery.inArray()										
+.inArray()	R	jQuery.inArray()										
+.index	R	.index()										
+.index()	A			jQuery methods							<section class="prog__container"><p>Search for a given element from among the matched elements.</p><pre><code>$(selector).index() → Integer\n$(selector).index(selector) → Integer\n$(selector).index(element) → Integer</code></pre></section>	https://api.jquery.com/index/
+.innerHeight	R	.innerHeight()										
+.innerHeight()	A			jQuery methods							<section class="prog__container"><p>Get the current computed height for the first element in the set of matched elements, including padding but not border.</p><pre><code>$(selector).innerHeight() → Number</code></pre>\n<p>Set the CSS inner height of each element in the set of matched elements.</p><pre><code>$(selector).innerHeight(value) → jQuery\n$(selector).innerHeight(function) → jQuery</code></pre></section>	https://api.jquery.com/innerHeight/
+.innerWidth	R	.innerWidth()										
+.innerWidth()	A			jQuery methods							<section class="prog__container"><p>Get the current computed inner width for the first element in the set of matched elements, including padding but not border.</p><pre><code>$(selector).innerWidth() → Number</code></pre>\n<p>Set the CSS inner width of each element in the set of matched elements.</p><pre><code>$(selector).innerWidth(value) → jQuery\n$(selector).innerWidth(function) → jQuery</code></pre></section>	https://api.jquery.com/innerWidth/
+.insertAfter	R	.insertAfter()										
+.insertAfter()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements after the target.</p><pre><code>$(selector).insertAfter(target) → jQuery</code></pre></section>	https://api.jquery.com/insertAfter/
+.insertBefore	R	.insertBefore()										
+.insertBefore()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements before the target.</p><pre><code>$(selector).insertBefore(target) → jQuery</code></pre></section>	https://api.jquery.com/insertBefore/
+.is	R	.is()										
+.is()	A			jQuery methods							<section class="prog__container"><p>Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.</p><pre><code>$(selector).is(selector) → Boolean\n$(selector).is(function) → Boolean\n$(selector).is(selection) → Boolean\n$(selector).is(elements) → Boolean</code></pre></section>	https://api.jquery.com/is/
+.isArray	R	jQuery.isArray()										
+.isArray()	R	jQuery.isArray()										
+.isDefaultPrevented	R	event.isDefaultPrevented()										
+.isDefaultPrevented()	R	event.isDefaultPrevented()										
+.isEmptyObject	R	jQuery.isEmptyObject()										
+.isEmptyObject()	R	jQuery.isEmptyObject()										
+.isFunction	R	jQuery.isFunction()										
+.isFunction()	R	jQuery.isFunction()										
+.isImmediatePropagationStopped	R	event.isImmediatePropagationStopped()										
+.isImmediatePropagationStopped()	R	event.isImmediatePropagationStopped()										
+.isNumeric	R	jQuery.isNumeric()										
+.isNumeric()	R	jQuery.isNumeric()										
+.isPlainObject	R	jQuery.isPlainObject()										
+.isPlainObject()	R	jQuery.isPlainObject()										
+.isPropagationStopped	R	event.isPropagationStopped()										
+.isPropagationStopped()	R	event.isPropagationStopped()										
+.isRejected	R	deferred.isRejected()										
+.isRejected()	R	deferred.isRejected()										
+.isResolved	R	deferred.isResolved()										
+.isResolved()	R	deferred.isResolved()										
+.isWindow	R	jQuery.isWindow()										
+.isWindow()	R	jQuery.isWindow()										
+.isXMLDoc	R	jQuery.isXMLDoc()										
+.isXMLDoc()	R	jQuery.isXMLDoc()										
+.jquery	A			jQuery properties							<section class="prog__container"><p>A string containing the jQuery version number.</p><pre><code>$(selector).jquery → String</code></pre></section>	https://api.jquery.com/jquery-2/
+.keydown	R	.keydown()										
+.keydown event	R	.keydown()										
+.keydown()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).keydown(handler) → jQuery\n$(selector).keydown(eventData, handler) → jQuery\n$(selector).keydown() → jQuery</code></pre></section>	https://api.jquery.com/keydown/
+.keydown() event	R	.keydown()										
+.keypress	R	.keypress()										
+.keypress event	R	.keypress()										
+.keypress()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).keypress(handler) → jQuery\n$(selector).keypress(eventData, handler) → jQuery\n$(selector).keypress() → jQuery</code></pre></section>	https://api.jquery.com/keypress/
+.keypress() event	R	.keypress()										
+.keyup	R	.keyup()										
+.keyup event	R	.keyup()										
+.keyup()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).keyup(handler) → jQuery\n$(selector).keyup(eventData, handler) → jQuery\n$(selector).keyup() → jQuery</code></pre></section>	https://api.jquery.com/keyup/
+.keyup() event	R	.keyup()										
+.last	R	.last()										
+.last()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to the final one in the set.</p><pre><code>$(selector).last() → jQuery</code></pre></section>	https://api.jquery.com/last/
+.length	A			jQuery properties							<section class="prog__container"><p>The number of elements in the jQuery object.</p><pre><code>$(selector).length → Integer</code></pre></section>	https://api.jquery.com/length/
+.live	R	.live()										
+.live event	R	.live()										
+.live()	A			jQuery methods							<section class="prog__container"><p>Attach an event handler for all elements which match the current selector, now and in the future.</p><pre><code>$(selector).live(events, handler) → jQuery\n$(selector).live(events, data, handler) → jQuery\n$(selector).live(events) → jQuery</code></pre></section>	https://api.jquery.com/live/
+.live() event	R	.live()										
+.load	R	.load()										
+.load event	R	.load()										
+.load()	A			jQuery methods							<section class="prog__container"><p>Load data from the server and place the returned HTML into the matched element.</p><pre><code>$(selector).load(url, data, complete) → jQuery</code></pre></section>	https://api.jquery.com/load/
+.load() event	R	.load()										
+.lock	R	callbacks.lock()										
+.lock()	R	callbacks.lock()										
+.locked	R	callbacks.locked()										
+.locked()	R	callbacks.locked()										
+.makeArray	R	jQuery.makeArray()										
+.makeArray()	R	jQuery.makeArray()										
+.map	R	.map()										
+.map()	A			jQuery methods							<section class="prog__container"><p>Pass each element in the current matched set through a function, producing a new jQuery object containing the return values.</p><pre><code>$(selector).map(callback) → jQuery</code></pre></section>	https://api.jquery.com/map/
+.merge	R	jQuery.merge()										
+.merge()	R	jQuery.merge()										
+.metaKey	R	event.metaKey										
+.mousedown	R	.mousedown()										
+.mousedown event	R	.mousedown()										
+.mousedown()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mousedown(handler) → jQuery\n$(selector).mousedown(eventData, handler) → jQuery\n$(selector).mousedown() → jQuery</code></pre></section>	https://api.jquery.com/mousedown/
+.mousedown() event	R	.mousedown()										
+.mouseenter	R	.mouseenter()										
+.mouseenter event	R	.mouseenter()										
+.mouseenter()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.</p><pre><code>$(selector).mouseenter(handler) → jQuery\n$(selector).mouseenter(eventData, handler) → jQuery\n$(selector).mouseenter() → jQuery</code></pre></section>	https://api.jquery.com/mouseenter/
+.mouseenter() event	R	.mouseenter()										
+.mouseleave	R	.mouseleave()										
+.mouseleave event	R	.mouseleave()										
+.mouseleave()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.</p><pre><code>$(selector).mouseleave(handler) → jQuery\n$(selector).mouseleave(eventData, handler) → jQuery\n$(selector).mouseleave() → jQuery</code></pre></section>	https://api.jquery.com/mouseleave/
+.mouseleave() event	R	.mouseleave()										
+.mousemove	R	.mousemove()										
+.mousemove event	R	.mousemove()										
+.mousemove()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mousemove(handler) → jQuery\n$(selector).mousemove(eventData, handler) → jQuery\n$(selector).mousemove() → jQuery</code></pre></section>	https://api.jquery.com/mousemove/
+.mousemove() event	R	.mousemove()										
+.mouseout	R	.mouseout()										
+.mouseout event	R	.mouseout()										
+.mouseout()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mouseout(handler) → jQuery\n$(selector).mouseout(eventData, handler) → jQuery\n$(selector).mouseout() → jQuery</code></pre></section>	https://api.jquery.com/mouseout/
+.mouseout() event	R	.mouseout()										
+.mouseover	R	.mouseover()										
+.mouseover event	R	.mouseover()										
+.mouseover()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mouseover(handler) → jQuery\n$(selector).mouseover(eventData, handler) → jQuery\n$(selector).mouseover() → jQuery</code></pre></section>	https://api.jquery.com/mouseover/
+.mouseover() event	R	.mouseover()										
+.mouseup	R	.mouseup()										
+.mouseup event	R	.mouseup()										
+.mouseup()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mouseup(handler) → jQuery\n$(selector).mouseup(eventData, handler) → jQuery\n$(selector).mouseup() → jQuery</code></pre></section>	https://api.jquery.com/mouseup/
+.mouseup() event	R	.mouseup()										
+.namespace	R	event.namespace										
+.next	R	.next()										
+.next()	A			jQuery methods							<section class="prog__container"><p>Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.</p><pre><code>$(selector).next(selector) → jQuery</code></pre></section>	https://api.jquery.com/next/
+.nextAll	R	.nextAll()										
+.nextAll()	A			jQuery methods							<section class="prog__container"><p>Get all following siblings of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).nextAll(selector) → jQuery</code></pre></section>	https://api.jquery.com/nextAll/
+.nextUntil	R	.nextUntil()										
+.nextUntil()	A			jQuery methods							<section class="prog__container"><p>Get all following siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object passed.</p><pre><code>$(selector).nextUntil(selector, filter) → jQuery\n$(selector).nextUntil(element, filter) → jQuery</code></pre></section>	https://api.jquery.com/nextUntil/
+.noConflict	R	jQuery.noConflict()										
+.noConflict()	R	jQuery.noConflict()										
+.noop	R	jQuery.noop()										
+.noop()	R	jQuery.noop()										
+.not	R	.not()										
+.not()	A			jQuery methods							<section class="prog__container"><p>Remove elements from the set of matched elements.</p><pre><code>$(selector).not(selector) → jQuery\n$(selector).not(function) → jQuery\n$(selector).not(selection) → jQuery</code></pre></section>	https://api.jquery.com/not/
+.notify	R	deferred.notify()										
+.notify()	R	deferred.notify()										
+.notifyWith	R	deferred.notifyWith()										
+.notifyWith()	R	deferred.notifyWith()										
+.now	R	jQuery.now()										
+.now()	R	jQuery.now()										
+.off	R	.off()										
+.off event	R	.off()										
+.off()	A			jQuery methods							<section class="prog__container"><p>Remove an event handler.</p><pre><code>$(selector).off(events, selector, handler) → jQuery\n$(selector).off(events, selector) → jQuery\n$(selector).off(event) → jQuery\n$(selector).off() → jQuery</code></pre></section>	https://api.jquery.com/off/
+.off() event	R	.off()										
+.offset	R	.offset()										
+.offset()	A			jQuery methods							<section class="prog__container"><p>Get the current coordinates of the first element in the set of matched elements, relative to the document.</p><pre><code>$(selector).offset() → Object</code></pre>\n<p>Set the current coordinates of every element in the set of matched elements, relative to the document.</p><pre><code>$(selector).offset(coordinates) → jQuery\n$(selector).offset(function) → jQuery</code></pre></section>	https://api.jquery.com/offset/
+.offsetParent	R	.offsetParent()										
+.offsetParent()	A			jQuery methods							<section class="prog__container"><p>Get the closest ancestor element that is positioned.</p><pre><code>$(selector).offsetParent() → jQuery</code></pre></section>	https://api.jquery.com/offsetParent/
+.on	R	.on()										
+.on event	R	.on()										
+.on()	A			jQuery methods							<section class="prog__container"><p>Attach an event handler function for one or more events to the selected elements.</p><pre><code>$(selector).on(events, selector, data, handler) → jQuery\n$(selector).on(events, selector, data) → jQuery</code></pre></section>	https://api.jquery.com/on/
+.on() event	R	.on()										
+.one	R	.one()										
+.one event	R	.one()										
+.one()	A			jQuery methods							<section class="prog__container"><p>Attach a handler to an event for the elements. The handler is executed at most once per element per event type.</p><pre><code>$(selector).one(events, data, handler) → jQuery\n$(selector).one(events, selector, data, handler) → jQuery\n$(selector).one(events, selector, data) → jQuery</code></pre></section>	https://api.jquery.com/one/
+.one() event	R	.one()										
+.outerHeight	R	.outerHeight()										
+.outerHeight()	A			jQuery methods							<section class="prog__container"><p>Get the current computed outer height (including padding, border, and optionally margin) for the first element in the set of matched elements.</p><pre><code>$(selector).outerHeight(includeMargin) → Number</code></pre>\n<p>Set the CSS outer height of each element in the set of matched elements.</p><pre><code>$(selector).outerHeight(value) → jQuery\n$(selector).outerHeight(function(index, height)) → jQuery</code></pre></section>	https://api.jquery.com/outerHeight/
+.outerWidth	R	.outerWidth()										
+.outerWidth()	A			jQuery methods							<section class="prog__container"><p>Get the current computed outer width (including padding, border, and optionally margin) for the first element in the set of matched elements.</p><pre><code>$(selector).outerWidth(includeMargin) → Number</code></pre>\n<p>Set the CSS outer width of each element in the set of matched elements.</p><pre><code>$(selector).outerWidth(value) → jQuery\n$(selector).outerWidth(function(index, width)) → jQuery</code></pre></section>	https://api.jquery.com/outerWidth/
+.pageX	R	event.pageX										
+.pageY	R	event.pageY										
+.param	R	jQuery.param()										
+.param()	R	jQuery.param()										
+.parent	R	.parent()										
+.parent()	A			jQuery methods							<section class="prog__container"><p>Get the parent of each element in the current set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).parent(selector) → jQuery</code></pre></section>	https://api.jquery.com/parent/
+.parents	R	.parents()										
+.parents()	A			jQuery methods							<section class="prog__container"><p>Get the ancestors of each element in the current set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).parents(selector) → jQuery</code></pre></section>	https://api.jquery.com/parents/
+.parentsUntil	R	.parentsUntil()										
+.parentsUntil()	A			jQuery methods							<section class="prog__container"><p>Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.</p><pre><code>$(selector).parentsUntil(selector, filter) → jQuery\n$(selector).parentsUntil(element, filter) → jQuery</code></pre></section>	https://api.jquery.com/parentsUntil/
+.parseHTML	R	jQuery.parseHTML()										
+.parseHTML()	R	jQuery.parseHTML()										
+.parseJSON	R	jQuery.parseJSON()										
+.parseJSON()	R	jQuery.parseJSON()										
+.parseXML	R	jQuery.parseXML()										
+.parseXML()	R	jQuery.parseXML()										
+.pipe	R	deferred.pipe()										
+.pipe()	R	deferred.pipe()										
+.position	R	.position()										
+.position()	A			jQuery methods							<section class="prog__container"><p>Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.</p><pre><code>$(selector).position() → Object</code></pre></section>	https://api.jquery.com/position/
+.post	R	jQuery.post()										
+.post()	R	jQuery.post()										
+.prepend	R	.prepend()										
+.prepend()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, to the beginning of each element in the set of matched elements.</p><pre><code>$(selector).prepend(content, content) → jQuery\n$(selector).prepend(function) → jQuery</code></pre></section>	https://api.jquery.com/prepend/
+.prependTo	R	.prependTo()										
+.prependTo()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements to the beginning of the target.</p><pre><code>$(selector).prependTo(target) → jQuery</code></pre></section>	https://api.jquery.com/prependTo/
+.prev	R	.prev()										
+.prev()	A			jQuery methods							<section class="prog__container"><p>Get the immediately preceding sibling of each element in the set of matched elements. If a selector is provided, it retrieves the previous sibling only if it matches that selector.</p><pre><code>$(selector).prev(selector) → jQuery</code></pre></section>	https://api.jquery.com/prev/
+.prevAll	R	.prevAll()										
+.prevAll()	A			jQuery methods							<section class="prog__container"><p>Get all preceding siblings of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).prevAll(selector) → jQuery</code></pre></section>	https://api.jquery.com/prevAll/
+.prevUntil	R	.prevUntil()										
+.prevUntil()	A			jQuery methods							<section class="prog__container"><p>Get all preceding siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object.</p><pre><code>$(selector).prevUntil(selector, filter) → jQuery\n$(selector).prevUntil(element, filter) → jQuery</code></pre></section>	https://api.jquery.com/prevUntil/
+.preventDefault	R	event.preventDefault()										
+.preventDefault()	R	event.preventDefault()										
+.progress	R	deferred.progress()										
+.progress()	R	deferred.progress()										
+.promise	R	.promise()										
+.promise()	A			jQuery methods							<section class="prog__container"><p> Return a Promise object to observe when all actions of a certain type bound to the collection, queued or not, have finished. </p><pre><code>$(selector).promise(type, target) → Promise</code></pre></section>	https://api.jquery.com/promise/
+.prop	R	.prop()										
+.prop()	A			jQuery methods							<section class="prog__container"><p>Get the value of a property for the first element in the set of matched elements.</p><pre><code>$(selector).prop(propertyName) → Anything</code></pre>\n<p>Set one or more properties for the set of matched elements.</p><pre><code>$(selector).prop(propertyName, value) → jQuery\n$(selector).prop(properties) → jQuery\n$(selector).prop(propertyName, function) → jQuery</code></pre></section>	https://api.jquery.com/prop/
+.proxy	R	jQuery.proxy()										
+.proxy()	R	jQuery.proxy()										
+.pushStack	R	.pushStack()										
+.pushStack()	A			jQuery methods							<section class="prog__container"><p>Add a collection of DOM elements onto the jQuery stack.</p><pre><code>$(selector).pushStack(elements) → jQuery\n$(selector).pushStack(elements, name, arguments) → jQuery</code></pre></section>	https://api.jquery.com/pushStack/
+.queue	R	.queue()										
+.queue()	A			jQuery methods							<section class="prog__container"><p>Show the queue of functions to be executed on the matched elements.</p><pre><code>$(selector).queue(queueName) → Array</code></pre>\n<p>Manipulate the queue of functions to be executed, once for each matched element.</p><pre><code>$(selector).queue(queueName, newQueue) → jQuery\n$(selector).queue(queueName, callback) → jQuery</code></pre></section>	https://api.jquery.com/queue/
+.ready	R	.ready()										
+.ready event	R	.ready()										
+.ready()	A			jQuery methods							<section class="prog__container"><p>Specify a function to execute when the DOM is fully loaded.</p><pre><code>$(selector).ready(handler) → jQuery</code></pre></section>	https://api.jquery.com/ready/
+.ready() event	R	.ready()										
+.readyException	R	jQuery.readyException()										
+.readyException()	R	jQuery.readyException()										
+.reject	R	deferred.reject()										
+.reject()	R	deferred.reject()										
+.rejectWith	R	deferred.rejectWith()										
+.rejectWith()	R	deferred.rejectWith()										
+.relatedTarget	R	event.relatedTarget										
+.remove	R	.remove()										
+.remove()	A			jQuery methods							<section class="prog__container"><p>Remove the set of matched elements from the DOM.</p><pre><code>$(selector).remove(selector) → jQuery</code></pre></section>	https://api.jquery.com/remove/
+.removeAttr	R	.removeAttr()										
+.removeAttr()	A			jQuery methods							<section class="prog__container"><p>Remove an attribute from each element in the set of matched elements.</p><pre><code>$(selector).removeAttr(attributeName) → jQuery</code></pre></section>	https://api.jquery.com/removeAttr/
+.removeClass	R	.removeClass()										
+.removeClass()	A			jQuery methods							<section class="prog__container"><p>Remove a single class, multiple classes, or all classes from each element in the set of matched elements.</p><pre><code>$(selector).removeClass(className) → jQuery\n$(selector).removeClass(function) → jQuery</code></pre></section>	https://api.jquery.com/removeClass/
+.removeData	R	.removeData()										
+.removeData()	A			jQuery methods							<section class="prog__container"><p>Remove a previously-stored piece of data.</p><pre><code>$(selector).removeData(name) → jQuery\n$(selector).removeData(list) → jQuery</code></pre></section>	https://api.jquery.com/removeData/
+.removeProp	R	.removeProp()										
+.removeProp()	A			jQuery methods							<section class="prog__container"><p>Remove a property for the set of matched elements.</p><pre><code>$(selector).removeProp(propertyName) → jQuery</code></pre></section>	https://api.jquery.com/removeProp/
+.replaceAll	R	.replaceAll()										
+.replaceAll()	A			jQuery methods							<section class="prog__container"><p>Replace each target element with the set of matched elements.</p><pre><code>$(selector).replaceAll(target) → jQuery</code></pre></section>	https://api.jquery.com/replaceAll/
+.replaceWith	R	.replaceWith()										
+.replaceWith()	A			jQuery methods							<section class="prog__container"><p>Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.</p><pre><code>$(selector).replaceWith(newContent) → jQuery\n$(selector).replaceWith(function) → jQuery</code></pre></section>	https://api.jquery.com/replaceWith/
+.resize	R	.resize()										
+.resize event	R	.resize()										
+.resize()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).resize(handler) → jQuery\n$(selector).resize(eventData, handler) → jQuery\n$(selector).resize() → jQuery</code></pre></section>	https://api.jquery.com/resize/
+.resize() event	R	.resize()										
+.resolve	R	deferred.resolve()										
+.resolve()	R	deferred.resolve()										
+.resolveWith	R	deferred.resolveWith()										
+.resolveWith()	R	deferred.resolveWith()										
+.result	R	event.result										
+.scroll	R	.scroll()										
+.scroll event	R	.scroll()										
+.scroll()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).scroll(handler) → jQuery\n$(selector).scroll(eventData, handler) → jQuery\n$(selector).scroll() → jQuery</code></pre></section>	https://api.jquery.com/scroll/
+.scroll() event	R	.scroll()										
+.scrollLeft	R	.scrollLeft()										
+.scrollLeft()	A			jQuery methods							<section class="prog__container"><p>Get the current horizontal position of the scroll bar for the first element in the set of matched elements.</p><pre><code>$(selector).scrollLeft() → Integer</code></pre>\n<p>Set the current horizontal position of the scroll bar for each of the set of matched elements.</p><pre><code>$(selector).scrollLeft(value) → jQuery</code></pre></section>	https://api.jquery.com/scrollLeft/
+.scrollTop	R	.scrollTop()										
+.scrollTop()	A			jQuery methods							<section class="prog__container"><p>Get the current vertical position of the scroll bar for the first element in the set of matched elements or set the vertical position of the scroll bar for every matched element.</p><pre><code>$(selector).scrollTop() → Number</code></pre>\n<p>Set the current vertical position of the scroll bar for each of the set of matched elements.</p><pre><code>$(selector).scrollTop(value) → jQuery</code></pre></section>	https://api.jquery.com/scrollTop/
+.select	R	.select()										
+.select event	R	.select()										
+.select()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "select" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).select(handler) → jQuery\n$(selector).select(eventData, handler) → jQuery\n$(selector).select() → jQuery</code></pre></section>	https://api.jquery.com/select/
+.select() event	R	.select()										
+.selector	A			jQuery properties							<section class="prog__container"><p>A selector representing selector passed to jQuery(), if any, when creating the original set.</p><pre><code>$(selector).selector → String</code></pre></section>	https://api.jquery.com/selector/
+.serialize	R	.serialize()										
+.serialize()	A			jQuery methods							<section class="prog__container"><p>Encode a set of form elements as a string for submission.</p><pre><code>$(selector).serialize() → String</code></pre></section>	https://api.jquery.com/serialize/
+.serializeArray	R	.serializeArray()										
+.serializeArray()	A			jQuery methods							<section class="prog__container"><p>Encode a set of form elements as an array of names and values.</p><pre><code>$(selector).serializeArray() → Array</code></pre></section>	https://api.jquery.com/serializeArray/
+.show	R	.show()										
+.show()	A			jQuery methods							<section class="prog__container"><p>Display the matched elements.</p><pre><code>$(selector).show() → jQuery\n$(selector).show(duration, complete) → jQuery\n$(selector).show(options) → jQuery\n$(selector).show(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/show/
+.siblings	R	.siblings()										
+.siblings()	A			jQuery methods							<section class="prog__container"><p>Get the siblings of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).siblings(selector) → jQuery</code></pre></section>	https://api.jquery.com/siblings/
+.size	R	.size()										
+.size()	A			jQuery methods							<section class="prog__container"><p>Return the number of elements in the jQuery object.</p><pre><code>$(selector).size() → Integer</code></pre></section>	https://api.jquery.com/size/
+.slice	R	.slice()										
+.slice()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to a subset specified by a range of indices.</p><pre><code>$(selector).slice(start, end) → jQuery</code></pre></section>	https://api.jquery.com/slice/
+.slideDown	R	.slideDown()										
+.slideDown()	A			jQuery methods							<section class="prog__container"><p>Display the matched elements with a sliding motion.</p><pre><code>$(selector).slideDown(duration, complete) → jQuery\n$(selector).slideDown(options) → jQuery\n$(selector).slideDown(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/slideDown/
+.slideToggle	R	.slideToggle()										
+.slideToggle()	A			jQuery methods							<section class="prog__container"><p>Display or hide the matched elements with a sliding motion.</p><pre><code>$(selector).slideToggle(duration, complete) → jQuery\n$(selector).slideToggle(options) → jQuery\n$(selector).slideToggle(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/slideToggle/
+.slideUp	R	.slideUp()										
+.slideUp()	A			jQuery methods							<section class="prog__container"><p>Hide the matched elements with a sliding motion.</p><pre><code>$(selector).slideUp(duration, complete) → jQuery\n$(selector).slideUp(options) → jQuery\n$(selector).slideUp(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/slideUp/
+.speed	R	jQuery.speed										
+.state	R	deferred.state()										
+.state()	R	deferred.state()										
+.stop	R	.stop()										
+.stop()	A			jQuery methods							<section class="prog__container"><p>Stop the currently-running animation on the matched elements.</p><pre><code>$(selector).stop(clearQueue, jumpToEnd) → jQuery\n$(selector).stop(queue, clearQueue, jumpToEnd) → jQuery</code></pre></section>	https://api.jquery.com/stop/
+.stopImmediatePropagation	R	event.stopImmediatePropagation()										
+.stopImmediatePropagation()	R	event.stopImmediatePropagation()										
+.stopPropagation	R	event.stopPropagation()										
+.stopPropagation()	R	event.stopPropagation()										
+.sub	R	jQuery.sub()										
+.sub()	R	jQuery.sub()										
+.submit	R	.submit()										
+.submit event	R	.submit()										
+.submit()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).submit(handler) → jQuery\n$(selector).submit(eventData, handler) → jQuery\n$(selector).submit() → jQuery</code></pre></section>	https://api.jquery.com/submit/
+.submit() event	R	.submit()										
+.support	R	jQuery.support										
+.target	R	event.target										
+.text	R	.text()										
+.text()	A			jQuery methods							<section class="prog__container"><p>Get the combined text contents of each element in the set of matched elements, including their descendants.</p><pre><code>$(selector).text() → String</code></pre>\n<p>Set the content of each element in the set of matched elements to the specified text.</p><pre><code>$(selector).text(text) → jQuery\n$(selector).text(function) → jQuery</code></pre></section>	https://api.jquery.com/text/
+.then	R	deferred.then()										
+.then()	R	deferred.then()										
+.timeStamp	R	event.timeStamp										
+.toArray	R	.toArray()										
+.toArray()	A			jQuery methods							<section class="prog__container"><p>Retrieve all the elements contained in the jQuery set, as an array.</p><pre><code>$(selector).toArray() → Array</code></pre></section>	https://api.jquery.com/toArray/
+.toggle	R	.toggle()										
+.toggle event	R	.toggle()										
+.toggle()	A			jQuery methods							<section class="prog__container"><p>Display or hide the matched elements.</p><pre><code>$(selector).toggle(duration, complete) → jQuery\n$(selector).toggle(options) → jQuery\n$(selector).toggle(duration, easing, complete) → jQuery\n$(selector).toggle(display) → jQuery</code></pre></section>	https://api.jquery.com/toggle/
+.toggle() event	R	.toggle()										
+.toggleClass	R	.toggleClass()										
+.toggleClass()	A			jQuery methods							<section class="prog__container"><p>Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the state argument.</p><pre><code>$(selector).toggleClass(className) → jQuery\n$(selector).toggleClass(className, state) → jQuery\n$(selector).toggleClass(function, state) → jQuery</code></pre>\n<p></p><pre><code>$(selector).toggleClass(state) → jQuery</code></pre></section>	https://api.jquery.com/toggleClass/
+.trigger	R	.trigger()										
+.trigger event	R	.trigger()										
+.trigger()	A			jQuery methods							<section class="prog__container"><p>Execute all handlers and behaviors attached to the matched elements for the given event type.</p><pre><code>$(selector).trigger(eventType, extraParameters) → jQuery\n$(selector).trigger(event, extraParameters) → jQuery</code></pre></section>	https://api.jquery.com/trigger/
+.trigger() event	R	.trigger()										
+.triggerHandler	R	.triggerHandler()										
+.triggerHandler event	R	.triggerHandler()										
+.triggerHandler()	A			jQuery methods							<section class="prog__container"><p>Execute all handlers attached to an element for an event.</p><pre><code>$(selector).triggerHandler(eventType, extraParameters) → Object\n$(selector).triggerHandler(event, extraParameters) → Object</code></pre></section>	https://api.jquery.com/triggerHandler/
+.triggerHandler() event	R	.triggerHandler()										
+.trim	R	jQuery.trim()										
+.trim()	R	jQuery.trim()										
+.type	R	event.type										
+.type()	R	jQuery.type()										
+.unbind	R	.unbind()										
+.unbind event	R	.unbind()										
+.unbind()	A			jQuery methods							<section class="prog__container"><p>Remove a previously-attached event handler from the elements.</p><pre><code>$(selector).unbind(eventType, handler) → jQuery\n$(selector).unbind(eventType, false) → jQuery\n$(selector).unbind(event) → jQuery\n$(selector).unbind() → jQuery</code></pre></section>	https://api.jquery.com/unbind/
+.unbind() event	R	.unbind()										
+.undelegate	R	.undelegate()										
+.undelegate event	R	.undelegate()										
+.undelegate()	A			jQuery methods							<section class="prog__container"><p>Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.</p><pre><code>$(selector).undelegate() → jQuery\n$(selector).undelegate(selector, eventType) → jQuery\n$(selector).undelegate(selector, eventType, handler) → jQuery\n$(selector).undelegate(selector, events) → jQuery\n$(selector).undelegate(namespace) → jQuery</code></pre></section>	https://api.jquery.com/undelegate/
+.undelegate() event	R	.undelegate()										
+.unique	R	jQuery.unique()										
+.unique()	R	jQuery.unique()										
+.uniqueSort	R	jQuery.uniqueSort()										
+.uniqueSort()	R	jQuery.uniqueSort()										
+.unload	R	.unload()										
+.unload event	R	.unload()										
+.unload()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "unload" JavaScript event.</p><pre><code>$(selector).unload(handler) → jQuery\n$(selector).unload(eventData, handler) → jQuery</code></pre></section>	https://api.jquery.com/unload/
+.unload() event	R	.unload()										
+.unwrap	R	.unwrap()										
+.unwrap()	A			jQuery methods							<section class="prog__container"><p>Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.</p><pre><code>$(selector).unwrap() → jQuery\n$(selector).unwrap(selector) → jQuery</code></pre></section>	https://api.jquery.com/unwrap/
+.val	R	.val()										
+.val()	A			jQuery methods							<section class="prog__container"><p>Get the current value of the first element in the set of matched elements.</p><pre><code>$(selector).val() → String|Number|Array</code></pre>\n<p>Set the value of each element in the set of matched elements.</p><pre><code>$(selector).val(value) → jQuery\n$(selector).val(function) → jQuery</code></pre></section>	https://api.jquery.com/val/
+.when	R	jQuery.when()										
+.when()	R	jQuery.when()										
+.which	R	event.which										
+.width	R	.width()										
+.width()	A			jQuery methods							<section class="prog__container"><p>Get the current computed width for the first element in the set of matched elements.</p><pre><code>$(selector).width() → Number</code></pre>\n<p>Set the CSS width of each element in the set of matched elements.</p><pre><code>$(selector).width(value) → jQuery\n$(selector).width(function) → jQuery</code></pre></section>	https://api.jquery.com/width/
+.wrap	R	.wrap()										
+.wrap()	A			jQuery methods							<section class="prog__container"><p>Wrap an HTML structure around each element in the set of matched elements.</p><pre><code>$(selector).wrap(wrappingElement) → jQuery\n$(selector).wrap(function) → jQuery</code></pre></section>	https://api.jquery.com/wrap/
+.wrapAll	R	.wrapAll()										
+.wrapAll()	A			jQuery methods							<section class="prog__container"><p>Wrap an HTML structure around all elements in the set of matched elements.</p><pre><code>$(selector).wrapAll(wrappingElement) → jQuery\n$(selector).wrapAll(function) → jQuery</code></pre></section>	https://api.jquery.com/wrapAll/
+.wrapInner	R	.wrapInner()										
+.wrapInner()	A			jQuery methods							<section class="prog__container"><p>Wrap an HTML structure around the content of each element in the set of matched elements.</p><pre><code>$(selector).wrapInner(wrappingElement) → jQuery\n$(selector).wrapInner(function) → jQuery</code></pre></section>	https://api.jquery.com/wrapInner/
+:animated Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that are in the progress of an animation at the time the selector is run.</p><pre><code>$(":animated") → jQuery</code></pre></section>	https://api.jquery.com/animated-selector/
+:button Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all button elements and elements of type button.</p><pre><code>$(":button") → jQuery</code></pre></section>	https://api.jquery.com/button-selector/
+:checkbox Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type checkbox.</p><pre><code>$(":checkbox") → jQuery</code></pre></section>	https://api.jquery.com/checkbox-selector/
+:checked Selector	A			jQuery selectors							<section class="prog__container"><p>Matches all elements that are checked or selected.</p><pre><code>$(":checked") → jQuery</code></pre></section>	https://api.jquery.com/checked-selector/
+:contains() Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that contain the specified text.</p><pre><code>$(":contains(text)") → jQuery</code></pre></section>	https://api.jquery.com/contains-selector/
+:disabled Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are disabled.</p><pre><code>$(":disabled") → jQuery</code></pre></section>	https://api.jquery.com/disabled-selector/
+:empty Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that have no children (including text nodes).</p><pre><code>$(":empty") → jQuery</code></pre></section>	https://api.jquery.com/empty-selector/
+:enabled Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are enabled.</p><pre><code>$(":enabled") → jQuery</code></pre></section>	https://api.jquery.com/enabled-selector/
+:eq() Selector	A			jQuery selectors							<section class="prog__container"><p>Select the element at index n within the matched set.</p><pre><code>$(":eq(index)") → jQuery\n$(":eq(-index)") → jQuery</code></pre></section>	https://api.jquery.com/eq-selector/
+:even Selector	A			jQuery selectors							<section class="prog__container"><p>Selects even elements, zero-indexed.  See also odd.</p><pre><code>$(":even") → jQuery</code></pre></section>	https://api.jquery.com/even-selector/
+:file Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type file.</p><pre><code>$(":file") → jQuery</code></pre></section>	https://api.jquery.com/file-selector/
+:first Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the first matched DOM element.</p><pre><code>$(":first") → jQuery</code></pre></section>	https://api.jquery.com/first-selector/
+:first-child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the first child of their parent.</p><pre><code>$(":first-child") → jQuery</code></pre></section>	https://api.jquery.com/first-child-selector/
+:first-of-type Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the first among siblings of the same element name.</p><pre><code>$(":first-of-type") → jQuery</code></pre></section>	https://api.jquery.com/first-of-type-selector/
+:focus Selector	A			jQuery selectors							<section class="prog__container"><p>Selects element if it is currently focused.</p><pre><code>$(":focus") → jQuery</code></pre></section>	https://api.jquery.com/focus-selector/
+:gt() Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements at an index greater than index within the matched set.</p><pre><code>$(":gt(index)") → jQuery\n$(":gt(-index)") → jQuery</code></pre></section>	https://api.jquery.com/gt-selector/
+:has() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements which contain at least one element that matches the specified selector.</p><pre><code>$(":has(selector)") → jQuery</code></pre></section>	https://api.jquery.com/has-selector/
+:header Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are headers, like h1, h2, h3 and so on.</p><pre><code>$(":header") → jQuery</code></pre></section>	https://api.jquery.com/header-selector/
+:hidden Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are hidden.</p><pre><code>$(":hidden") → jQuery</code></pre></section>	https://api.jquery.com/hidden-selector/
+:image Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type image.</p><pre><code>$(":image") → jQuery</code></pre></section>	https://api.jquery.com/image-selector/
+:input Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all input, textarea, select and button elements.</p><pre><code>$(":input") → jQuery</code></pre></section>	https://api.jquery.com/input-selector/
+:lang() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of the specified language.</p><pre><code>$(":lang(language)") → jQuery</code></pre></section>	https://api.jquery.com/lang-selector/
+:last Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the last matched element.</p><pre><code>$(":last") → jQuery</code></pre></section>	https://api.jquery.com/last-selector/
+:last-child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the last child of their parent.</p><pre><code>$(":last-child") → jQuery</code></pre></section>	https://api.jquery.com/last-child-selector/
+:last-of-type Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the last among siblings of the same element name.</p><pre><code>$(":last-of-type") → jQuery</code></pre></section>	https://api.jquery.com/last-of-type-selector/
+:lt() Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements at an index less than index within the matched set.</p><pre><code>$(":lt(index)") → jQuery\n$(":lt(-index)") → jQuery</code></pre></section>	https://api.jquery.com/lt-selector/
+:not() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that do not match the given selector.</p><pre><code>$(":not(selector)") → jQuery</code></pre></section>	https://api.jquery.com/not-selector/
+:nth-child() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the nth-child of their parent.</p><pre><code>$(":nth-child(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-child-selector/
+:nth-last-child() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the nth-child of their parent, counting from the last element to the first.</p><pre><code>$(":nth-last-child(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-last-child-selector/
+:nth-last-of-type() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all the elements that are the nth-child of their parent in relation to siblings with the same element name, counting from the last element to the first.</p><pre><code>$(":nth-last-of-type(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-last-of-type-selector/
+:nth-of-type() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the nth child of their parent in relation to siblings with the same element name.</p><pre><code>$(":nth-of-type(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-of-type-selector/
+:odd Selector	A			jQuery selectors							<section class="prog__container"><p>Selects odd elements, zero-indexed.  See also even.</p><pre><code>$(":odd") → jQuery</code></pre></section>	https://api.jquery.com/odd-selector/
+:only-child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the only child of their parent.</p><pre><code>$(":only-child") → jQuery</code></pre></section>	https://api.jquery.com/only-child-selector/
+:only-of-type Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that have no siblings with the same element name.</p><pre><code>$(":only-of-type") → jQuery</code></pre></section>	https://api.jquery.com/only-of-type-selector/
+:parent Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that have at least one child node (either an element or text).</p><pre><code>$(":parent") → jQuery</code></pre></section>	https://api.jquery.com/parent-selector/
+:password Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type password.</p><pre><code>$(":password") → jQuery</code></pre></section>	https://api.jquery.com/password-selector/
+:radio Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all  elements of type radio.</p><pre><code>$(":radio") → jQuery</code></pre></section>	https://api.jquery.com/radio-selector/
+:reset Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type reset.</p><pre><code>$(":reset") → jQuery</code></pre></section>	https://api.jquery.com/reset-selector/
+:root Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the element that is the root of the document.</p><pre><code>$(":root") → jQuery</code></pre></section>	https://api.jquery.com/root-selector/
+:selected Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are selected.</p><pre><code>$(":selected") → jQuery</code></pre></section>	https://api.jquery.com/selected-selector/
+:submit Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type submit.</p><pre><code>$(":submit") → jQuery</code></pre></section>	https://api.jquery.com/submit-selector/
+:target Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the target element indicated by the fragment identifier of the document's URI.</p><pre><code>$(":target") → jQuery</code></pre></section>	https://api.jquery.com/target-selector/
+:text Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all input elements of type text.</p><pre><code>$(":text") → jQuery</code></pre></section>	https://api.jquery.com/text-selector/
+:visible Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are visible.</p><pre><code>$(":visible") → jQuery</code></pre></section>	https://api.jquery.com/visible-selector/
+All Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements.</p><pre><code>$("*") → jQuery</code></pre></section>	https://api.jquery.com/all-selector/
+Attribute Contains Prefix Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value either equal to a given string or starting with that string followed by a hyphen (-).</p><pre><code>$("[attribute|='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-contains-prefix-selector/
+Attribute Contains Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value containing a given substring.</p><pre><code>$("[attribute*='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-contains-selector/
+Attribute Contains Word Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value containing a given word, delimited by spaces.</p><pre><code>$("[attribute~='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-contains-word-selector/
+Attribute Ends With Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value ending exactly with a given string. The comparison is case sensitive.</p><pre><code>$("[attribute$='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-ends-with-selector/
+Attribute Equals Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value exactly equal to a certain value.</p><pre><code>$("[attribute='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-equals-selector/
+Attribute Not Equal Selector	A			jQuery selectors							<section class="prog__container"><p>Select elements that either don't have the specified attribute, or do have the specified attribute but not with a certain value.</p><pre><code>$("[attribute!='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-not-equal-selector/
+Attribute Starts With Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute with a value beginning exactly with a given string.</p><pre><code>$("[attribute^='value']") → jQuery</code></pre></section>	https://api.jquery.com/attribute-starts-with-selector/
+Callbacks	R	jQuery.Callbacks()										
+Callbacks()	R	jQuery.Callbacks()										
+Child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all direct child elements specified by "child" of elements specified by "parent".</p><pre><code>$("parent > child") → jQuery</code></pre></section>	https://api.jquery.com/child-selector/
+Class Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements with the given class. </p><pre><code>$(".class") → jQuery</code></pre></section>	https://api.jquery.com/class-selector/
+Deferred	R	jQuery.Deferred()										
+Deferred()	R	jQuery.Deferred()										
+Descendant Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are descendants of a given ancestor.</p><pre><code>$("ancestor descendant") → jQuery</code></pre></section>	https://api.jquery.com/descendant-selector/
+Element Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements with the given tag name.</p><pre><code>$("element") → jQuery</code></pre></section>	https://api.jquery.com/element-selector/
+Has Attribute Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute, with any value. </p><pre><code>$("[attribute]") → jQuery</code></pre></section>	https://api.jquery.com/has-attribute-selector/
+ID Selector	A			jQuery selectors							<section class="prog__container"><p>Selects a single element with the given id attribute. </p><pre><code>$("#id") → jQuery</code></pre></section>	https://api.jquery.com/id-selector/
+Multiple Attribute Selector	A			jQuery selectors							<section class="prog__container"><p>Matches elements that match all of the specified attribute filters.</p><pre><code>$("[attributeFilter1][attributeFilter2][attributeFilterN]") → jQuery</code></pre></section>	https://api.jquery.com/multiple-attribute-selector/
+Multiple Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the combined results of all the specified selectors.</p><pre><code>$("selector1, selector2, selectorN") → jQuery</code></pre></section>	https://api.jquery.com/multiple-selector/
+Next Adjacent Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all next elements matching "next" that are immediately preceded by a sibling "prev".</p><pre><code>$("prev + next") → jQuery</code></pre></section>	https://api.jquery.com/next-adjacent-selector/
+Next Siblings Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all sibling elements that follow after the "prev" element, have the same parent, and match the filtering "siblings" selector.</p><pre><code>$("prev ~ siblings") → jQuery</code></pre></section>	https://api.jquery.com/next-siblings-selector/
+add	R	.add()										
+add back	R	.addBack()										
+add class	R	.addClass()										
+add()	R	.add()										
+addBack	R	.addBack()										
+addBack()	R	.addBack()										
+addClass	R	.addClass()										
+addClass()	R	.addClass()										
+addback	R	.addBack()										
+addclass	R	.addClass()										
+after	R	.after()										
+after()	R	.after()										
+ajax	R	jQuery.ajax()										
+ajax complete	R	.ajaxComplete()										
+ajax error	R	.ajaxError()										
+ajax prefilter	R	jQuery.ajaxPrefilter()										
+ajax send	R	.ajaxSend()										
+ajax setup	R	jQuery.ajaxSetup()										
+ajax start	R	.ajaxStart()										
+ajax stop	R	.ajaxStop()										
+ajax success	R	.ajaxSuccess()										
+ajax transport	R	jQuery.ajaxTransport()										
+ajax()	R	jQuery.ajax()										
+ajaxComplete	R	.ajaxComplete()										
+ajaxComplete()	R	.ajaxComplete()										
+ajaxError	R	.ajaxError()										
+ajaxError()	R	.ajaxError()										
+ajaxPrefilter	R	jQuery.ajaxPrefilter()										
+ajaxPrefilter()	R	jQuery.ajaxPrefilter()										
+ajaxSend	R	.ajaxSend()										
+ajaxSend()	R	.ajaxSend()										
+ajaxSetup	R	jQuery.ajaxSetup()										
+ajaxSetup()	R	jQuery.ajaxSetup()										
+ajaxStart	R	.ajaxStart()										
+ajaxStart()	R	.ajaxStart()										
+ajaxStop	R	.ajaxStop()										
+ajaxStop()	R	.ajaxStop()										
+ajaxSuccess	R	.ajaxSuccess()										
+ajaxSuccess()	R	.ajaxSuccess()										
+ajaxTransport	R	jQuery.ajaxTransport()										
+ajaxTransport()	R	jQuery.ajaxTransport()										
+ajaxcomplete	R	.ajaxComplete()										
+ajaxerror	R	.ajaxError()										
+ajaxprefilter	R	jQuery.ajaxPrefilter()										
+ajaxsend	R	.ajaxSend()										
+ajaxsetup	R	jQuery.ajaxSetup()										
+ajaxstart	R	.ajaxStart()										
+ajaxstop	R	.ajaxStop()										
+ajaxsuccess	R	.ajaxSuccess()										
+ajaxtransport	R	jQuery.ajaxTransport()										
+all selector	R	All Selector										
+always	R	deferred.always()										
+always()	R	deferred.always()										
+and self	R	.andSelf()										
+andSelf	R	.andSelf()										
+andSelf()	R	.andSelf()										
+andself	R	.andSelf()										
+animate	R	.animate()										
+animate()	R	.animate()										
+animated selector	R	:animated Selector										
+append	R	.append()										
+append to	R	.appendTo()										
+append()	R	.append()										
+appendTo	R	.appendTo()										
+appendTo()	R	.appendTo()										
+appendto	R	.appendTo()										
+attr	R	.attr()										
+attr()	R	.attr()										
+attribute contains prefix selector	R	Attribute Contains Prefix Selector										
+attribute contains selector	R	Attribute Contains Selector										
+attribute contains word selector	R	Attribute Contains Word Selector										
+attribute ends with selector	R	Attribute Ends With Selector										
+attribute equals selector	R	Attribute Equals Selector										
+attribute not equal selector	R	Attribute Not Equal Selector										
+attribute starts with selector	R	Attribute Starts With Selector										
+before	R	.before()										
+before()	R	.before()										
+bind	R	.bind()										
+bind event	R	.bind()										
+bind()	R	.bind()										
+bind() event	R	.bind()										
+blur	R	.blur()										
+blur event	R	.blur()										
+blur()	R	.blur()										
+blur() event	R	.blur()										
+box model	R	jQuery.boxModel										
+boxModel	R	jQuery.boxModel										
+boxmodel	R	jQuery.boxModel										
+browser	R	jQuery.browser										
+button selector	R	:button Selector										
+callbacks	R	jQuery.Callbacks()										
+callbacks add	R	callbacks.add()										
+callbacks disable	R	callbacks.disable()										
+callbacks disabled	R	callbacks.disabled()										
+callbacks empty	R	callbacks.empty()										
+callbacks fire	R	callbacks.fire()										
+callbacks fire with	R	callbacks.fireWith()										
+callbacks fired	R	callbacks.fired()										
+callbacks firewith	R	callbacks.fireWith()										
+callbacks has	R	callbacks.has()										
+callbacks lock	R	callbacks.lock()										
+callbacks locked	R	callbacks.locked()										
+callbacks remove	R	callbacks.remove()										
+callbacks.add	R	callbacks.add()										
+callbacks.add()	A			jQuery methods							<section class="prog__container"><p>Add a callback or a collection of callbacks to a callback list.</p><pre><code>callbacks.add(callbacks) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.add/
+callbacks.disable	R	callbacks.disable()										
+callbacks.disable()	A			jQuery methods							<section class="prog__container"><p>Disable a callback list from doing anything more.</p><pre><code>callbacks.disable() → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.disable/
+callbacks.disabled	R	callbacks.disabled()										
+callbacks.disabled()	A			jQuery methods							<section class="prog__container"><p>Determine if the callbacks list has been disabled.</p><pre><code>callbacks.disabled() → Boolean</code></pre></section>	https://api.jquery.com/callbacks.disabled/
+callbacks.empty	R	callbacks.empty()										
+callbacks.empty()	A			jQuery methods							<section class="prog__container"><p>Remove all of the callbacks from a list.</p><pre><code>callbacks.empty() → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.empty/
+callbacks.fire	R	callbacks.fire()										
+callbacks.fire()	A			jQuery methods							<section class="prog__container"><p>Call all of the callbacks with the given arguments.</p><pre><code>callbacks.fire(arguments) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.fire/
+callbacks.fireWith	R	callbacks.fireWith()										
+callbacks.fireWith()	A			jQuery methods							<section class="prog__container"><p>Call all callbacks in a list with the given context and arguments.</p><pre><code>callbacks.fireWith(context, args) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.fireWith/
+callbacks.fired	R	callbacks.fired()										
+callbacks.fired()	A			jQuery methods							<section class="prog__container"><p>Determine if the callbacks have already been called at least once.</p><pre><code>callbacks.fired() → Boolean</code></pre></section>	https://api.jquery.com/callbacks.fired/
+callbacks.has	R	callbacks.has()										
+callbacks.has()	A			jQuery methods							<section class="prog__container"><p>Determine whether or not the list has any callbacks attached. If a callback is provided as an argument, determine whether it is in a list.</p><pre><code>callbacks.has(callback) → Boolean</code></pre></section>	https://api.jquery.com/callbacks.has/
+callbacks.lock	R	callbacks.lock()										
+callbacks.lock()	A			jQuery methods							<section class="prog__container"><p>Lock a callback list in its current state.</p><pre><code>callbacks.lock() → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.lock/
+callbacks.locked	R	callbacks.locked()										
+callbacks.locked()	A			jQuery methods							<section class="prog__container"><p>Determine if the callbacks list has been locked.</p><pre><code>callbacks.locked() → Boolean</code></pre></section>	https://api.jquery.com/callbacks.locked/
+callbacks.remove	R	callbacks.remove()										
+callbacks.remove()	A			jQuery methods							<section class="prog__container"><p>Remove a callback or a collection of callbacks from a callback list.</p><pre><code>callbacks.remove(callbacks) → Callbacks</code></pre></section>	https://api.jquery.com/callbacks.remove/
+catch	R	deferred.catch()										
+catch()	R	deferred.catch()										
+change	R	.change()										
+change event	R	.change()										
+change()	R	.change()										
+change() event	R	.change()										
+checkbox selector	R	:checkbox Selector										
+checked selector	R	:checked Selector										
+child selector	R	Child Selector										
+children	R	.children()										
+children()	R	.children()										
+class selector	R	Class Selector										
+clear queue	R	.clearQueue()										
+clearQueue	R	.clearQueue()										
+clearQueue()	R	.clearQueue()										
+clearqueue	R	.clearQueue()										
+click	R	.click()										
+click event	R	.click()										
+click()	R	.click()										
+click() event	R	.click()										
+clone	R	.clone()										
+clone()	R	.clone()										
+closest	R	.closest()										
+closest()	R	.closest()										
+contains	R	jQuery.contains()										
+contains selector	R	:contains() Selector										
+contains()	R	jQuery.contains()										
+contents	R	.contents()										
+contents()	R	.contents()										
+context	R	.context										
+contextmenu	R	.contextmenu()										
+contextmenu event	R	.contextmenu()										
+contextmenu()	R	.contextmenu()										
+contextmenu() event	R	.contextmenu()										
+css	R	.css()										
+css hooks	R	jQuery.cssHooks										
+css number	R	jQuery.cssNumber										
+css()	R	.css()										
+cssHooks	R	jQuery.cssHooks										
+cssNumber	R	jQuery.cssNumber										
+csshooks	R	jQuery.cssHooks										
+cssnumber	R	jQuery.cssNumber										
+current target	R	event.currentTarget										
+currentTarget	R	event.currentTarget										
+currenttarget	R	event.currentTarget										
+data	R	.data()										
+data()	R	.data()										
 dblclick	R	.dblclick()										
-deferred.always()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object is either resolved or rejected. </p><pre><code>deferred.always(alwaysCallbacks, alwaysCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.always/
+dblclick event	R	.dblclick()										
+dblclick()	R	.dblclick()										
+dblclick() event	R	.dblclick()										
+deferred	R	jQuery.Deferred()										
 deferred always	R	deferred.always()										
-deferred.always	R	deferred.always()										
-deferred.catch()	A			jQuery methods							<section class="prog__container"><p>Add handlers to be called when the Deferred object is rejected. </p><pre><code>deferred.catch(failFilter) → Promise</code></pre></section>	https://api.jquery.com/deferred.catch/
 deferred catch	R	deferred.catch()										
-deferred.catch	R	deferred.catch()										
-deferred.done()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object is resolved. </p><pre><code>deferred.done(doneCallbacks, doneCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.done/
 deferred done	R	deferred.done()										
-deferred.done	R	deferred.done()										
-deferred.fail()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object is rejected. </p><pre><code>deferred.fail(failCallbacks, failCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.fail/
 deferred fail	R	deferred.fail()										
-deferred.fail	R	deferred.fail()										
-deferred.isRejected()	A			jQuery methods							<section class="prog__container"><p> Determine whether a Deferred object has been rejected. </p><pre><code>deferred.isRejected() → Boolean</code></pre></section>	https://api.jquery.com/deferred.isRejected/
 deferred is rejected	R	deferred.isRejected()										
-deferred isrejected	R	deferred.isRejected()										
-deferred.isRejected	R	deferred.isRejected()										
-deferred.isResolved()	A			jQuery methods							<section class="prog__container"><p> Determine whether a Deferred object has been resolved. </p><pre><code>deferred.isResolved() → Boolean</code></pre></section>	https://api.jquery.com/deferred.isResolved/
 deferred is resolved	R	deferred.isResolved()										
+deferred isrejected	R	deferred.isRejected()										
 deferred isresolved	R	deferred.isResolved()										
-deferred.isResolved	R	deferred.isResolved()										
-deferred.notify()	A			jQuery methods							<section class="prog__container"><p> Call the progressCallbacks on a Deferred object with the given args. </p><pre><code>deferred.notify(args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.notify/
 deferred notify	R	deferred.notify()										
-deferred.notify	R	deferred.notify()										
-deferred.notifyWith()	A			jQuery methods							<section class="prog__container"><p> Call the progressCallbacks on a Deferred object with the given context and args. </p><pre><code>deferred.notifyWith(context, args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.notifyWith/
 deferred notify with	R	deferred.notifyWith()										
 deferred notifywith	R	deferred.notifyWith()										
-deferred.notifyWith	R	deferred.notifyWith()										
-deferred.pipe()	A			jQuery methods							<section class="prog__container"><p> Utility method to filter and/or chain Deferreds.  </p><pre><code>deferred.pipe(doneFilter, failFilter) → Promise\ndeferred.pipe(doneFilter, failFilter, progressFilter) → Promise</code></pre></section>	https://api.jquery.com/deferred.pipe/
 deferred pipe	R	deferred.pipe()										
-deferred.pipe	R	deferred.pipe()										
-deferred.progress()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object generates progress notifications.</p><pre><code>deferred.progress(progressCallbacks, progressCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.progress/
 deferred progress	R	deferred.progress()										
-deferred.progress	R	deferred.progress()										
-deferred.promise()	A			jQuery methods							<section class="prog__container"><p> Return a Deferred's Promise object. </p><pre><code>deferred.promise(target) → Promise</code></pre></section>	https://api.jquery.com/deferred.promise/
 deferred promise	R	deferred.promise()										
-deferred.promise	R	deferred.promise()										
-deferred.reject()	A			jQuery methods							<section class="prog__container"><p> Reject a Deferred object and call any failCallbacks with the given args. </p><pre><code>deferred.reject(args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.reject/
 deferred reject	R	deferred.reject()										
-deferred.reject	R	deferred.reject()										
-deferred.rejectWith()	A			jQuery methods							<section class="prog__container"><p> Reject a Deferred object and call any failCallbacks with the given context and args. </p><pre><code>deferred.rejectWith(context, args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.rejectWith/
 deferred reject with	R	deferred.rejectWith()										
 deferred rejectwith	R	deferred.rejectWith()										
-deferred.rejectWith	R	deferred.rejectWith()										
-deferred.resolve()	A			jQuery methods							<section class="prog__container"><p> Resolve a Deferred object and call any doneCallbacks with the given args. </p><pre><code>deferred.resolve(args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.resolve/
 deferred resolve	R	deferred.resolve()										
-deferred.resolve	R	deferred.resolve()										
-deferred.resolveWith()	A			jQuery methods							<section class="prog__container"><p> Resolve a Deferred object and call any doneCallbacks with the given context and args. </p><pre><code>deferred.resolveWith(context, args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.resolveWith/
 deferred resolve with	R	deferred.resolveWith()										
 deferred resolvewith	R	deferred.resolveWith()										
-deferred.resolveWith	R	deferred.resolveWith()										
-deferred	R	jQuery.Deferred()										
-.Deferred()	R	jQuery.Deferred()										
-.Deferred	R	jQuery.Deferred()										
-$.Deferred()	R	jQuery.Deferred()										
-$.Deferred	R	jQuery.Deferred()										
-Deferred()	R	jQuery.Deferred()										
-Deferred	R	jQuery.Deferred()										
-deferred.state()	A			jQuery methods							<section class="prog__container"><p>Determine the current state of a Deferred object. </p><pre><code>deferred.state() → String</code></pre></section>	https://api.jquery.com/deferred.state/
 deferred state	R	deferred.state()										
-deferred.state	R	deferred.state()										
-deferred.then()	A			jQuery methods							<section class="prog__container"><p>Add handlers to be called when the Deferred object is resolved, rejected, or still in progress. </p><pre><code>deferred.then(doneFilter, failFilter, progressFilter) → Promise\ndeferred.then(doneCallbacks, failCallbacks) → Promise\ndeferred.then(doneCallbacks, failCallbacks, progressCallbacks) → Promise</code></pre></section>	https://api.jquery.com/deferred.then/
 deferred then	R	deferred.then()										
+deferred.always	R	deferred.always()										
+deferred.always()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object is either resolved or rejected. </p><pre><code>deferred.always(alwaysCallbacks, alwaysCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.always/
+deferred.catch	R	deferred.catch()										
+deferred.catch()	A			jQuery methods							<section class="prog__container"><p>Add handlers to be called when the Deferred object is rejected. </p><pre><code>deferred.catch(failFilter) → Promise</code></pre></section>	https://api.jquery.com/deferred.catch/
+deferred.done	R	deferred.done()										
+deferred.done()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object is resolved. </p><pre><code>deferred.done(doneCallbacks, doneCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.done/
+deferred.fail	R	deferred.fail()										
+deferred.fail()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object is rejected. </p><pre><code>deferred.fail(failCallbacks, failCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.fail/
+deferred.isRejected	R	deferred.isRejected()										
+deferred.isRejected()	A			jQuery methods							<section class="prog__container"><p> Determine whether a Deferred object has been rejected. </p><pre><code>deferred.isRejected() → Boolean</code></pre></section>	https://api.jquery.com/deferred.isRejected/
+deferred.isResolved	R	deferred.isResolved()										
+deferred.isResolved()	A			jQuery methods							<section class="prog__container"><p> Determine whether a Deferred object has been resolved. </p><pre><code>deferred.isResolved() → Boolean</code></pre></section>	https://api.jquery.com/deferred.isResolved/
+deferred.notify	R	deferred.notify()										
+deferred.notify()	A			jQuery methods							<section class="prog__container"><p> Call the progressCallbacks on a Deferred object with the given args. </p><pre><code>deferred.notify(args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.notify/
+deferred.notifyWith	R	deferred.notifyWith()										
+deferred.notifyWith()	A			jQuery methods							<section class="prog__container"><p> Call the progressCallbacks on a Deferred object with the given context and args. </p><pre><code>deferred.notifyWith(context, args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.notifyWith/
+deferred.pipe	R	deferred.pipe()										
+deferred.pipe()	A			jQuery methods							<section class="prog__container"><p> Utility method to filter and/or chain Deferreds.  </p><pre><code>deferred.pipe(doneFilter, failFilter) → Promise\ndeferred.pipe(doneFilter, failFilter, progressFilter) → Promise</code></pre></section>	https://api.jquery.com/deferred.pipe/
+deferred.progress	R	deferred.progress()										
+deferred.progress()	A			jQuery methods							<section class="prog__container"><p> Add handlers to be called when the Deferred object generates progress notifications.</p><pre><code>deferred.progress(progressCallbacks, progressCallbacks) → Deferred</code></pre></section>	https://api.jquery.com/deferred.progress/
+deferred.promise	R	deferred.promise()										
+deferred.promise()	A			jQuery methods							<section class="prog__container"><p> Return a Deferred's Promise object. </p><pre><code>deferred.promise(target) → Promise</code></pre></section>	https://api.jquery.com/deferred.promise/
+deferred.reject	R	deferred.reject()										
+deferred.reject()	A			jQuery methods							<section class="prog__container"><p> Reject a Deferred object and call any failCallbacks with the given args. </p><pre><code>deferred.reject(args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.reject/
+deferred.rejectWith	R	deferred.rejectWith()										
+deferred.rejectWith()	A			jQuery methods							<section class="prog__container"><p> Reject a Deferred object and call any failCallbacks with the given context and args. </p><pre><code>deferred.rejectWith(context, args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.rejectWith/
+deferred.resolve	R	deferred.resolve()										
+deferred.resolve()	A			jQuery methods							<section class="prog__container"><p> Resolve a Deferred object and call any doneCallbacks with the given args. </p><pre><code>deferred.resolve(args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.resolve/
+deferred.resolveWith	R	deferred.resolveWith()										
+deferred.resolveWith()	A			jQuery methods							<section class="prog__container"><p> Resolve a Deferred object and call any doneCallbacks with the given context and args. </p><pre><code>deferred.resolveWith(context, args) → Deferred</code></pre></section>	https://api.jquery.com/deferred.resolveWith/
+deferred.state	R	deferred.state()										
+deferred.state()	A			jQuery methods							<section class="prog__container"><p>Determine the current state of a Deferred object. </p><pre><code>deferred.state() → String</code></pre></section>	https://api.jquery.com/deferred.state/
 deferred.then	R	deferred.then()										
-.delay()	A			jQuery methods							<section class="prog__container"><p>Set a timer to delay execution of subsequent items in the queue.</p><pre><code>$(selector).delay(duration, queueName) → jQuery</code></pre></section>	https://api.jquery.com/delay/
-.delay	R	.delay()										
-delay()	R	.delay()										
+deferred.then()	A			jQuery methods							<section class="prog__container"><p>Add handlers to be called when the Deferred object is resolved, rejected, or still in progress. </p><pre><code>deferred.then(doneFilter, failFilter, progressFilter) → Promise\ndeferred.then(doneCallbacks, failCallbacks) → Promise\ndeferred.then(doneCallbacks, failCallbacks, progressCallbacks) → Promise</code></pre></section>	https://api.jquery.com/deferred.then/
 delay	R	.delay()										
-.delegate()	A			jQuery methods							<section class="prog__container"><p>Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.</p><pre><code>$(selector).delegate(selector, eventType, handler) → jQuery\n$(selector).delegate(selector, eventType, eventData, handler) → jQuery\n$(selector).delegate(selector, events) → jQuery</code></pre></section>	https://api.jquery.com/delegate/
-.delegate event	R	.delegate()										
-.delegate() event	R	.delegate()										
-delegate event	R	.delegate()										
-delegate() event	R	.delegate()										
-.delegate	R	.delegate()										
-delegate()	R	.delegate()										
+delay()	R	.delay()										
 delegate	R	.delegate()										
+delegate event	R	.delegate()										
 delegate target	R	event.delegateTarget										
-delegatetarget	R	event.delegateTarget										
-.delegateTarget	R	event.delegateTarget										
+delegate()	R	.delegate()										
+delegate() event	R	.delegate()										
 delegateTarget	R	event.delegateTarget										
-.dequeue()	A			jQuery methods							<section class="prog__container"><p>Execute the next function on the queue for the matched elements.</p><pre><code>$(selector).dequeue(queueName) → jQuery</code></pre></section>	https://api.jquery.com/dequeue/
-.dequeue	R	.dequeue()										
-dequeue()	R	.dequeue()										
+delegatetarget	R	event.delegateTarget										
 dequeue	R	.dequeue()										
-$.dequeue()	R	jQuery.dequeue()										
-$.dequeue	R	jQuery.dequeue()										
-Descendant Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are descendants of a given ancestor.</p><pre><code>$("ancestor descendant") → jQuery</code></pre></section>	https://api.jquery.com/descendant-selector/
+dequeue()	R	.dequeue()										
 descendant selector	R	Descendant Selector										
-.detach()	A			jQuery methods							<section class="prog__container"><p>Remove the set of matched elements from the DOM.</p><pre><code>$(selector).detach(selector) → jQuery</code></pre></section>	https://api.jquery.com/detach/
-.detach	R	.detach()										
-detach()	R	.detach()										
 detach	R	.detach()										
-.die()	A			jQuery methods							<section class="prog__container"><p>Remove event handlers previously attached using .live() from the elements.</p><pre><code>$(selector).die() → jQuery\n$(selector).die(eventType, handler) → jQuery\n$(selector).die(events) → jQuery</code></pre></section>	https://api.jquery.com/die/
-.die event	R	.die()										
-.die() event	R	.die()										
-die event	R	.die()										
-die() event	R	.die()										
-.die	R	.die()										
-die()	R	.die()										
+detach()	R	.detach()										
 die	R	.die()										
-.disabled()	R	callbacks.disabled()										
-.disabled	R	callbacks.disabled()										
-disabled()	R	callbacks.disabled()										
-disabled	R	callbacks.disabled()										
-:disabled Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are disabled.</p><pre><code>$(":disabled") → jQuery</code></pre></section>	https://api.jquery.com/disabled-selector/
-disabled selector	R	:disabled Selector										
-.disable()	R	callbacks.disable()										
-.disable	R	callbacks.disable()										
-disable()	R	callbacks.disable()										
+die event	R	.die()										
+die()	R	.die()										
+die() event	R	.die()										
 disable	R	callbacks.disable()										
-.done()	R	deferred.done()										
-.done	R	deferred.done()										
-done()	R	deferred.done()										
+disable()	R	callbacks.disable()										
+disabled	R	callbacks.disabled()										
+disabled selector	R	:disabled Selector										
+disabled()	R	callbacks.disabled()										
 done	R	deferred.done()										
-.each()	A			jQuery methods							<section class="prog__container"><p>Iterate over a jQuery object, executing a function for each matched element. </p><pre><code>$(selector).each(function) → jQuery</code></pre></section>	https://api.jquery.com/each/
-.each	R	.each()										
-each()	R	.each()										
+done()	R	deferred.done()										
 each	R	.each()										
-$.each()	R	jQuery.each()										
-$.each	R	jQuery.each()										
-Element Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements with the given tag name.</p><pre><code>$("element") → jQuery</code></pre></section>	https://api.jquery.com/element-selector/
+each()	R	.each()										
 element selector	R	Element Selector										
-.empty()	A			jQuery methods							<section class="prog__container"><p>Remove all child nodes of the set of matched elements from the DOM.</p><pre><code>$(selector).empty() → jQuery</code></pre></section>	https://api.jquery.com/empty/
-.empty	R	.empty()										
-empty()	R	.empty()										
 empty	R	.empty()										
-:empty Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that have no children (including text nodes).</p><pre><code>$(":empty") → jQuery</code></pre></section>	https://api.jquery.com/empty-selector/
 empty selector	R	:empty Selector										
-:enabled Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are enabled.</p><pre><code>$(":enabled") → jQuery</code></pre></section>	https://api.jquery.com/enabled-selector/
+empty()	R	.empty()										
 enabled selector	R	:enabled Selector										
-.end()	A			jQuery methods							<section class="prog__container"><p>End the most recent filtering operation in the current chain and return the set of matched elements to its previous state.</p><pre><code>$(selector).end() → jQuery</code></pre></section>	https://api.jquery.com/end/
-.end	R	.end()										
-end()	R	.end()										
 end	R	.end()										
-.eq()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to the one at the specified index.</p><pre><code>$(selector).eq(index) → jQuery\n$(selector).eq(indexFromEnd) → jQuery</code></pre></section>	https://api.jquery.com/eq/
-.eq	R	.eq()										
-eq()	R	.eq()										
+end()	R	.end()										
 eq	R	.eq()										
-:eq() Selector	A			jQuery selectors							<section class="prog__container"><p>Select the element at index n within the matched set.</p><pre><code>$(":eq(index)") → jQuery\n$(":eq(-index)") → jQuery</code></pre></section>	https://api.jquery.com/eq-selector/
 eq selector	R	:eq() Selector										
-.error()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "error" JavaScript event.</p><pre><code>$(selector).error(handler) → jQuery\n$(selector).error(eventData, handler) → jQuery</code></pre></section>	https://api.jquery.com/error/
-.error event	R	.error()										
-.error() event	R	.error()										
-error event	R	.error()										
-error() event	R	.error()										
-.error	R	.error()										
-error()	R	.error()										
+eq()	R	.eq()										
 error	R	.error()										
-$.error()	R	jQuery.error()										
-$.error	R	jQuery.error()										
+error event	R	.error()										
+error()	R	.error()										
+error() event	R	.error()										
 escape selector	R	jQuery.escapeSelector()										
-escapeselector	R	jQuery.escapeSelector()										
-.escapeSelector()	R	jQuery.escapeSelector()										
-.escapeSelector	R	jQuery.escapeSelector()										
-$.escapeSelector()	R	jQuery.escapeSelector()										
-$.escapeSelector	R	jQuery.escapeSelector()										
-escapeSelector()	R	jQuery.escapeSelector()										
 escapeSelector	R	jQuery.escapeSelector()										
-:even Selector	A			jQuery selectors							<section class="prog__container"><p>Selects even elements, zero-indexed.  See also odd.</p><pre><code>$(":even") → jQuery</code></pre></section>	https://api.jquery.com/even-selector/
+escapeSelector()	R	jQuery.escapeSelector()										
+escapeselector	R	jQuery.escapeSelector()										
 even selector	R	:even Selector										
-event.currentTarget	A			jQuery properties							<section class="prog__container"><p> The current DOM element within the event bubbling phase.  </p><pre><code>event.currentTarget → Element</code></pre></section>	https://api.jquery.com/event.currentTarget/
 event current target	R	event.currentTarget										
 event currenttarget	R	event.currentTarget										
-event.data	A			jQuery properties							<section class="prog__container"><p>An optional object of data passed to an event method when the current executing handler is bound.  </p><pre><code>event.data → Object</code></pre></section>	https://api.jquery.com/event.data/
 event data	R	event.data										
-event.delegateTarget	A			jQuery properties							<section class="prog__container"><p>The element where the currently-called jQuery event handler was attached.</p><pre><code>event.delegateTarget → Element</code></pre></section>	https://api.jquery.com/event.delegateTarget/
 event delegate target	R	event.delegateTarget										
 event delegatetarget	R	event.delegateTarget										
-event.isDefaultPrevented()	A			jQuery methods							<section class="prog__container"><p>Returns whether event.preventDefault() was ever called on this event object. </p><pre><code>event.isDefaultPrevented() → Boolean</code></pre></section>	https://api.jquery.com/event.isDefaultPrevented/
 event is default prevented	R	event.isDefaultPrevented()										
-event isdefaultprevented	R	event.isDefaultPrevented()										
-event.isDefaultPrevented	R	event.isDefaultPrevented()										
-event.isImmediatePropagationStopped()	A			jQuery methods							<section class="prog__container"><p>  Returns whether event.stopImmediatePropagation() was ever called on this event object. </p><pre><code>event.isImmediatePropagationStopped() → Boolean</code></pre></section>	https://api.jquery.com/event.isImmediatePropagationStopped/
 event is immediate propagation stopped	R	event.isImmediatePropagationStopped()										
-event isimmediatepropagationstopped	R	event.isImmediatePropagationStopped()										
-event.isImmediatePropagationStopped	R	event.isImmediatePropagationStopped()										
-event.isPropagationStopped()	A			jQuery methods							<section class="prog__container"><p>  Returns whether event.stopPropagation() was ever called on this event object. </p><pre><code>event.isPropagationStopped() → Boolean</code></pre></section>	https://api.jquery.com/event.isPropagationStopped/
 event is propagation stopped	R	event.isPropagationStopped()										
+event isdefaultprevented	R	event.isDefaultPrevented()										
+event isimmediatepropagationstopped	R	event.isImmediatePropagationStopped()										
 event ispropagationstopped	R	event.isPropagationStopped()										
-event.isPropagationStopped	R	event.isPropagationStopped()										
-event.metaKey	A			jQuery properties							<section class="prog__container"><p>Indicates whether the META key was pressed when the event fired.</p><pre><code>event.metaKey → Boolean</code></pre></section>	https://api.jquery.com/event.metaKey/
 event meta key	R	event.metaKey										
 event metakey	R	event.metaKey										
-event.namespace	A			jQuery properties							<section class="prog__container"><p>The namespace specified when the event was triggered.</p><pre><code>event.namespace → String</code></pre></section>	https://api.jquery.com/event.namespace/
 event namespace	R	event.namespace										
-event.pageX	A			jQuery properties							<section class="prog__container"><p>The mouse position relative to the left edge of the document.</p><pre><code>event.pageX → Number</code></pre></section>	https://api.jquery.com/event.pageX/
 event page x	R	event.pageX										
-event pagex	R	event.pageX										
-event.pageY	A			jQuery properties							<section class="prog__container"><p>The mouse position relative to the top edge of the document.</p><pre><code>event.pageY → Number</code></pre></section>	https://api.jquery.com/event.pageY/
 event page y	R	event.pageY										
+event pagex	R	event.pageX										
 event pagey	R	event.pageY										
-event.preventDefault()	A			jQuery methods							<section class="prog__container"><p>If this method is called, the default action of the event will not be triggered.</p><pre><code>event.preventDefault() → undefined</code></pre></section>	https://api.jquery.com/event.preventDefault/
 event prevent default	R	event.preventDefault()										
 event preventdefault	R	event.preventDefault()										
-event.preventDefault	R	event.preventDefault()										
-event.relatedTarget	A			jQuery properties							<section class="prog__container"><p>The other DOM element involved in the event, if any.</p><pre><code>event.relatedTarget → Element</code></pre></section>	https://api.jquery.com/event.relatedTarget/
 event related target	R	event.relatedTarget										
 event relatedtarget	R	event.relatedTarget										
-event.result	A			jQuery properties							<section class="prog__container"><p>The last value returned by an event handler that was triggered by this event, unless the value was undefined.</p><pre><code>event.result → Object</code></pre></section>	https://api.jquery.com/event.result/
 event result	R	event.result										
-event.stopImmediatePropagation()	A			jQuery methods							<section class="prog__container"><p>Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.</p><pre><code>event.stopImmediatePropagation() → undefined</code></pre></section>	https://api.jquery.com/event.stopImmediatePropagation/
 event stop immediate propagation	R	event.stopImmediatePropagation()										
-event stopimmediatepropagation	R	event.stopImmediatePropagation()										
-event.stopImmediatePropagation	R	event.stopImmediatePropagation()										
-event.stopPropagation()	A			jQuery methods							<section class="prog__container"><p>Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.</p><pre><code>event.stopPropagation() → undefined</code></pre></section>	https://api.jquery.com/event.stopPropagation/
 event stop propagation	R	event.stopPropagation()										
+event stopimmediatepropagation	R	event.stopImmediatePropagation()										
 event stoppropagation	R	event.stopPropagation()										
-event.stopPropagation	R	event.stopPropagation()										
-event.target	A			jQuery properties							<section class="prog__container"><p> The DOM element that initiated the event.  </p><pre><code>event.target → Element</code></pre></section>	https://api.jquery.com/event.target/
 event target	R	event.target										
-event.timeStamp	A			jQuery properties							<section class="prog__container"><p>The difference in milliseconds between the time the browser created the event and January 1, 1970.</p><pre><code>event.timeStamp → Number</code></pre></section>	https://api.jquery.com/event.timeStamp/
 event time stamp	R	event.timeStamp										
 event timestamp	R	event.timeStamp										
-event.type	A			jQuery properties							<section class="prog__container"><p>Describes the nature of the event.</p><pre><code>event.type → String</code></pre></section>	https://api.jquery.com/event.type/
 event type	R	event.type										
-event.which	A			jQuery properties							<section class="prog__container"><p>For key or mouse events, this property indicates the specific key or button that was pressed.</p><pre><code>event.which → Number</code></pre></section>	https://api.jquery.com/event.which/
 event which	R	event.which										
-.extend()	R	jQuery.extend()										
-.extend	R	jQuery.extend()										
-$.extend()	R	jQuery.extend()										
-$.extend	R	jQuery.extend()										
-extend()	R	jQuery.extend()										
+event.currentTarget	A			jQuery properties							<section class="prog__container"><p> The current DOM element within the event bubbling phase.  </p><pre><code>event.currentTarget → Element</code></pre></section>	https://api.jquery.com/event.currentTarget/
+event.data	A			jQuery properties							<section class="prog__container"><p>An optional object of data passed to an event method when the current executing handler is bound.  </p><pre><code>event.data → Object</code></pre></section>	https://api.jquery.com/event.data/
+event.delegateTarget	A			jQuery properties							<section class="prog__container"><p>The element where the currently-called jQuery event handler was attached.</p><pre><code>event.delegateTarget → Element</code></pre></section>	https://api.jquery.com/event.delegateTarget/
+event.isDefaultPrevented	R	event.isDefaultPrevented()										
+event.isDefaultPrevented()	A			jQuery methods							<section class="prog__container"><p>Returns whether event.preventDefault() was ever called on this event object. </p><pre><code>event.isDefaultPrevented() → Boolean</code></pre></section>	https://api.jquery.com/event.isDefaultPrevented/
+event.isImmediatePropagationStopped	R	event.isImmediatePropagationStopped()										
+event.isImmediatePropagationStopped()	A			jQuery methods							<section class="prog__container"><p>  Returns whether event.stopImmediatePropagation() was ever called on this event object. </p><pre><code>event.isImmediatePropagationStopped() → Boolean</code></pre></section>	https://api.jquery.com/event.isImmediatePropagationStopped/
+event.isPropagationStopped	R	event.isPropagationStopped()										
+event.isPropagationStopped()	A			jQuery methods							<section class="prog__container"><p>  Returns whether event.stopPropagation() was ever called on this event object. </p><pre><code>event.isPropagationStopped() → Boolean</code></pre></section>	https://api.jquery.com/event.isPropagationStopped/
+event.metaKey	A			jQuery properties							<section class="prog__container"><p>Indicates whether the META key was pressed when the event fired.</p><pre><code>event.metaKey → Boolean</code></pre></section>	https://api.jquery.com/event.metaKey/
+event.namespace	A			jQuery properties							<section class="prog__container"><p>The namespace specified when the event was triggered.</p><pre><code>event.namespace → String</code></pre></section>	https://api.jquery.com/event.namespace/
+event.pageX	A			jQuery properties							<section class="prog__container"><p>The mouse position relative to the left edge of the document.</p><pre><code>event.pageX → Number</code></pre></section>	https://api.jquery.com/event.pageX/
+event.pageY	A			jQuery properties							<section class="prog__container"><p>The mouse position relative to the top edge of the document.</p><pre><code>event.pageY → Number</code></pre></section>	https://api.jquery.com/event.pageY/
+event.preventDefault	R	event.preventDefault()										
+event.preventDefault()	A			jQuery methods							<section class="prog__container"><p>If this method is called, the default action of the event will not be triggered.</p><pre><code>event.preventDefault() → undefined</code></pre></section>	https://api.jquery.com/event.preventDefault/
+event.relatedTarget	A			jQuery properties							<section class="prog__container"><p>The other DOM element involved in the event, if any.</p><pre><code>event.relatedTarget → Element</code></pre></section>	https://api.jquery.com/event.relatedTarget/
+event.result	A			jQuery properties							<section class="prog__container"><p>The last value returned by an event handler that was triggered by this event, unless the value was undefined.</p><pre><code>event.result → Object</code></pre></section>	https://api.jquery.com/event.result/
+event.stopImmediatePropagation	R	event.stopImmediatePropagation()										
+event.stopImmediatePropagation()	A			jQuery methods							<section class="prog__container"><p>Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.</p><pre><code>event.stopImmediatePropagation() → undefined</code></pre></section>	https://api.jquery.com/event.stopImmediatePropagation/
+event.stopPropagation	R	event.stopPropagation()										
+event.stopPropagation()	A			jQuery methods							<section class="prog__container"><p>Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.</p><pre><code>event.stopPropagation() → undefined</code></pre></section>	https://api.jquery.com/event.stopPropagation/
+event.target	A			jQuery properties							<section class="prog__container"><p> The DOM element that initiated the event.  </p><pre><code>event.target → Element</code></pre></section>	https://api.jquery.com/event.target/
+event.timeStamp	A			jQuery properties							<section class="prog__container"><p>The difference in milliseconds between the time the browser created the event and January 1, 1970.</p><pre><code>event.timeStamp → Number</code></pre></section>	https://api.jquery.com/event.timeStamp/
+event.type	A			jQuery properties							<section class="prog__container"><p>Describes the nature of the event.</p><pre><code>event.type → String</code></pre></section>	https://api.jquery.com/event.type/
+event.which	A			jQuery properties							<section class="prog__container"><p>For key or mouse events, this property indicates the specific key or button that was pressed.</p><pre><code>event.which → Number</code></pre></section>	https://api.jquery.com/event.which/
 extend	R	jQuery.extend()										
-.fadeIn()	A			jQuery methods							<section class="prog__container"><p>Display the matched elements by fading them to opaque.</p><pre><code>$(selector).fadeIn(duration, complete) → jQuery\n$(selector).fadeIn(options) → jQuery\n$(selector).fadeIn(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/fadeIn/
+extend()	R	jQuery.extend()										
 fade in	R	.fadeIn()										
-fadein	R	.fadeIn()										
-.fadeIn	R	.fadeIn()										
-fadeIn()	R	.fadeIn()										
-fadeIn	R	.fadeIn()										
-.fadeOut()	A			jQuery methods							<section class="prog__container"><p>Hide the matched elements by fading them to transparent.</p><pre><code>$(selector).fadeOut(duration, complete) → jQuery\n$(selector).fadeOut(options) → jQuery\n$(selector).fadeOut(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/fadeOut/
 fade out	R	.fadeOut()										
-fadeout	R	.fadeOut()										
-.fadeOut	R	.fadeOut()										
-fadeOut()	R	.fadeOut()										
-fadeOut	R	.fadeOut()										
-.fadeTo()	A			jQuery methods							<section class="prog__container"><p>Adjust the opacity of the matched elements.</p><pre><code>$(selector).fadeTo(duration, opacity, complete) → jQuery\n$(selector).fadeTo(duration, opacity, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/fadeTo/
-.fadeToggle()	A			jQuery methods							<section class="prog__container"><p>Display or hide the matched elements by animating their opacity.</p><pre><code>$(selector).fadeToggle(duration, easing, complete) → jQuery\n$(selector).fadeToggle(options) → jQuery</code></pre></section>	https://api.jquery.com/fadeToggle/
-fade toggle	R	.fadeToggle()										
-fadetoggle	R	.fadeToggle()										
-.fadeToggle	R	.fadeToggle()										
-fadeToggle()	R	.fadeToggle()										
-fadeToggle	R	.fadeToggle()										
 fade to	R	.fadeTo()										
-fadeto	R	.fadeTo()										
-.fadeTo	R	.fadeTo()										
-fadeTo()	R	.fadeTo()										
+fade toggle	R	.fadeToggle()										
+fadeIn	R	.fadeIn()										
+fadeIn()	R	.fadeIn()										
+fadeOut	R	.fadeOut()										
+fadeOut()	R	.fadeOut()										
 fadeTo	R	.fadeTo()										
-.fail()	R	deferred.fail()										
-.fail	R	deferred.fail()										
-fail()	R	deferred.fail()										
+fadeTo()	R	.fadeTo()										
+fadeToggle	R	.fadeToggle()										
+fadeToggle()	R	.fadeToggle()										
+fadein	R	.fadeIn()										
+fadeout	R	.fadeOut()										
+fadeto	R	.fadeTo()										
+fadetoggle	R	.fadeToggle()										
 fail	R	deferred.fail()										
-:file Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type file.</p><pre><code>$(":file") → jQuery</code></pre></section>	https://api.jquery.com/file-selector/
+fail()	R	deferred.fail()										
 file selector	R	:file Selector										
-.filter()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to those that match the selector or pass the function's test. </p><pre><code>$(selector).filter(selector) → jQuery\n$(selector).filter(function) → jQuery\n$(selector).filter(elements) → jQuery\n$(selector).filter(selection) → jQuery</code></pre></section>	https://api.jquery.com/filter/
-.filter	R	.filter()										
-filter()	R	.filter()										
 filter	R	.filter()										
-.find()	A			jQuery methods							<section class="prog__container"><p>Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.</p><pre><code>$(selector).find(selector) → jQuery\n$(selector).find(element) → jQuery</code></pre></section>	https://api.jquery.com/find/
-.find	R	.find()										
-find()	R	.find()										
+filter()	R	.filter()										
 find	R	.find()										
-.finish()	A			jQuery methods							<section class="prog__container"><p>Stop the currently-running animation, remove all queued animations, and complete all animations for the matched elements.</p><pre><code>$(selector).finish(queue) → jQuery</code></pre></section>	https://api.jquery.com/finish/
-.finish	R	.finish()										
-finish()	R	.finish()										
+find()	R	.find()										
 finish	R	.finish()										
-.fired()	R	callbacks.fired()										
-.fired	R	callbacks.fired()										
-fired()	R	callbacks.fired()										
-fired	R	callbacks.fired()										
-.fire()	R	callbacks.fire()										
-.fire	R	callbacks.fire()										
-fire()	R	callbacks.fire()										
+finish()	R	.finish()										
 fire	R	callbacks.fire()										
 fire with	R	callbacks.fireWith()										
-firewith	R	callbacks.fireWith()										
-.fireWith()	R	callbacks.fireWith()										
-.fireWith	R	callbacks.fireWith()										
-fireWith()	R	callbacks.fireWith()										
+fire()	R	callbacks.fire()										
 fireWith	R	callbacks.fireWith()										
-.first()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to the first in the set.</p><pre><code>$(selector).first() → jQuery</code></pre></section>	https://api.jquery.com/first/
-:first-child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the first child of their parent.</p><pre><code>$(":first-child") → jQuery</code></pre></section>	https://api.jquery.com/first-child-selector/
-first child selector	R	:first-child Selector										
-:first-of-type Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the first among siblings of the same element name.</p><pre><code>$(":first-of-type") → jQuery</code></pre></section>	https://api.jquery.com/first-of-type-selector/
-first of type selector	R	:first-of-type Selector										
-.first	R	.first()										
-first()	R	.first()										
+fireWith()	R	callbacks.fireWith()										
+fired	R	callbacks.fired()										
+fired()	R	callbacks.fired()										
+firewith	R	callbacks.fireWith()										
 first	R	.first()										
-:first Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the first matched DOM element.</p><pre><code>$(":first") → jQuery</code></pre></section>	https://api.jquery.com/first-selector/
+first child selector	R	:first-child Selector										
+first of type selector	R	:first-of-type Selector										
 first selector	R	:first Selector										
-.fn.extend()	R	jQuery.fn.extend()										
-.fn.extend	R	jQuery.fn.extend()										
-$.fn.extend()	R	jQuery.fn.extend()										
-$.fn.extend	R	jQuery.fn.extend()										
+first()	R	.first()										
 fn extend	R	jQuery.fn.extend()										
-fn.extend()	R	jQuery.fn.extend()										
 fn.extend	R	jQuery.fn.extend()										
-.focus()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).focus(handler) → jQuery\n$(selector).focus(eventData, handler) → jQuery\n$(selector).focus() → jQuery</code></pre></section>	https://api.jquery.com/focus/
-.focus event	R	.focus()										
-.focus() event	R	.focus()										
-focus event	R	.focus()										
-focus() event	R	.focus()										
-.focusin()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "focusin" event.</p><pre><code>$(selector).focusin(handler) → jQuery\n$(selector).focusin(eventData, handler) → jQuery\n$(selector).focusin() → jQuery</code></pre></section>	https://api.jquery.com/focusin/
-.focusin event	R	.focusin()										
-.focusin() event	R	.focusin()										
-focusin event	R	.focusin()										
-focusin() event	R	.focusin()										
-.focusin	R	.focusin()										
-focusin()	R	.focusin()										
-focusin	R	.focusin()										
-.focusout()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "focusout" JavaScript event.</p><pre><code>$(selector).focusout(handler) → jQuery\n$(selector).focusout(eventData, handler) → jQuery\n$(selector).focusout() → jQuery</code></pre></section>	https://api.jquery.com/focusout/
-.focusout event	R	.focusout()										
-.focusout() event	R	.focusout()										
-focusout event	R	.focusout()										
-focusout() event	R	.focusout()										
-.focusout	R	.focusout()										
-focusout()	R	.focusout()										
-focusout	R	.focusout()										
-.focus	R	.focus()										
-focus()	R	.focus()										
+fn.extend()	R	jQuery.fn.extend()										
 focus	R	.focus()										
-:focus Selector	A			jQuery selectors							<section class="prog__container"><p>Selects element if it is currently focused.</p><pre><code>$(":focus") → jQuery</code></pre></section>	https://api.jquery.com/focus-selector/
+focus event	R	.focus()										
 focus selector	R	:focus Selector										
-.fx.interval	R	jQuery.fx.interval										
-$.fx.interval	R	jQuery.fx.interval										
+focus()	R	.focus()										
+focus() event	R	.focus()										
+focusin	R	.focusin()										
+focusin event	R	.focusin()										
+focusin()	R	.focusin()										
+focusin() event	R	.focusin()										
+focusout	R	.focusout()										
+focusout event	R	.focusout()										
+focusout()	R	.focusout()										
+focusout() event	R	.focusout()										
 fx interval	R	jQuery.fx.interval										
-fx.interval	R	jQuery.fx.interval										
-.fx.off	R	jQuery.fx.off										
-$.fx.off	R	jQuery.fx.off										
 fx off	R	jQuery.fx.off										
+fx.interval	R	jQuery.fx.interval										
 fx.off	R	jQuery.fx.off										
-.get()	A			jQuery methods							<section class="prog__container"><p>Retrieve one of the elements matched by the jQuery object.</p><pre><code>$(selector).get(index) → Element</code></pre>\n<p>Retrieve the elements matched by the jQuery object.</p><pre><code>$(selector).get() → Array</code></pre></section>	https://api.jquery.com/get/
-get json	R	jQuery.getJSON()										
-getjson	R	jQuery.getJSON()										
-.getJSON()	R	jQuery.getJSON()										
-.getJSON	R	jQuery.getJSON()										
-$.getJSON()	R	jQuery.getJSON()										
-$.getJSON	R	jQuery.getJSON()										
-getJSON()	R	jQuery.getJSON()										
-getJSON	R	jQuery.getJSON()										
-.get	R	.get()										
-get()	R	.get()										
 get	R	.get()										
-$.get()	R	jQuery.get()										
-$.get	R	jQuery.get()										
+get json	R	jQuery.getJSON()										
 get script	R	jQuery.getScript()										
-getscript	R	jQuery.getScript()										
-.getScript()	R	jQuery.getScript()										
-.getScript	R	jQuery.getScript()										
-$.getScript()	R	jQuery.getScript()										
-$.getScript	R	jQuery.getScript()										
-getScript()	R	jQuery.getScript()										
+get()	R	.get()										
+getJSON	R	jQuery.getJSON()										
+getJSON()	R	jQuery.getJSON()										
 getScript	R	jQuery.getScript()										
+getScript()	R	jQuery.getScript()										
+getjson	R	jQuery.getJSON()										
+getscript	R	jQuery.getScript()										
 global eval	R	jQuery.globalEval()										
-globaleval	R	jQuery.globalEval()										
-.globalEval()	R	jQuery.globalEval()										
-.globalEval	R	jQuery.globalEval()										
-$.globalEval()	R	jQuery.globalEval()										
-$.globalEval	R	jQuery.globalEval()										
-globalEval()	R	jQuery.globalEval()										
 globalEval	R	jQuery.globalEval()										
-.grep()	R	jQuery.grep()										
-.grep	R	jQuery.grep()										
-$.grep()	R	jQuery.grep()										
-$.grep	R	jQuery.grep()										
-grep()	R	jQuery.grep()										
+globalEval()	R	jQuery.globalEval()										
+globaleval	R	jQuery.globalEval()										
 grep	R	jQuery.grep()										
-:gt() Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements at an index greater than index within the matched set.</p><pre><code>$(":gt(index)") → jQuery\n$(":gt(-index)") → jQuery</code></pre></section>	https://api.jquery.com/gt-selector/
+grep()	R	jQuery.grep()										
 gt selector	R	:gt() Selector										
-.has()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to those that have a descendant that matches the selector or DOM element.</p><pre><code>$(selector).has(selector) → jQuery\n$(selector).has(contained) → jQuery</code></pre></section>	https://api.jquery.com/has/
-Has Attribute Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements that have the specified attribute, with any value. </p><pre><code>$("[attribute]") → jQuery</code></pre></section>	https://api.jquery.com/has-attribute-selector/
-has attribute selector	R	Has Attribute Selector										
-.hasClass()	A			jQuery methods							<section class="prog__container"><p>Determine whether any of the matched elements are assigned the given class.</p><pre><code>$(selector).hasClass(className) → Boolean</code></pre></section>	https://api.jquery.com/hasClass/
-has class	R	.hasClass()										
-hasclass	R	.hasClass()										
-.hasClass	R	.hasClass()										
-hasClass()	R	.hasClass()										
-hasClass	R	.hasClass()										
-has data	R	jQuery.hasData()										
-hasdata	R	jQuery.hasData()										
-.hasData()	R	jQuery.hasData()										
-.hasData	R	jQuery.hasData()										
-$.hasData()	R	jQuery.hasData()										
-$.hasData	R	jQuery.hasData()										
-hasData()	R	jQuery.hasData()										
-hasData	R	jQuery.hasData()										
-.has	R	.has()										
-has()	R	.has()										
 has	R	.has()										
-:has() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects elements which contain at least one element that matches the specified selector.</p><pre><code>$(":has(selector)") → jQuery</code></pre></section>	https://api.jquery.com/has-selector/
+has attribute selector	R	Has Attribute Selector										
+has class	R	.hasClass()										
+has data	R	jQuery.hasData()										
 has selector	R	:has() Selector										
-:header Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are headers, like h1, h2, h3 and so on.</p><pre><code>$(":header") → jQuery</code></pre></section>	https://api.jquery.com/header-selector/
+has()	R	.has()										
+hasClass	R	.hasClass()										
+hasClass()	R	.hasClass()										
+hasData	R	jQuery.hasData()										
+hasData()	R	jQuery.hasData()										
+hasclass	R	.hasClass()										
+hasdata	R	jQuery.hasData()										
 header selector	R	:header Selector										
-.height()	A			jQuery methods							<section class="prog__container"><p>Get the current computed height for the first element in the set of matched elements.</p><pre><code>$(selector).height() → Number</code></pre>\n<p>Set the CSS height of every matched element.</p><pre><code>$(selector).height(value) → jQuery\n$(selector).height(function) → jQuery</code></pre></section>	https://api.jquery.com/height/
-.height	R	.height()										
-height()	R	.height()										
 height	R	.height()										
-:hidden Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are hidden.</p><pre><code>$(":hidden") → jQuery</code></pre></section>	https://api.jquery.com/hidden-selector/
+height()	R	.height()										
 hidden selector	R	:hidden Selector										
-.hide()	A			jQuery methods							<section class="prog__container"><p>Hide the matched elements.</p><pre><code>$(selector).hide() → jQuery\n$(selector).hide(duration, complete) → jQuery\n$(selector).hide(options) → jQuery\n$(selector).hide(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/hide/
-.hide	R	.hide()										
-hide()	R	.hide()										
 hide	R	.hide()										
+hide()	R	.hide()										
 hold ready	R	jQuery.holdReady()										
-holdready	R	jQuery.holdReady()										
-.holdReady()	R	jQuery.holdReady()										
-.holdReady	R	jQuery.holdReady()										
-$.holdReady()	R	jQuery.holdReady()										
-$.holdReady	R	jQuery.holdReady()										
-holdReady()	R	jQuery.holdReady()										
 holdReady	R	jQuery.holdReady()										
-.hover()	A			jQuery methods							<section class="prog__container"><p>Bind two handlers to the matched elements, to be executed when the mouse pointer enters and leaves the elements.</p><pre><code>$(selector).hover(handlerIn, handlerOut) → jQuery</code></pre>\n<p>Bind a single handler to the matched elements, to be executed when the mouse pointer enters or leaves the elements.</p><pre><code>$(selector).hover(handlerInOut) → jQuery</code></pre></section>	https://api.jquery.com/hover/
-.hover event	R	.hover()										
-.hover() event	R	.hover()										
-hover event	R	.hover()										
-hover() event	R	.hover()										
-.hover	R	.hover()										
-hover()	R	.hover()										
+holdReady()	R	jQuery.holdReady()										
+holdready	R	jQuery.holdReady()										
 hover	R	.hover()										
-.html()	A			jQuery methods							<section class="prog__container"><p>Get the HTML contents of the first element in the set of matched elements.</p><pre><code>$(selector).html() → String</code></pre>\n<p>Set the HTML contents of each element in the set of matched elements.</p><pre><code>$(selector).html(htmlString) → jQuery\n$(selector).html(function) → jQuery</code></pre></section>	https://api.jquery.com/html/
-html prefilter	R	jQuery.htmlPrefilter()										
-htmlprefilter	R	jQuery.htmlPrefilter()										
-.htmlPrefilter()	R	jQuery.htmlPrefilter()										
-.htmlPrefilter	R	jQuery.htmlPrefilter()										
-$.htmlPrefilter()	R	jQuery.htmlPrefilter()										
-$.htmlPrefilter	R	jQuery.htmlPrefilter()										
-htmlPrefilter()	R	jQuery.htmlPrefilter()										
-htmlPrefilter	R	jQuery.htmlPrefilter()										
-.html	R	.html()										
-html()	R	.html()										
+hover event	R	.hover()										
+hover()	R	.hover()										
+hover() event	R	.hover()										
 html	R	.html()										
-ID Selector	A			jQuery selectors							<section class="prog__container"><p>Selects a single element with the given id attribute. </p><pre><code>$("#id") → jQuery</code></pre></section>	https://api.jquery.com/id-selector/
+html prefilter	R	jQuery.htmlPrefilter()										
+html()	R	.html()										
+htmlPrefilter	R	jQuery.htmlPrefilter()										
+htmlPrefilter()	R	jQuery.htmlPrefilter()										
+htmlprefilter	R	jQuery.htmlPrefilter()										
 id selector	R	ID Selector										
-:image Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type image.</p><pre><code>$(":image") → jQuery</code></pre></section>	https://api.jquery.com/image-selector/
 image selector	R	:image Selector										
 in array	R	jQuery.inArray()										
-inarray	R	jQuery.inArray()										
-.inArray()	R	jQuery.inArray()										
-.inArray	R	jQuery.inArray()										
-$.inArray()	R	jQuery.inArray()										
-$.inArray	R	jQuery.inArray()										
-inArray()	R	jQuery.inArray()										
 inArray	R	jQuery.inArray()										
-.index()	A			jQuery methods							<section class="prog__container"><p>Search for a given element from among the matched elements.</p><pre><code>$(selector).index() → Integer\n$(selector).index(selector) → Integer\n$(selector).index(element) → Integer</code></pre></section>	https://api.jquery.com/index/
-.index	R	.index()										
-index()	R	.index()										
+inArray()	R	jQuery.inArray()										
+inarray	R	jQuery.inArray()										
 index	R	.index()										
-.innerHeight()	A			jQuery methods							<section class="prog__container"><p>Get the current computed height for the first element in the set of matched elements, including padding but not border.</p><pre><code>$(selector).innerHeight() → Number</code></pre>\n<p>Set the CSS inner height of each element in the set of matched elements.</p><pre><code>$(selector).innerHeight(value) → jQuery\n$(selector).innerHeight(function) → jQuery</code></pre></section>	https://api.jquery.com/innerHeight/
+index()	R	.index()										
 inner height	R	.innerHeight()										
-innerheight	R	.innerHeight()										
-.innerHeight	R	.innerHeight()										
-innerHeight()	R	.innerHeight()										
-innerHeight	R	.innerHeight()										
-.innerWidth()	A			jQuery methods							<section class="prog__container"><p>Get the current computed inner width for the first element in the set of matched elements, including padding but not border.</p><pre><code>$(selector).innerWidth() → Number</code></pre>\n<p>Set the CSS inner width of each element in the set of matched elements.</p><pre><code>$(selector).innerWidth(value) → jQuery\n$(selector).innerWidth(function) → jQuery</code></pre></section>	https://api.jquery.com/innerWidth/
 inner width	R	.innerWidth()										
-innerwidth	R	.innerWidth()										
-.innerWidth	R	.innerWidth()										
-innerWidth()	R	.innerWidth()										
+innerHeight	R	.innerHeight()										
+innerHeight()	R	.innerHeight()										
 innerWidth	R	.innerWidth()										
-:input Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all input, textarea, select and button elements.</p><pre><code>$(":input") → jQuery</code></pre></section>	https://api.jquery.com/input-selector/
+innerWidth()	R	.innerWidth()										
+innerheight	R	.innerHeight()										
+innerwidth	R	.innerWidth()										
 input selector	R	:input Selector										
-.insertAfter()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements after the target.</p><pre><code>$(selector).insertAfter(target) → jQuery</code></pre></section>	https://api.jquery.com/insertAfter/
 insert after	R	.insertAfter()										
-insertafter	R	.insertAfter()										
-.insertAfter	R	.insertAfter()										
-insertAfter()	R	.insertAfter()										
-insertAfter	R	.insertAfter()										
-.insertBefore()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements before the target.</p><pre><code>$(selector).insertBefore(target) → jQuery</code></pre></section>	https://api.jquery.com/insertBefore/
 insert before	R	.insertBefore()										
-insertbefore	R	.insertBefore()										
-.insertBefore	R	.insertBefore()										
-insertBefore()	R	.insertBefore()										
+insertAfter	R	.insertAfter()										
+insertAfter()	R	.insertAfter()										
 insertBefore	R	.insertBefore()										
-.is()	A			jQuery methods							<section class="prog__container"><p>Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.</p><pre><code>$(selector).is(selector) → Boolean\n$(selector).is(function) → Boolean\n$(selector).is(selection) → Boolean\n$(selector).is(elements) → Boolean</code></pre></section>	https://api.jquery.com/is/
-is array	R	jQuery.isArray()										
-isarray	R	jQuery.isArray()										
-.isArray()	R	jQuery.isArray()										
-.isArray	R	jQuery.isArray()										
-$.isArray()	R	jQuery.isArray()										
-$.isArray	R	jQuery.isArray()										
-isArray()	R	jQuery.isArray()										
-isArray	R	jQuery.isArray()										
-is default prevented	R	event.isDefaultPrevented()										
-isdefaultprevented	R	event.isDefaultPrevented()										
-.isDefaultPrevented()	R	event.isDefaultPrevented()										
-.isDefaultPrevented	R	event.isDefaultPrevented()										
-isDefaultPrevented()	R	event.isDefaultPrevented()										
-isDefaultPrevented	R	event.isDefaultPrevented()										
-is empty object	R	jQuery.isEmptyObject()										
-isemptyobject	R	jQuery.isEmptyObject()										
-.isEmptyObject()	R	jQuery.isEmptyObject()										
-.isEmptyObject	R	jQuery.isEmptyObject()										
-$.isEmptyObject()	R	jQuery.isEmptyObject()										
-$.isEmptyObject	R	jQuery.isEmptyObject()										
-isEmptyObject()	R	jQuery.isEmptyObject()										
-isEmptyObject	R	jQuery.isEmptyObject()										
-is function	R	jQuery.isFunction()										
-isfunction	R	jQuery.isFunction()										
-.isFunction()	R	jQuery.isFunction()										
-.isFunction	R	jQuery.isFunction()										
-$.isFunction()	R	jQuery.isFunction()										
-$.isFunction	R	jQuery.isFunction()										
-isFunction()	R	jQuery.isFunction()										
-isFunction	R	jQuery.isFunction()										
-is immediate propagation stopped	R	event.isImmediatePropagationStopped()										
-isimmediatepropagationstopped	R	event.isImmediatePropagationStopped()										
-.isImmediatePropagationStopped()	R	event.isImmediatePropagationStopped()										
-.isImmediatePropagationStopped	R	event.isImmediatePropagationStopped()										
-isImmediatePropagationStopped()	R	event.isImmediatePropagationStopped()										
-isImmediatePropagationStopped	R	event.isImmediatePropagationStopped()										
-is numeric	R	jQuery.isNumeric()										
-isnumeric	R	jQuery.isNumeric()										
-.isNumeric()	R	jQuery.isNumeric()										
-.isNumeric	R	jQuery.isNumeric()										
-$.isNumeric()	R	jQuery.isNumeric()										
-$.isNumeric	R	jQuery.isNumeric()										
-isNumeric()	R	jQuery.isNumeric()										
-isNumeric	R	jQuery.isNumeric()										
-is plain object	R	jQuery.isPlainObject()										
-isplainobject	R	jQuery.isPlainObject()										
-.isPlainObject()	R	jQuery.isPlainObject()										
-.isPlainObject	R	jQuery.isPlainObject()										
-$.isPlainObject()	R	jQuery.isPlainObject()										
-$.isPlainObject	R	jQuery.isPlainObject()										
-isPlainObject()	R	jQuery.isPlainObject()										
-isPlainObject	R	jQuery.isPlainObject()										
-is propagation stopped	R	event.isPropagationStopped()										
-ispropagationstopped	R	event.isPropagationStopped()										
-.isPropagationStopped()	R	event.isPropagationStopped()										
-.isPropagationStopped	R	event.isPropagationStopped()										
-isPropagationStopped()	R	event.isPropagationStopped()										
-isPropagationStopped	R	event.isPropagationStopped()										
-is rejected	R	deferred.isRejected()										
-isrejected	R	deferred.isRejected()										
-.isRejected()	R	deferred.isRejected()										
-.isRejected	R	deferred.isRejected()										
-isRejected()	R	deferred.isRejected()										
-isRejected	R	deferred.isRejected()										
-is resolved	R	deferred.isResolved()										
-isresolved	R	deferred.isResolved()										
-.isResolved()	R	deferred.isResolved()										
-.isResolved	R	deferred.isResolved()										
-isResolved()	R	deferred.isResolved()										
-isResolved	R	deferred.isResolved()										
-.is	R	.is()										
-is()	R	.is()										
+insertBefore()	R	.insertBefore()										
+insertafter	R	.insertAfter()										
+insertbefore	R	.insertBefore()										
 is	R	.is()										
+is array	R	jQuery.isArray()										
+is default prevented	R	event.isDefaultPrevented()										
+is empty object	R	jQuery.isEmptyObject()										
+is function	R	jQuery.isFunction()										
+is immediate propagation stopped	R	event.isImmediatePropagationStopped()										
+is numeric	R	jQuery.isNumeric()										
+is plain object	R	jQuery.isPlainObject()										
+is propagation stopped	R	event.isPropagationStopped()										
+is rejected	R	deferred.isRejected()										
+is resolved	R	deferred.isResolved()										
 is window	R	jQuery.isWindow()										
-iswindow	R	jQuery.isWindow()										
-.isWindow()	R	jQuery.isWindow()										
-.isWindow	R	jQuery.isWindow()										
-$.isWindow()	R	jQuery.isWindow()										
-$.isWindow	R	jQuery.isWindow()										
-isWindow()	R	jQuery.isWindow()										
-isWindow	R	jQuery.isWindow()										
 is xmldoc	R	jQuery.isXMLDoc()										
-isxmldoc	R	jQuery.isXMLDoc()										
-.isXMLDoc()	R	jQuery.isXMLDoc()										
-.isXMLDoc	R	jQuery.isXMLDoc()										
-$.isXMLDoc()	R	jQuery.isXMLDoc()										
-$.isXMLDoc	R	jQuery.isXMLDoc()										
-isXMLDoc()	R	jQuery.isXMLDoc()										
+is()	R	.is()										
+isArray	R	jQuery.isArray()										
+isArray()	R	jQuery.isArray()										
+isDefaultPrevented	R	event.isDefaultPrevented()										
+isDefaultPrevented()	R	event.isDefaultPrevented()										
+isEmptyObject	R	jQuery.isEmptyObject()										
+isEmptyObject()	R	jQuery.isEmptyObject()										
+isFunction	R	jQuery.isFunction()										
+isFunction()	R	jQuery.isFunction()										
+isImmediatePropagationStopped	R	event.isImmediatePropagationStopped()										
+isImmediatePropagationStopped()	R	event.isImmediatePropagationStopped()										
+isNumeric	R	jQuery.isNumeric()										
+isNumeric()	R	jQuery.isNumeric()										
+isPlainObject	R	jQuery.isPlainObject()										
+isPlainObject()	R	jQuery.isPlainObject()										
+isPropagationStopped	R	event.isPropagationStopped()										
+isPropagationStopped()	R	event.isPropagationStopped()										
+isRejected	R	deferred.isRejected()										
+isRejected()	R	deferred.isRejected()										
+isResolved	R	deferred.isResolved()										
+isResolved()	R	deferred.isResolved()										
+isWindow	R	jQuery.isWindow()										
+isWindow()	R	jQuery.isWindow()										
 isXMLDoc	R	jQuery.isXMLDoc()										
-jQuery.ajax()	A			jQuery methods							<section class="prog__container"><p>Perform an asynchronous HTTP (Ajax) request.</p><pre><code>jQuery.ajax(url, settings) → jqXHR\njQuery.ajax(settings) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.ajax/
-jQuery.ajaxPrefilter()	A			jQuery methods							<section class="prog__container"><p>Handle custom Ajax options or modify existing options before each request is sent and before they are processed by $.ajax().</p><pre><code>jQuery.ajaxPrefilter(dataTypes, handler) → undefined</code></pre></section>	https://api.jquery.com/jQuery.ajaxPrefilter/
-jQuery.ajaxPrefilter	R	jQuery.ajaxPrefilter()										
-jQuery.ajax	R	jQuery.ajax()										
-jQuery.ajaxSetup()	A			jQuery methods							<section class="prog__container"><p>Set default values for future Ajax requests. Its use is not recommended.</p><pre><code>jQuery.ajaxSetup(options) → undefined</code></pre></section>	https://api.jquery.com/jQuery.ajaxSetup/
-jQuery.ajaxSetup	R	jQuery.ajaxSetup()										
-jQuery.ajaxTransport()	A			jQuery methods							<section class="prog__container"><p>Creates an object that handles the actual transmission of Ajax data.</p><pre><code>jQuery.ajaxTransport(dataType, handler) → undefined</code></pre></section>	https://api.jquery.com/jQuery.ajaxTransport/
-jQuery.ajaxTransport	R	jQuery.ajaxTransport()										
+isXMLDoc()	R	jQuery.isXMLDoc()										
+isarray	R	jQuery.isArray()										
+isdefaultprevented	R	event.isDefaultPrevented()										
+isemptyobject	R	jQuery.isEmptyObject()										
+isfunction	R	jQuery.isFunction()										
+isimmediatepropagationstopped	R	event.isImmediatePropagationStopped()										
+isnumeric	R	jQuery.isNumeric()										
+isplainobject	R	jQuery.isPlainObject()										
+ispropagationstopped	R	event.isPropagationStopped()										
+isrejected	R	deferred.isRejected()										
+isresolved	R	deferred.isResolved()										
+iswindow	R	jQuery.isWindow()										
+isxmldoc	R	jQuery.isXMLDoc()										
+jQuery	R	jQuery()										
 jQuery()	A			jQuery methods							<section class="prog__container"><p>Accepts a string containing a CSS selector which is then used to match a set of elements.</p><pre><code>$(selector).jQuery(selector, context) → jQuery\n$(selector).jQuery(element) → jQuery\n$(selector).jQuery(elementArray) → jQuery\n$(selector).jQuery(object) → jQuery\n$(selector).jQuery(selection) → jQuery\n$(selector).jQuery() → jQuery</code></pre>\n<p>Creates DOM elements on the fly from the provided string of raw HTML.</p><pre><code>$(selector).jQuery(html, ownerDocument) → jQuery\n$(selector).jQuery(html, attributes) → jQuery</code></pre>\n<p>Binds a function to be executed when the DOM has finished loading.</p><pre><code>$(selector).jQuery(callback) → jQuery</code></pre></section>	https://api.jquery.com/jQuery/
-.jquery	A			jQuery properties							<section class="prog__container"><p>A string containing the jQuery version number.</p><pre><code>$(selector).jquery → String</code></pre></section>	https://api.jquery.com/jquery-2/
+jQuery.Callbacks	R	jQuery.Callbacks()										
+jQuery.Callbacks()	A			jQuery methods							<section class="prog__container"><p>A multi-purpose callbacks list object that provides a powerful way to manage callback lists.</p><pre><code>jQuery.Callbacks(flags) → Callbacks</code></pre></section>	https://api.jquery.com/jQuery.Callbacks/
+jQuery.Deferred	R	jQuery.Deferred()										
+jQuery.Deferred()	A			jQuery methods							<section class="prog__container"><p> A factory function that returns a chainable utility object with methods to register multiple callbacks into callback queues, invoke callback queues, and relay the success or failure state of any synchronous or asynchronous function.</p><pre><code>jQuery.Deferred(beforeStart) → Deferred</code></pre></section>	https://api.jquery.com/jQuery.Deferred/
+jQuery.ajax	R	jQuery.ajax()										
+jQuery.ajax()	A			jQuery methods							<section class="prog__container"><p>Perform an asynchronous HTTP (Ajax) request.</p><pre><code>jQuery.ajax(url, settings) → jqXHR\njQuery.ajax(settings) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.ajax/
+jQuery.ajaxPrefilter	R	jQuery.ajaxPrefilter()										
+jQuery.ajaxPrefilter()	A			jQuery methods							<section class="prog__container"><p>Handle custom Ajax options or modify existing options before each request is sent and before they are processed by $.ajax().</p><pre><code>jQuery.ajaxPrefilter(dataTypes, handler) → undefined</code></pre></section>	https://api.jquery.com/jQuery.ajaxPrefilter/
+jQuery.ajaxSetup	R	jQuery.ajaxSetup()										
+jQuery.ajaxSetup()	A			jQuery methods							<section class="prog__container"><p>Set default values for future Ajax requests. Its use is not recommended.</p><pre><code>jQuery.ajaxSetup(options) → undefined</code></pre></section>	https://api.jquery.com/jQuery.ajaxSetup/
+jQuery.ajaxTransport	R	jQuery.ajaxTransport()										
+jQuery.ajaxTransport()	A			jQuery methods							<section class="prog__container"><p>Creates an object that handles the actual transmission of Ajax data.</p><pre><code>jQuery.ajaxTransport(dataType, handler) → undefined</code></pre></section>	https://api.jquery.com/jQuery.ajaxTransport/
 jQuery.boxModel	A			jQuery properties							<section class="prog__container"><p>States if the current page, in the user's browser, is being rendered using the W3C CSS Box Model. This property was removed in jQuery 1.8. Please try to use feature detection instead.</p><pre><code>jQuery.boxModel → Boolean</code></pre></section>	https://api.jquery.com/jQuery.boxModel/
 jQuery.browser	A			jQuery properties							<section class="prog__container"><p>Contains flags for the useragent, read from navigator.userAgent. This property was removed in jQuery 1.9 and is available only through the jQuery.migrate plugin. Please try to use feature detection instead.</p><pre><code>jQuery.browser → PlainObject</code></pre>\n<p>The version number of the rendering engine for the user's browser. This property was removed in jQuery 1.9 and is available only through the jQuery.migrate plugin.</p><pre><code>jQuery.browser.version → String</code></pre></section>	https://api.jquery.com/jQuery.browser/
-jQuery.Callbacks()	A			jQuery methods							<section class="prog__container"><p>A multi-purpose callbacks list object that provides a powerful way to manage callback lists.</p><pre><code>jQuery.Callbacks(flags) → Callbacks</code></pre></section>	https://api.jquery.com/jQuery.Callbacks/
-jQuery.Callbacks	R	jQuery.Callbacks()										
-jQuery.contains()	A			jQuery methods							<section class="prog__container"><p>Check to see if a DOM element is a descendant of another DOM element.</p><pre><code>jQuery.contains(container, contained) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.contains/
 jQuery.contains	R	jQuery.contains()										
+jQuery.contains()	A			jQuery methods							<section class="prog__container"><p>Check to see if a DOM element is a descendant of another DOM element.</p><pre><code>jQuery.contains(container, contained) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.contains/
 jQuery.cssHooks	A			jQuery properties							<section class="prog__container"><p>Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize CSS property naming, or create custom properties.</p><pre><code>jQuery.cssHooks → Object</code></pre></section>	https://api.jquery.com/jQuery.cssHooks/
 jQuery.cssNumber	A			jQuery properties							<section class="prog__container"><p>An object containing all CSS properties that may be used without a unit. The .css() method uses this object to see if it may append px to unitless values.</p><pre><code>jQuery.cssNumber → Object</code></pre></section>	https://api.jquery.com/jQuery.cssNumber/
-jQuery.data()	A			jQuery methods							<section class="prog__container"><p>Store arbitrary data associated with the specified element. Returns the value that was set.</p><pre><code>jQuery.data(element, key, value) → Object</code></pre>\n<p>Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.</p><pre><code>jQuery.data(element, key) → Object\njQuery.data(element) → Object</code></pre></section>	https://api.jquery.com/jQuery.data/
 jQuery.data	R	jQuery.data()										
-jQuery.Deferred()	A			jQuery methods							<section class="prog__container"><p> A factory function that returns a chainable utility object with methods to register multiple callbacks into callback queues, invoke callback queues, and relay the success or failure state of any synchronous or asynchronous function.</p><pre><code>jQuery.Deferred(beforeStart) → Deferred</code></pre></section>	https://api.jquery.com/jQuery.Deferred/
-jQuery.Deferred	R	jQuery.Deferred()										
-jQuery.dequeue()	A			jQuery methods							<section class="prog__container"><p>Execute the next function on the queue for the matched element.</p><pre><code>jQuery.dequeue(element, queueName) → undefined</code></pre></section>	https://api.jquery.com/jQuery.dequeue/
+jQuery.data()	A			jQuery methods							<section class="prog__container"><p>Store arbitrary data associated with the specified element. Returns the value that was set.</p><pre><code>jQuery.data(element, key, value) → Object</code></pre>\n<p>Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.</p><pre><code>jQuery.data(element, key) → Object\njQuery.data(element) → Object</code></pre></section>	https://api.jquery.com/jQuery.data/
 jQuery.dequeue	R	jQuery.dequeue()										
-jQuery.each()	A			jQuery methods							<section class="prog__container"><p>A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.</p><pre><code>jQuery.each(array, callback) → Object\njQuery.each(object, callback) → Object</code></pre></section>	https://api.jquery.com/jQuery.each/
+jQuery.dequeue()	A			jQuery methods							<section class="prog__container"><p>Execute the next function on the queue for the matched element.</p><pre><code>jQuery.dequeue(element, queueName) → undefined</code></pre></section>	https://api.jquery.com/jQuery.dequeue/
 jQuery.each	R	jQuery.each()										
-jQuery.error()	A			jQuery methods							<section class="prog__container"><p>Takes a string and throws an exception containing it.</p><pre><code>jQuery.error(message) → undefined</code></pre></section>	https://api.jquery.com/jQuery.error/
+jQuery.each()	A			jQuery methods							<section class="prog__container"><p>A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.</p><pre><code>jQuery.each(array, callback) → Object\njQuery.each(object, callback) → Object</code></pre></section>	https://api.jquery.com/jQuery.each/
 jQuery.error	R	jQuery.error()										
-jQuery.escapeSelector()	A			jQuery methods							<section class="prog__container"><p>Escapes any character that has a special meaning in a CSS selector.</p><pre><code>jQuery.escapeSelector(selector) → Selector</code></pre></section>	https://api.jquery.com/jQuery.escapeSelector/
+jQuery.error()	A			jQuery methods							<section class="prog__container"><p>Takes a string and throws an exception containing it.</p><pre><code>jQuery.error(message) → undefined</code></pre></section>	https://api.jquery.com/jQuery.error/
 jQuery.escapeSelector	R	jQuery.escapeSelector()										
-jQuery.extend()	A			jQuery methods							<section class="prog__container"><p>Merge the contents of two or more objects together into the first object.</p><pre><code>jQuery.extend(target, object1, objectN) → Object\njQuery.extend(deep, target, object1, objectN) → Object</code></pre></section>	https://api.jquery.com/jQuery.extend/
+jQuery.escapeSelector()	A			jQuery methods							<section class="prog__container"><p>Escapes any character that has a special meaning in a CSS selector.</p><pre><code>jQuery.escapeSelector(selector) → Selector</code></pre></section>	https://api.jquery.com/jQuery.escapeSelector/
 jQuery.extend	R	jQuery.extend()										
-jQuery.fn.extend()	A			jQuery methods							<section class="prog__container"><p>Merge the contents of an object onto the jQuery prototype to provide new jQuery instance methods.</p><pre><code>jQuery.fn.extend(object) → Object</code></pre></section>	https://api.jquery.com/jQuery.fn.extend/
+jQuery.extend()	A			jQuery methods							<section class="prog__container"><p>Merge the contents of two or more objects together into the first object.</p><pre><code>jQuery.extend(target, object1, objectN) → Object\njQuery.extend(deep, target, object1, objectN) → Object</code></pre></section>	https://api.jquery.com/jQuery.extend/
 jQuery.fn.extend	R	jQuery.fn.extend()										
+jQuery.fn.extend()	A			jQuery methods							<section class="prog__container"><p>Merge the contents of an object onto the jQuery prototype to provide new jQuery instance methods.</p><pre><code>jQuery.fn.extend(object) → Object</code></pre></section>	https://api.jquery.com/jQuery.fn.extend/
 jQuery.fx.interval	A			jQuery properties							<section class="prog__container"><p>The rate (in milliseconds) at which animations fire.</p><pre><code>jQuery.fx.interval → Number</code></pre></section>	https://api.jquery.com/jQuery.fx.interval/
 jQuery.fx.off	A			jQuery properties							<section class="prog__container"><p>Globally disable all animations.</p><pre><code>jQuery.fx.off → Boolean</code></pre></section>	https://api.jquery.com/jQuery.fx.off/
-jQuery.get()	A			jQuery methods							<section class="prog__container"><p>Load data from the server using a HTTP GET request.</p><pre><code>jQuery.get(url, data, success, dataType) → jqXHR\njQuery.get(settings) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.get/
-jQuery.getJSON()	A			jQuery methods							<section class="prog__container"><p>Load JSON-encoded data from the server using a GET HTTP request.</p><pre><code>jQuery.getJSON(url, data, success) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.getJSON/
-jQuery.getJSON	R	jQuery.getJSON()										
 jQuery.get	R	jQuery.get()										
-jQuery.getScript()	A			jQuery methods							<section class="prog__container"><p>Load a JavaScript file from the server using a GET HTTP request, then execute it.</p><pre><code>jQuery.getScript(url, success) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.getScript/
+jQuery.get()	A			jQuery methods							<section class="prog__container"><p>Load data from the server using a HTTP GET request.</p><pre><code>jQuery.get(url, data, success, dataType) → jqXHR\njQuery.get(settings) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.get/
+jQuery.getJSON	R	jQuery.getJSON()										
+jQuery.getJSON()	A			jQuery methods							<section class="prog__container"><p>Load JSON-encoded data from the server using a GET HTTP request.</p><pre><code>jQuery.getJSON(url, data, success) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.getJSON/
 jQuery.getScript	R	jQuery.getScript()										
-jQuery.globalEval()	A			jQuery methods							<section class="prog__container"><p>Execute some JavaScript code globally.</p><pre><code>jQuery.globalEval(code) → undefined</code></pre></section>	https://api.jquery.com/jQuery.globalEval/
+jQuery.getScript()	A			jQuery methods							<section class="prog__container"><p>Load a JavaScript file from the server using a GET HTTP request, then execute it.</p><pre><code>jQuery.getScript(url, success) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.getScript/
 jQuery.globalEval	R	jQuery.globalEval()										
-jQuery.grep()	A			jQuery methods							<section class="prog__container"><p>Finds the elements of an array which satisfy a filter function. The original array is not affected.</p><pre><code>jQuery.grep(array, function, invert) → Array</code></pre></section>	https://api.jquery.com/jQuery.grep/
+jQuery.globalEval()	A			jQuery methods							<section class="prog__container"><p>Execute some JavaScript code globally.</p><pre><code>jQuery.globalEval(code) → undefined</code></pre></section>	https://api.jquery.com/jQuery.globalEval/
 jQuery.grep	R	jQuery.grep()										
-jQuery.hasData()	A			jQuery methods							<section class="prog__container"><p>Determine whether an element has any jQuery data associated with it.</p><pre><code>jQuery.hasData(element) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.hasData/
+jQuery.grep()	A			jQuery methods							<section class="prog__container"><p>Finds the elements of an array which satisfy a filter function. The original array is not affected.</p><pre><code>jQuery.grep(array, function, invert) → Array</code></pre></section>	https://api.jquery.com/jQuery.grep/
 jQuery.hasData	R	jQuery.hasData()										
-jQuery.holdReady()	A			jQuery methods							<section class="prog__container"><p>Holds or releases the execution of jQuery's ready event.</p><pre><code>jQuery.holdReady(hold) → undefined</code></pre></section>	https://api.jquery.com/jQuery.holdReady/
+jQuery.hasData()	A			jQuery methods							<section class="prog__container"><p>Determine whether an element has any jQuery data associated with it.</p><pre><code>jQuery.hasData(element) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.hasData/
 jQuery.holdReady	R	jQuery.holdReady()										
-jQuery.htmlPrefilter()	A			jQuery methods							<section class="prog__container"><p>Modify and filter HTML strings passed through jQuery manipulation methods.</p><pre><code>jQuery.htmlPrefilter(html) → String</code></pre></section>	https://api.jquery.com/jQuery.htmlPrefilter/
+jQuery.holdReady()	A			jQuery methods							<section class="prog__container"><p>Holds or releases the execution of jQuery's ready event.</p><pre><code>jQuery.holdReady(hold) → undefined</code></pre></section>	https://api.jquery.com/jQuery.holdReady/
 jQuery.htmlPrefilter	R	jQuery.htmlPrefilter()										
-jQuery.inArray()	A			jQuery methods							<section class="prog__container"><p>Search for a specified value within an array and return its index (or -1 if not found).</p><pre><code>jQuery.inArray(value, array, fromIndex) → Number</code></pre></section>	https://api.jquery.com/jQuery.inArray/
+jQuery.htmlPrefilter()	A			jQuery methods							<section class="prog__container"><p>Modify and filter HTML strings passed through jQuery manipulation methods.</p><pre><code>jQuery.htmlPrefilter(html) → String</code></pre></section>	https://api.jquery.com/jQuery.htmlPrefilter/
 jQuery.inArray	R	jQuery.inArray()										
-jQuery.isArray()	A			jQuery methods							<section class="prog__container"><p>Determine whether the argument is an array.</p><pre><code>jQuery.isArray(obj) → boolean</code></pre></section>	https://api.jquery.com/jQuery.isArray/
+jQuery.inArray()	A			jQuery methods							<section class="prog__container"><p>Search for a specified value within an array and return its index (or -1 if not found).</p><pre><code>jQuery.inArray(value, array, fromIndex) → Number</code></pre></section>	https://api.jquery.com/jQuery.inArray/
 jQuery.isArray	R	jQuery.isArray()										
-jQuery.isEmptyObject()	A			jQuery methods							<section class="prog__container"><p>Check to see if an object is empty (contains no enumerable properties).</p><pre><code>jQuery.isEmptyObject(object) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isEmptyObject/
+jQuery.isArray()	A			jQuery methods							<section class="prog__container"><p>Determine whether the argument is an array.</p><pre><code>jQuery.isArray(obj) → boolean</code></pre></section>	https://api.jquery.com/jQuery.isArray/
 jQuery.isEmptyObject	R	jQuery.isEmptyObject()										
-jQuery.isFunction()	A			jQuery methods							<section class="prog__container"><p>Determine if the argument passed is a JavaScript function object. </p><pre><code>jQuery.isFunction(obj) → boolean</code></pre></section>	https://api.jquery.com/jQuery.isFunction/
+jQuery.isEmptyObject()	A			jQuery methods							<section class="prog__container"><p>Check to see if an object is empty (contains no enumerable properties).</p><pre><code>jQuery.isEmptyObject(object) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isEmptyObject/
 jQuery.isFunction	R	jQuery.isFunction()										
-jQuery.isNumeric()	A			jQuery methods							<section class="prog__container"><p>Determines whether its argument represents a JavaScript number.</p><pre><code>jQuery.isNumeric(value) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isNumeric/
+jQuery.isFunction()	A			jQuery methods							<section class="prog__container"><p>Determine if the argument passed is a JavaScript function object. </p><pre><code>jQuery.isFunction(obj) → boolean</code></pre></section>	https://api.jquery.com/jQuery.isFunction/
 jQuery.isNumeric	R	jQuery.isNumeric()										
-jQuery.isPlainObject()	A			jQuery methods							<section class="prog__container"><p>Check to see if an object is a plain object (created using "{}" or "new Object").</p><pre><code>jQuery.isPlainObject(object) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isPlainObject/
+jQuery.isNumeric()	A			jQuery methods							<section class="prog__container"><p>Determines whether its argument represents a JavaScript number.</p><pre><code>jQuery.isNumeric(value) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isNumeric/
 jQuery.isPlainObject	R	jQuery.isPlainObject()										
-jQuery.isWindow()	A			jQuery methods							<section class="prog__container"><p>Determine whether the argument is a window.</p><pre><code>jQuery.isWindow(obj) → boolean</code></pre></section>	https://api.jquery.com/jQuery.isWindow/
+jQuery.isPlainObject()	A			jQuery methods							<section class="prog__container"><p>Check to see if an object is a plain object (created using "{}" or "new Object").</p><pre><code>jQuery.isPlainObject(object) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isPlainObject/
 jQuery.isWindow	R	jQuery.isWindow()										
-jQuery.isXMLDoc()	A			jQuery methods							<section class="prog__container"><p>Check to see if a DOM node is within an XML document (or is an XML document).</p><pre><code>jQuery.isXMLDoc(node) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isXMLDoc/
+jQuery.isWindow()	A			jQuery methods							<section class="prog__container"><p>Determine whether the argument is a window.</p><pre><code>jQuery.isWindow(obj) → boolean</code></pre></section>	https://api.jquery.com/jQuery.isWindow/
 jQuery.isXMLDoc	R	jQuery.isXMLDoc()										
-jQuery.makeArray()	A			jQuery methods							<section class="prog__container"><p>Convert an array-like object into a true JavaScript array.</p><pre><code>jQuery.makeArray(obj) → Array</code></pre></section>	https://api.jquery.com/jQuery.makeArray/
+jQuery.isXMLDoc()	A			jQuery methods							<section class="prog__container"><p>Check to see if a DOM node is within an XML document (or is an XML document).</p><pre><code>jQuery.isXMLDoc(node) → Boolean</code></pre></section>	https://api.jquery.com/jQuery.isXMLDoc/
 jQuery.makeArray	R	jQuery.makeArray()										
-jQuery.map()	A			jQuery methods							<section class="prog__container"><p>Translate all items in an array or object to new array of items.</p><pre><code>jQuery.map(array, callback) → Array\njQuery.map(object, callback) → Array</code></pre></section>	https://api.jquery.com/jQuery.map/
+jQuery.makeArray()	A			jQuery methods							<section class="prog__container"><p>Convert an array-like object into a true JavaScript array.</p><pre><code>jQuery.makeArray(obj) → Array</code></pre></section>	https://api.jquery.com/jQuery.makeArray/
 jQuery.map	R	jQuery.map()										
-jQuery.merge()	A			jQuery methods							<section class="prog__container"><p>Merge the contents of two arrays together into the first array. </p><pre><code>jQuery.merge(first, second) → Array</code></pre></section>	https://api.jquery.com/jQuery.merge/
+jQuery.map()	A			jQuery methods							<section class="prog__container"><p>Translate all items in an array or object to new array of items.</p><pre><code>jQuery.map(array, callback) → Array\njQuery.map(object, callback) → Array</code></pre></section>	https://api.jquery.com/jQuery.map/
 jQuery.merge	R	jQuery.merge()										
-jQuery.noConflict()	A			jQuery methods							<section class="prog__container"><p>Relinquish jQuery's control of the $ variable.</p><pre><code>jQuery.noConflict(removeAll) → Object</code></pre></section>	https://api.jquery.com/jQuery.noConflict/
+jQuery.merge()	A			jQuery methods							<section class="prog__container"><p>Merge the contents of two arrays together into the first array. </p><pre><code>jQuery.merge(first, second) → Array</code></pre></section>	https://api.jquery.com/jQuery.merge/
 jQuery.noConflict	R	jQuery.noConflict()										
-jQuery.noop()	A			jQuery methods							<section class="prog__container"><p>An empty function.</p><pre><code>jQuery.noop() → undefined</code></pre></section>	https://api.jquery.com/jQuery.noop/
+jQuery.noConflict()	A			jQuery methods							<section class="prog__container"><p>Relinquish jQuery's control of the $ variable.</p><pre><code>jQuery.noConflict(removeAll) → Object</code></pre></section>	https://api.jquery.com/jQuery.noConflict/
 jQuery.noop	R	jQuery.noop()										
-jQuery.now()	A			jQuery methods							<section class="prog__container"><p>Return a number representing the current time.</p><pre><code>jQuery.now() → Number</code></pre></section>	https://api.jquery.com/jQuery.now/
+jQuery.noop()	A			jQuery methods							<section class="prog__container"><p>An empty function.</p><pre><code>jQuery.noop() → undefined</code></pre></section>	https://api.jquery.com/jQuery.noop/
 jQuery.now	R	jQuery.now()										
-jQuery.param()	A			jQuery methods							<section class="prog__container"><p>Create a serialized representation of an array, a plain object, or a jQuery object suitable for use in a URL query string or Ajax request. In case a jQuery object is passed, it should contain input elements with name/value properties.</p><pre><code>jQuery.param(obj) → String\njQuery.param(obj, traditional) → String</code></pre></section>	https://api.jquery.com/jQuery.param/
+jQuery.now()	A			jQuery methods							<section class="prog__container"><p>Return a number representing the current time.</p><pre><code>jQuery.now() → Number</code></pre></section>	https://api.jquery.com/jQuery.now/
 jQuery.param	R	jQuery.param()										
-jQuery.parseHTML()	A			jQuery methods							<section class="prog__container"><p>Parses a string into an array of DOM nodes.</p><pre><code>jQuery.parseHTML(data, context, keepScripts) → Array</code></pre></section>	https://api.jquery.com/jQuery.parseHTML/
+jQuery.param()	A			jQuery methods							<section class="prog__container"><p>Create a serialized representation of an array, a plain object, or a jQuery object suitable for use in a URL query string or Ajax request. In case a jQuery object is passed, it should contain input elements with name/value properties.</p><pre><code>jQuery.param(obj) → String\njQuery.param(obj, traditional) → String</code></pre></section>	https://api.jquery.com/jQuery.param/
 jQuery.parseHTML	R	jQuery.parseHTML()										
-jQuery.parseJSON()	A			jQuery methods							<section class="prog__container"><p>Takes a well-formed JSON string and returns the resulting JavaScript value.</p><pre><code>jQuery.parseJSON(json) → String|Number|Object|Array|Boolean</code></pre></section>	https://api.jquery.com/jQuery.parseJSON/
+jQuery.parseHTML()	A			jQuery methods							<section class="prog__container"><p>Parses a string into an array of DOM nodes.</p><pre><code>jQuery.parseHTML(data, context, keepScripts) → Array</code></pre></section>	https://api.jquery.com/jQuery.parseHTML/
 jQuery.parseJSON	R	jQuery.parseJSON()										
-jQuery.parseXML()	A			jQuery methods							<section class="prog__container"><p>Parses a string into an XML document.</p><pre><code>jQuery.parseXML(data) → XMLDocument</code></pre></section>	https://api.jquery.com/jQuery.parseXML/
+jQuery.parseJSON()	A			jQuery methods							<section class="prog__container"><p>Takes a well-formed JSON string and returns the resulting JavaScript value.</p><pre><code>jQuery.parseJSON(json) → String|Number|Object|Array|Boolean</code></pre></section>	https://api.jquery.com/jQuery.parseJSON/
 jQuery.parseXML	R	jQuery.parseXML()										
-jQuery.post()	A			jQuery methods							<section class="prog__container"><p>Load data from the server using a HTTP POST request.</p><pre><code>jQuery.post(url, data, success, dataType) → jqXHR\njQuery.post(settings) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.post/
+jQuery.parseXML()	A			jQuery methods							<section class="prog__container"><p>Parses a string into an XML document.</p><pre><code>jQuery.parseXML(data) → XMLDocument</code></pre></section>	https://api.jquery.com/jQuery.parseXML/
 jQuery.post	R	jQuery.post()										
-jQuery.proxy()	A			jQuery methods							<section class="prog__container"><p>Takes a function and returns a new one that will always have a particular context.</p><pre><code>jQuery.proxy(function, context) → Function\njQuery.proxy(context, name) → Function\njQuery.proxy(function, context, additionalArguments) → Function\njQuery.proxy(context, name, additionalArguments) → Function</code></pre></section>	https://api.jquery.com/jQuery.proxy/
+jQuery.post()	A			jQuery methods							<section class="prog__container"><p>Load data from the server using a HTTP POST request.</p><pre><code>jQuery.post(url, data, success, dataType) → jqXHR\njQuery.post(settings) → jqXHR</code></pre></section>	https://api.jquery.com/jQuery.post/
 jQuery.proxy	R	jQuery.proxy()										
-jQuery.queue()	A			jQuery methods							<section class="prog__container"><p>Show the queue of functions to be executed on the matched element.</p><pre><code>jQuery.queue(element, queueName) → Array</code></pre>\n<p>Manipulate the queue of functions to be executed on the matched element.</p><pre><code>jQuery.queue(element, queueName, newQueue) → jQuery\njQuery.queue(element, queueName, callback) → jQuery</code></pre></section>	https://api.jquery.com/jQuery.queue/
+jQuery.proxy()	A			jQuery methods							<section class="prog__container"><p>Takes a function and returns a new one that will always have a particular context.</p><pre><code>jQuery.proxy(function, context) → Function\njQuery.proxy(context, name) → Function\njQuery.proxy(function, context, additionalArguments) → Function\njQuery.proxy(context, name, additionalArguments) → Function</code></pre></section>	https://api.jquery.com/jQuery.proxy/
 jQuery.queue	R	jQuery.queue()										
-jQuery.readyException()	A			jQuery methods							<section class="prog__container"><p>Handles errors thrown synchronously in functions wrapped in jQuery().</p><pre><code>jQuery.readyException(error) → Selector</code></pre></section>	https://api.jquery.com/jQuery.readyException/
+jQuery.queue()	A			jQuery methods							<section class="prog__container"><p>Show the queue of functions to be executed on the matched element.</p><pre><code>jQuery.queue(element, queueName) → Array</code></pre>\n<p>Manipulate the queue of functions to be executed on the matched element.</p><pre><code>jQuery.queue(element, queueName, newQueue) → jQuery\njQuery.queue(element, queueName, callback) → jQuery</code></pre></section>	https://api.jquery.com/jQuery.queue/
 jQuery.readyException	R	jQuery.readyException()										
-jQuery.removeData()	A			jQuery methods							<section class="prog__container"><p>Remove a previously-stored piece of data.</p><pre><code>jQuery.removeData(element, name) → jQuery</code></pre></section>	https://api.jquery.com/jQuery.removeData/
+jQuery.readyException()	A			jQuery methods							<section class="prog__container"><p>Handles errors thrown synchronously in functions wrapped in jQuery().</p><pre><code>jQuery.readyException(error) → Selector</code></pre></section>	https://api.jquery.com/jQuery.readyException/
 jQuery.removeData	R	jQuery.removeData()										
-jquery	R	.jquery										
-jQuery	R	jQuery()										
+jQuery.removeData()	A			jQuery methods							<section class="prog__container"><p>Remove a previously-stored piece of data.</p><pre><code>jQuery.removeData(element, name) → jQuery</code></pre></section>	https://api.jquery.com/jQuery.removeData/
 jQuery.speed	A			jQuery methods							<section class="prog__container"><p>Creates an object containing a set of properties ready to be used in the definition of custom animations.</p><pre><code>jQuery.speed(duration, settings) → PlainObject\njQuery.speed(duration, easing, complete) → PlainObject\njQuery.speed(settings) → PlainObject</code></pre></section>	https://api.jquery.com/jQuery.speed/
-jQuery.sub()	A			jQuery methods							<section class="prog__container"><p>Creates a new copy of jQuery whose properties and methods can be modified without affecting the original jQuery object.</p><pre><code>jQuery.sub() → jQuery</code></pre></section>	https://api.jquery.com/jQuery.sub/
 jQuery.sub	R	jQuery.sub()										
+jQuery.sub()	A			jQuery methods							<section class="prog__container"><p>Creates a new copy of jQuery whose properties and methods can be modified without affecting the original jQuery object.</p><pre><code>jQuery.sub() → jQuery</code></pre></section>	https://api.jquery.com/jQuery.sub/
 jQuery.support	A			jQuery properties							<section class="prog__container"><p>A collection of properties that represent the presence of different browser features or bugs. Intended for jQuery's internal use; specific properties may be removed when they are no longer needed internally to improve page startup performance. For your own project's feature-detection needs, we strongly recommend the use of an external library such as Modernizr instead of dependency on properties in jQuery.support.</p><pre><code>jQuery.support → Object</code></pre></section>	https://api.jquery.com/jQuery.support/
-jQuery.trim()	A			jQuery methods							<section class="prog__container"><p>Remove the whitespace from the beginning and end of a string.</p><pre><code>jQuery.trim(str) → String</code></pre></section>	https://api.jquery.com/jQuery.trim/
 jQuery.trim	R	jQuery.trim()										
-jQuery.type()	A			jQuery methods							<section class="prog__container"><p>Determine the internal JavaScript [[Class]] of an object.</p><pre><code>jQuery.type(obj) → String</code></pre></section>	https://api.jquery.com/jQuery.type/
+jQuery.trim()	A			jQuery methods							<section class="prog__container"><p>Remove the whitespace from the beginning and end of a string.</p><pre><code>jQuery.trim(str) → String</code></pre></section>	https://api.jquery.com/jQuery.trim/
 jQuery.type	R	jQuery.type()										
-jQuery.unique()	A			jQuery methods							<section class="prog__container"><p>Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.</p><pre><code>jQuery.unique(array) → Array</code></pre></section>	https://api.jquery.com/jQuery.unique/
+jQuery.type()	A			jQuery methods							<section class="prog__container"><p>Determine the internal JavaScript [[Class]] of an object.</p><pre><code>jQuery.type(obj) → String</code></pre></section>	https://api.jquery.com/jQuery.type/
 jQuery.unique	R	jQuery.unique()										
-jQuery.uniqueSort()	A			jQuery methods							<section class="prog__container"><p>Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.</p><pre><code>jQuery.uniqueSort(array) → Array</code></pre></section>	https://api.jquery.com/jQuery.uniqueSort/
+jQuery.unique()	A			jQuery methods							<section class="prog__container"><p>Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.</p><pre><code>jQuery.unique(array) → Array</code></pre></section>	https://api.jquery.com/jQuery.unique/
 jQuery.uniqueSort	R	jQuery.uniqueSort()										
-jQuery.when()	A			jQuery methods							<section class="prog__container"><p>Provides a way to execute callback functions based on zero or more objects, usually Deferred objects that represent asynchronous events.</p><pre><code>jQuery.when(deferreds) → Promise</code></pre></section>	https://api.jquery.com/jQuery.when/
+jQuery.uniqueSort()	A			jQuery methods							<section class="prog__container"><p>Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.</p><pre><code>jQuery.uniqueSort(array) → Array</code></pre></section>	https://api.jquery.com/jQuery.uniqueSort/
 jQuery.when	R	jQuery.when()										
-.keydown()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).keydown(handler) → jQuery\n$(selector).keydown(eventData, handler) → jQuery\n$(selector).keydown() → jQuery</code></pre></section>	https://api.jquery.com/keydown/
-.keydown event	R	.keydown()										
-.keydown() event	R	.keydown()										
-keydown event	R	.keydown()										
-keydown() event	R	.keydown()										
-.keydown	R	.keydown()										
-keydown()	R	.keydown()										
+jQuery.when()	A			jQuery methods							<section class="prog__container"><p>Provides a way to execute callback functions based on zero or more objects, usually Deferred objects that represent asynchronous events.</p><pre><code>jQuery.when(deferreds) → Promise</code></pre></section>	https://api.jquery.com/jQuery.when/
+jquery	R	.jquery										
 keydown	R	.keydown()										
-.keypress()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).keypress(handler) → jQuery\n$(selector).keypress(eventData, handler) → jQuery\n$(selector).keypress() → jQuery</code></pre></section>	https://api.jquery.com/keypress/
-.keypress event	R	.keypress()										
-.keypress() event	R	.keypress()										
-keypress event	R	.keypress()										
-keypress() event	R	.keypress()										
-.keypress	R	.keypress()										
-keypress()	R	.keypress()										
+keydown event	R	.keydown()										
+keydown()	R	.keydown()										
+keydown() event	R	.keydown()										
 keypress	R	.keypress()										
-.keyup()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).keyup(handler) → jQuery\n$(selector).keyup(eventData, handler) → jQuery\n$(selector).keyup() → jQuery</code></pre></section>	https://api.jquery.com/keyup/
-.keyup event	R	.keyup()										
-.keyup() event	R	.keyup()										
-keyup event	R	.keyup()										
-keyup() event	R	.keyup()										
-.keyup	R	.keyup()										
-keyup()	R	.keyup()										
+keypress event	R	.keypress()										
+keypress()	R	.keypress()										
+keypress() event	R	.keypress()										
 keyup	R	.keyup()										
-:lang() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of the specified language.</p><pre><code>$(":lang(language)") → jQuery</code></pre></section>	https://api.jquery.com/lang-selector/
+keyup event	R	.keyup()										
+keyup()	R	.keyup()										
+keyup() event	R	.keyup()										
 lang selector	R	:lang() Selector										
-.last()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to the final one in the set.</p><pre><code>$(selector).last() → jQuery</code></pre></section>	https://api.jquery.com/last/
-:last-child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the last child of their parent.</p><pre><code>$(":last-child") → jQuery</code></pre></section>	https://api.jquery.com/last-child-selector/
-last child selector	R	:last-child Selector										
-:last-of-type Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the last among siblings of the same element name.</p><pre><code>$(":last-of-type") → jQuery</code></pre></section>	https://api.jquery.com/last-of-type-selector/
-last of type selector	R	:last-of-type Selector										
-.last	R	.last()										
-last()	R	.last()										
 last	R	.last()										
-:last Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the last matched element.</p><pre><code>$(":last") → jQuery</code></pre></section>	https://api.jquery.com/last-selector/
+last child selector	R	:last-child Selector										
+last of type selector	R	:last-of-type Selector										
 last selector	R	:last Selector										
-.length	A			jQuery properties							<section class="prog__container"><p>The number of elements in the jQuery object.</p><pre><code>$(selector).length → Integer</code></pre></section>	https://api.jquery.com/length/
+last()	R	.last()										
 length	R	.length										
-.live()	A			jQuery methods							<section class="prog__container"><p>Attach an event handler for all elements which match the current selector, now and in the future.</p><pre><code>$(selector).live(events, handler) → jQuery\n$(selector).live(events, data, handler) → jQuery\n$(selector).live(events) → jQuery</code></pre></section>	https://api.jquery.com/live/
-.live event	R	.live()										
-.live() event	R	.live()										
-live event	R	.live()										
-live() event	R	.live()										
-.live	R	.live()										
-live()	R	.live()										
 live	R	.live()										
-.load()	A			jQuery methods							<section class="prog__container"><p>Load data from the server and place the returned HTML into the matched element.</p><pre><code>$(selector).load(url, data, complete) → jQuery</code></pre></section>	https://api.jquery.com/load/
-.load event	R	.load()										
-.load() event	R	.load()										
-load event	R	.load()										
-load() event	R	.load()										
-.load	R	.load()										
-load()	R	.load()										
+live event	R	.live()										
+live()	R	.live()										
+live() event	R	.live()										
 load	R	.load()										
-.locked()	R	callbacks.locked()										
-.locked	R	callbacks.locked()										
-locked()	R	callbacks.locked()										
-locked	R	callbacks.locked()										
-.lock()	R	callbacks.lock()										
-.lock	R	callbacks.lock()										
-lock()	R	callbacks.lock()										
+load event	R	.load()										
+load()	R	.load()										
+load() event	R	.load()										
 lock	R	callbacks.lock()										
-:lt() Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements at an index less than index within the matched set.</p><pre><code>$(":lt(index)") → jQuery\n$(":lt(-index)") → jQuery</code></pre></section>	https://api.jquery.com/lt-selector/
+lock()	R	callbacks.lock()										
+locked	R	callbacks.locked()										
+locked()	R	callbacks.locked()										
 lt selector	R	:lt() Selector										
 make array	R	jQuery.makeArray()										
-makearray	R	jQuery.makeArray()										
-.makeArray()	R	jQuery.makeArray()										
-.makeArray	R	jQuery.makeArray()										
-$.makeArray()	R	jQuery.makeArray()										
-$.makeArray	R	jQuery.makeArray()										
-makeArray()	R	jQuery.makeArray()										
 makeArray	R	jQuery.makeArray()										
-.map()	A			jQuery methods							<section class="prog__container"><p>Pass each element in the current matched set through a function, producing a new jQuery object containing the return values.</p><pre><code>$(selector).map(callback) → jQuery</code></pre></section>	https://api.jquery.com/map/
-$.map()	R	jQuery.map()										
-$.map	R	jQuery.map()										
-.map	R	.map()										
-map()	R	.map()										
+makeArray()	R	jQuery.makeArray()										
+makearray	R	jQuery.makeArray()										
 map	R	.map()										
-.merge()	R	jQuery.merge()										
-.merge	R	jQuery.merge()										
-$.merge()	R	jQuery.merge()										
-$.merge	R	jQuery.merge()										
-merge()	R	jQuery.merge()										
+map()	R	.map()										
 merge	R	jQuery.merge()										
+merge()	R	jQuery.merge()										
 meta key	R	event.metaKey										
-metakey	R	event.metaKey										
-.metaKey	R	event.metaKey										
 metaKey	R	event.metaKey										
-.mousedown()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mousedown(handler) → jQuery\n$(selector).mousedown(eventData, handler) → jQuery\n$(selector).mousedown() → jQuery</code></pre></section>	https://api.jquery.com/mousedown/
-.mousedown event	R	.mousedown()										
-.mousedown() event	R	.mousedown()										
-mouse down event	R	.mousedown()										
-mousedown event	R	.mousedown()										
-mousedown() event	R	.mousedown()										
-.mousedown	R	.mousedown()										
+metakey	R	event.metaKey										
 mouse down	R	.mousedown()										
-mousedown()	R	.mousedown()										
-mousedown	R	.mousedown()										
-.mouseenter()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.</p><pre><code>$(selector).mouseenter(handler) → jQuery\n$(selector).mouseenter(eventData, handler) → jQuery\n$(selector).mouseenter() → jQuery</code></pre></section>	https://api.jquery.com/mouseenter/
-.mouseenter event	R	.mouseenter()										
-.mouseenter() event	R	.mouseenter()										
-mouse enter event	R	.mouseenter()										
-mouseenter event	R	.mouseenter()										
-mouseenter() event	R	.mouseenter()										
-.mouseenter	R	.mouseenter()										
+mouse down event	R	.mousedown()										
 mouse enter	R	.mouseenter()										
-mouseenter()	R	.mouseenter()										
-mouseenter	R	.mouseenter()										
-.mouseleave()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.</p><pre><code>$(selector).mouseleave(handler) → jQuery\n$(selector).mouseleave(eventData, handler) → jQuery\n$(selector).mouseleave() → jQuery</code></pre></section>	https://api.jquery.com/mouseleave/
-.mouseleave event	R	.mouseleave()										
-.mouseleave() event	R	.mouseleave()										
-mouse leave event	R	.mouseleave()										
-mouseleave event	R	.mouseleave()										
-mouseleave() event	R	.mouseleave()										
-.mouseleave	R	.mouseleave()										
+mouse enter event	R	.mouseenter()										
 mouse leave	R	.mouseleave()										
-mouseleave()	R	.mouseleave()										
-mouseleave	R	.mouseleave()										
-.mousemove()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mousemove(handler) → jQuery\n$(selector).mousemove(eventData, handler) → jQuery\n$(selector).mousemove() → jQuery</code></pre></section>	https://api.jquery.com/mousemove/
-.mousemove event	R	.mousemove()										
-.mousemove() event	R	.mousemove()										
-mouse move event	R	.mousemove()										
-mousemove event	R	.mousemove()										
-mousemove() event	R	.mousemove()										
-.mousemove	R	.mousemove()										
+mouse leave event	R	.mouseleave()										
 mouse move	R	.mousemove()										
-mousemove()	R	.mousemove()										
-mousemove	R	.mousemove()										
-.mouseout()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mouseout(handler) → jQuery\n$(selector).mouseout(eventData, handler) → jQuery\n$(selector).mouseout() → jQuery</code></pre></section>	https://api.jquery.com/mouseout/
-.mouseout event	R	.mouseout()										
-.mouseout() event	R	.mouseout()										
-mouse out event	R	.mouseout()										
-mouseout event	R	.mouseout()										
-mouseout() event	R	.mouseout()										
-.mouseout	R	.mouseout()										
+mouse move event	R	.mousemove()										
 mouse out	R	.mouseout()										
-mouseout()	R	.mouseout()										
-mouseout	R	.mouseout()										
-.mouseover()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mouseover(handler) → jQuery\n$(selector).mouseover(eventData, handler) → jQuery\n$(selector).mouseover() → jQuery</code></pre></section>	https://api.jquery.com/mouseover/
-.mouseover event	R	.mouseover()										
-.mouseover() event	R	.mouseover()										
-mouse over event	R	.mouseover()										
-mouseover event	R	.mouseover()										
-mouseover() event	R	.mouseover()										
-.mouseover	R	.mouseover()										
+mouse out event	R	.mouseout()										
 mouse over	R	.mouseover()										
-mouseover()	R	.mouseover()										
-mouseover	R	.mouseover()										
-.mouseup()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).mouseup(handler) → jQuery\n$(selector).mouseup(eventData, handler) → jQuery\n$(selector).mouseup() → jQuery</code></pre></section>	https://api.jquery.com/mouseup/
-.mouseup event	R	.mouseup()										
-.mouseup() event	R	.mouseup()										
-mouse up event	R	.mouseup()										
-mouseup event	R	.mouseup()										
-mouseup() event	R	.mouseup()										
-.mouseup	R	.mouseup()										
+mouse over event	R	.mouseover()										
 mouse up	R	.mouseup()										
-mouseup()	R	.mouseup()										
+mouse up event	R	.mouseup()										
+mousedown	R	.mousedown()										
+mousedown event	R	.mousedown()										
+mousedown()	R	.mousedown()										
+mousedown() event	R	.mousedown()										
+mouseenter	R	.mouseenter()										
+mouseenter event	R	.mouseenter()										
+mouseenter()	R	.mouseenter()										
+mouseenter() event	R	.mouseenter()										
+mouseleave	R	.mouseleave()										
+mouseleave event	R	.mouseleave()										
+mouseleave()	R	.mouseleave()										
+mouseleave() event	R	.mouseleave()										
+mousemove	R	.mousemove()										
+mousemove event	R	.mousemove()										
+mousemove()	R	.mousemove()										
+mousemove() event	R	.mousemove()										
+mouseout	R	.mouseout()										
+mouseout event	R	.mouseout()										
+mouseout()	R	.mouseout()										
+mouseout() event	R	.mouseout()										
+mouseover	R	.mouseover()										
+mouseover event	R	.mouseover()										
+mouseover()	R	.mouseover()										
+mouseover() event	R	.mouseover()										
 mouseup	R	.mouseup()										
-Multiple Attribute Selector	A			jQuery selectors							<section class="prog__container"><p>Matches elements that match all of the specified attribute filters.</p><pre><code>$("[attributeFilter1][attributeFilter2][attributeFilterN]") → jQuery</code></pre></section>	https://api.jquery.com/multiple-attribute-selector/
+mouseup event	R	.mouseup()										
+mouseup()	R	.mouseup()										
+mouseup() event	R	.mouseup()										
 multiple attribute selector	R	Multiple Attribute Selector										
-Multiple Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the combined results of all the specified selectors.</p><pre><code>$("selector1, selector2, selectorN") → jQuery</code></pre></section>	https://api.jquery.com/multiple-selector/
 multiple selector	R	Multiple Selector										
-.namespace	R	event.namespace										
 namespace	R	event.namespace										
-Next Adjacent Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all next elements matching "next" that are immediately preceded by a sibling "prev".</p><pre><code>$("prev + next") → jQuery</code></pre></section>	https://api.jquery.com/next-adjacent-selector/
-next adjacent selector	R	Next Adjacent Selector										
-.next()	A			jQuery methods							<section class="prog__container"><p>Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.</p><pre><code>$(selector).next(selector) → jQuery</code></pre></section>	https://api.jquery.com/next/
-.nextAll()	A			jQuery methods							<section class="prog__container"><p>Get all following siblings of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).nextAll(selector) → jQuery</code></pre></section>	https://api.jquery.com/nextAll/
-next all	R	.nextAll()										
-nextall	R	.nextAll()										
-.nextAll	R	.nextAll()										
-nextAll()	R	.nextAll()										
-nextAll	R	.nextAll()										
-.next	R	.next()										
-next()	R	.next()										
 next	R	.next()										
-Next Siblings Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all sibling elements that follow after the "prev" element, have the same parent, and match the filtering "siblings" selector.</p><pre><code>$("prev ~ siblings") → jQuery</code></pre></section>	https://api.jquery.com/next-siblings-selector/
+next adjacent selector	R	Next Adjacent Selector										
+next all	R	.nextAll()										
 next siblings selector	R	Next Siblings Selector										
-.nextUntil()	A			jQuery methods							<section class="prog__container"><p>Get all following siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object passed.</p><pre><code>$(selector).nextUntil(selector, filter) → jQuery\n$(selector).nextUntil(element, filter) → jQuery</code></pre></section>	https://api.jquery.com/nextUntil/
 next until	R	.nextUntil()										
-nextuntil	R	.nextUntil()										
-.nextUntil	R	.nextUntil()										
-nextUntil()	R	.nextUntil()										
+next()	R	.next()										
+nextAll	R	.nextAll()										
+nextAll()	R	.nextAll()										
 nextUntil	R	.nextUntil()										
+nextUntil()	R	.nextUntil()										
+nextall	R	.nextAll()										
+nextuntil	R	.nextUntil()										
 no conflict	R	jQuery.noConflict()										
-noconflict	R	jQuery.noConflict()										
-.noConflict()	R	jQuery.noConflict()										
-.noConflict	R	jQuery.noConflict()										
-$.noConflict()	R	jQuery.noConflict()										
-$.noConflict	R	jQuery.noConflict()										
-noConflict()	R	jQuery.noConflict()										
 noConflict	R	jQuery.noConflict()										
-.noop()	R	jQuery.noop()										
-.noop	R	jQuery.noop()										
-$.noop()	R	jQuery.noop()										
-$.noop	R	jQuery.noop()										
-noop()	R	jQuery.noop()										
+noConflict()	R	jQuery.noConflict()										
+noconflict	R	jQuery.noConflict()										
 noop	R	jQuery.noop()										
-.not()	A			jQuery methods							<section class="prog__container"><p>Remove elements from the set of matched elements.</p><pre><code>$(selector).not(selector) → jQuery\n$(selector).not(function) → jQuery\n$(selector).not(selection) → jQuery</code></pre></section>	https://api.jquery.com/not/
-.notify()	R	deferred.notify()										
-.notify	R	deferred.notify()										
-notify()	R	deferred.notify()										
+noop()	R	jQuery.noop()										
+not	R	.not()										
+not selector	R	:not() Selector										
+not()	R	.not()										
 notify	R	deferred.notify()										
 notify with	R	deferred.notifyWith()										
-notifywith	R	deferred.notifyWith()										
-.notifyWith()	R	deferred.notifyWith()										
-.notifyWith	R	deferred.notifyWith()										
-notifyWith()	R	deferred.notifyWith()										
+notify()	R	deferred.notify()										
 notifyWith	R	deferred.notifyWith()										
-.not	R	.not()										
-not()	R	.not()										
-not	R	.not()										
-:not() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that do not match the given selector.</p><pre><code>$(":not(selector)") → jQuery</code></pre></section>	https://api.jquery.com/not-selector/
-not selector	R	:not() Selector										
-.now()	R	jQuery.now()										
-.now	R	jQuery.now()										
-$.now()	R	jQuery.now()										
-$.now	R	jQuery.now()										
-now()	R	jQuery.now()										
+notifyWith()	R	deferred.notifyWith()										
+notifywith	R	deferred.notifyWith()										
 now	R	jQuery.now()										
-:nth-child() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the nth-child of their parent.</p><pre><code>$(":nth-child(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-child-selector/
+now()	R	jQuery.now()										
 nth child selector	R	:nth-child() Selector										
-:nth-last-child() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the nth-child of their parent, counting from the last element to the first.</p><pre><code>$(":nth-last-child(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-last-child-selector/
 nth last child selector	R	:nth-last-child() Selector										
-:nth-last-of-type() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all the elements that are the nth-child of their parent in relation to siblings with the same element name, counting from the last element to the first.</p><pre><code>$(":nth-last-of-type(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-last-of-type-selector/
 nth last of type selector	R	:nth-last-of-type() Selector										
-:nth-of-type() Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the nth child of their parent in relation to siblings with the same element name.</p><pre><code>$(":nth-of-type(index/even/odd/equation)") → jQuery</code></pre></section>	https://api.jquery.com/nth-of-type-selector/
 nth of type selector	R	:nth-of-type() Selector										
-:odd Selector	A			jQuery selectors							<section class="prog__container"><p>Selects odd elements, zero-indexed.  See also even.</p><pre><code>$(":odd") → jQuery</code></pre></section>	https://api.jquery.com/odd-selector/
 odd selector	R	:odd Selector										
-.off()	A			jQuery methods							<section class="prog__container"><p>Remove an event handler.</p><pre><code>$(selector).off(events, selector, handler) → jQuery\n$(selector).off(events, selector) → jQuery\n$(selector).off(event) → jQuery\n$(selector).off() → jQuery</code></pre></section>	https://api.jquery.com/off/
-.off event	R	.off()										
-.off() event	R	.off()										
-off event	R	.off()										
-off() event	R	.off()										
-.off	R	.off()										
-off()	R	.off()										
 off	R	.off()										
-.offset()	A			jQuery methods							<section class="prog__container"><p>Get the current coordinates of the first element in the set of matched elements, relative to the document.</p><pre><code>$(selector).offset() → Object</code></pre>\n<p>Set the current coordinates of every element in the set of matched elements, relative to the document.</p><pre><code>$(selector).offset(coordinates) → jQuery\n$(selector).offset(function) → jQuery</code></pre></section>	https://api.jquery.com/offset/
-.offsetParent()	A			jQuery methods							<section class="prog__container"><p>Get the closest ancestor element that is positioned.</p><pre><code>$(selector).offsetParent() → jQuery</code></pre></section>	https://api.jquery.com/offsetParent/
-offset parent	R	.offsetParent()										
-offsetparent	R	.offsetParent()										
-.offsetParent	R	.offsetParent()										
-offsetParent()	R	.offsetParent()										
-offsetParent	R	.offsetParent()										
-.offset	R	.offset()										
-offset()	R	.offset()										
+off event	R	.off()										
+off()	R	.off()										
+off() event	R	.off()										
 offset	R	.offset()										
-.on()	A			jQuery methods							<section class="prog__container"><p>Attach an event handler function for one or more events to the selected elements.</p><pre><code>$(selector).on(events, selector, data, handler) → jQuery\n$(selector).on(events, selector, data) → jQuery</code></pre></section>	https://api.jquery.com/on/
-on .bind()	R	.bind()										
-on .bind	R	.bind()										
-on bind()	R	.bind()										
-on bind	R	.bind()										
-on .blur()	R	.blur()										
-on .blur	R	.blur()										
-on blur()	R	.blur()										
-on blur	R	.blur()										
-on .change()	R	.change()										
-on .change	R	.change()										
-on change()	R	.change()										
-on change	R	.change()										
-on .click()	R	.click()										
-on .click	R	.click()										
-on click()	R	.click()										
-on click	R	.click()										
-on .contextmenu()	R	.contextmenu()										
-on .contextmenu	R	.contextmenu()										
-on contextmenu()	R	.contextmenu()										
-on contextmenu	R	.contextmenu()										
-on .dblclick()	R	.dblclick()										
-on .dblclick	R	.dblclick()										
-on dblclick()	R	.dblclick()										
-on dblclick	R	.dblclick()										
-on .delegate()	R	.delegate()										
-on .delegate	R	.delegate()										
-on delegate()	R	.delegate()										
-on delegate	R	.delegate()										
-on .die()	R	.die()										
-on .die	R	.die()										
-on die()	R	.die()										
-on die	R	.die()										
-.one()	A			jQuery methods							<section class="prog__container"><p>Attach a handler to an event for the elements. The handler is executed at most once per element per event type.</p><pre><code>$(selector).one(events, data, handler) → jQuery\n$(selector).one(events, selector, data, handler) → jQuery\n$(selector).one(events, selector, data) → jQuery</code></pre></section>	https://api.jquery.com/one/
-.one event	R	.one()										
-.one() event	R	.one()										
-one event	R	.one()										
-one() event	R	.one()										
-.one	R	.one()										
-one()	R	.one()										
-one	R	.one()										
-on .error()	R	.error()										
-on .error	R	.error()										
-on error()	R	.error()										
-on error	R	.error()										
-.on event	R	.on()										
-.on() event	R	.on()										
-on event	R	.on()										
-on() event	R	.on()										
-on .focusin()	R	.focusin()										
-on .focusin	R	.focusin()										
-on focusin()	R	.focusin()										
-on focusin	R	.focusin()										
-on .focusout()	R	.focusout()										
-on .focusout	R	.focusout()										
-on focusout()	R	.focusout()										
-on focusout	R	.focusout()										
-on .focus()	R	.focus()										
-on .focus	R	.focus()										
-on focus()	R	.focus()										
-on focus	R	.focus()										
-on .hover()	R	.hover()										
-on .hover	R	.hover()										
-on hover()	R	.hover()										
-on hover	R	.hover()										
-on .keydown()	R	.keydown()										
-on .keydown	R	.keydown()										
-on keydown()	R	.keydown()										
-on keydown	R	.keydown()										
-on .keypress()	R	.keypress()										
-on .keypress	R	.keypress()										
-on keypress()	R	.keypress()										
-on keypress	R	.keypress()										
-on .keyup()	R	.keyup()										
-on .keyup	R	.keyup()										
-on keyup()	R	.keyup()										
-on keyup	R	.keyup()										
-on .live()	R	.live()										
-on .live	R	.live()										
-on live()	R	.live()										
-on live	R	.live()										
-on .load()	R	.load()										
-on .load	R	.load()										
-on load()	R	.load()										
-on load	R	.load()										
-:only-child Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are the only child of their parent.</p><pre><code>$(":only-child") → jQuery</code></pre></section>	https://api.jquery.com/only-child-selector/
-only child selector	R	:only-child Selector										
-:only-of-type Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that have no siblings with the same element name.</p><pre><code>$(":only-of-type") → jQuery</code></pre></section>	https://api.jquery.com/only-of-type-selector/
-only of type selector	R	:only-of-type Selector										
-on .mousedown()	R	.mousedown()										
-on .mousedown	R	.mousedown()										
-on mouse down	R	.mousedown()										
-on mousedown()	R	.mousedown()										
-on mousedown	R	.mousedown()										
-on .mouseenter()	R	.mouseenter()										
-on .mouseenter	R	.mouseenter()										
-on mouse enter	R	.mouseenter()										
-on mouseenter()	R	.mouseenter()										
-on mouseenter	R	.mouseenter()										
-on .mouseleave()	R	.mouseleave()										
-on .mouseleave	R	.mouseleave()										
-on mouse leave	R	.mouseleave()										
-on mouseleave()	R	.mouseleave()										
-on mouseleave	R	.mouseleave()										
-on .mousemove()	R	.mousemove()										
-on .mousemove	R	.mousemove()										
-on mouse move	R	.mousemove()										
-on mousemove()	R	.mousemove()										
-on mousemove	R	.mousemove()										
-on .mouseout()	R	.mouseout()										
-on .mouseout	R	.mouseout()										
-on mouse out	R	.mouseout()										
-on mouseout()	R	.mouseout()										
-on mouseout	R	.mouseout()										
-on .mouseover()	R	.mouseover()										
-on .mouseover	R	.mouseover()										
-on mouse over	R	.mouseover()										
-on mouseover()	R	.mouseover()										
-on mouseover	R	.mouseover()										
-on .mouseup()	R	.mouseup()										
-on .mouseup	R	.mouseup()										
-on mouse up	R	.mouseup()										
-on mouseup()	R	.mouseup()										
-on mouseup	R	.mouseup()										
-on .off()	R	.off()										
-on .off	R	.off()										
-on off()	R	.off()										
-on off	R	.off()										
-on .one()	R	.one()										
-on .one	R	.one()										
-on one()	R	.one()										
-on one	R	.one()										
-on .on()	R	.on()										
-on .on	R	.on()										
-on on()	R	.on()										
-on on	R	.on()										
-on .ready()	R	.ready()										
-on .ready	R	.ready()										
-on ready()	R	.ready()										
-on ready	R	.ready()										
-on .resize()	R	.resize()										
-on .resize	R	.resize()										
-on resize()	R	.resize()										
-on resize	R	.resize()										
-.on	R	.on()										
-on()	R	.on()										
+offset parent	R	.offsetParent()										
+offset()	R	.offset()										
+offsetParent	R	.offsetParent()										
+offsetParent()	R	.offsetParent()										
+offsetparent	R	.offsetParent()										
 on	R	.on()										
-on .scroll()	R	.scroll()										
+on .bind	R	.bind()										
+on .bind()	R	.bind()										
+on .blur	R	.blur()										
+on .blur()	R	.blur()										
+on .change	R	.change()										
+on .change()	R	.change()										
+on .click	R	.click()										
+on .click()	R	.click()										
+on .contextmenu	R	.contextmenu()										
+on .contextmenu()	R	.contextmenu()										
+on .dblclick	R	.dblclick()										
+on .dblclick()	R	.dblclick()										
+on .delegate	R	.delegate()										
+on .delegate()	R	.delegate()										
+on .die	R	.die()										
+on .die()	R	.die()										
+on .error	R	.error()										
+on .error()	R	.error()										
+on .focus	R	.focus()										
+on .focus()	R	.focus()										
+on .focusin	R	.focusin()										
+on .focusin()	R	.focusin()										
+on .focusout	R	.focusout()										
+on .focusout()	R	.focusout()										
+on .hover	R	.hover()										
+on .hover()	R	.hover()										
+on .keydown	R	.keydown()										
+on .keydown()	R	.keydown()										
+on .keypress	R	.keypress()										
+on .keypress()	R	.keypress()										
+on .keyup	R	.keyup()										
+on .keyup()	R	.keyup()										
+on .live	R	.live()										
+on .live()	R	.live()										
+on .load	R	.load()										
+on .load()	R	.load()										
+on .mousedown	R	.mousedown()										
+on .mousedown()	R	.mousedown()										
+on .mouseenter	R	.mouseenter()										
+on .mouseenter()	R	.mouseenter()										
+on .mouseleave	R	.mouseleave()										
+on .mouseleave()	R	.mouseleave()										
+on .mousemove	R	.mousemove()										
+on .mousemove()	R	.mousemove()										
+on .mouseout	R	.mouseout()										
+on .mouseout()	R	.mouseout()										
+on .mouseover	R	.mouseover()										
+on .mouseover()	R	.mouseover()										
+on .mouseup	R	.mouseup()										
+on .mouseup()	R	.mouseup()										
+on .off	R	.off()										
+on .off()	R	.off()										
+on .on	R	.on()										
+on .on()	R	.on()										
+on .one	R	.one()										
+on .one()	R	.one()										
+on .ready	R	.ready()										
+on .ready()	R	.ready()										
+on .resize	R	.resize()										
+on .resize()	R	.resize()										
 on .scroll	R	.scroll()										
-on scroll()	R	.scroll()										
-on scroll	R	.scroll()										
-on .select()	R	.select()										
+on .scroll()	R	.scroll()										
 on .select	R	.select()										
-on select()	R	.select()										
-on select	R	.select()										
-on .submit()	R	.submit()										
+on .select()	R	.select()										
 on .submit	R	.submit()										
-on submit()	R	.submit()										
-on submit	R	.submit()										
-on .toggle()	R	.toggle()										
+on .submit()	R	.submit()										
 on .toggle	R	.toggle()										
-on toggle()	R	.toggle()										
-on toggle	R	.toggle()										
-on trigger handler	R	.triggerHandler()										
-on triggerhandler	R	.triggerHandler()										
-on .triggerHandler()	R	.triggerHandler()										
-on .triggerHandler	R	.triggerHandler()										
-on triggerHandler()	R	.triggerHandler()										
-on triggerHandler	R	.triggerHandler()										
-on .trigger()	R	.trigger()										
+on .toggle()	R	.toggle()										
 on .trigger	R	.trigger()										
-on trigger()	R	.trigger()										
-on trigger	R	.trigger()										
-on .unbind()	R	.unbind()										
+on .trigger()	R	.trigger()										
+on .triggerHandler	R	.triggerHandler()										
+on .triggerHandler()	R	.triggerHandler()										
 on .unbind	R	.unbind()										
-on unbind()	R	.unbind()										
-on unbind	R	.unbind()										
-on .undelegate()	R	.undelegate()										
+on .unbind()	R	.unbind()										
 on .undelegate	R	.undelegate()										
-on undelegate()	R	.undelegate()										
-on undelegate	R	.undelegate()										
-on .unload()	R	.unload()										
+on .undelegate()	R	.undelegate()										
 on .unload	R	.unload()										
-on unload()	R	.unload()										
+on .unload()	R	.unload()										
+on bind	R	.bind()										
+on bind()	R	.bind()										
+on blur	R	.blur()										
+on blur()	R	.blur()										
+on change	R	.change()										
+on change()	R	.change()										
+on click	R	.click()										
+on click()	R	.click()										
+on contextmenu	R	.contextmenu()										
+on contextmenu()	R	.contextmenu()										
+on dblclick	R	.dblclick()										
+on dblclick()	R	.dblclick()										
+on delegate	R	.delegate()										
+on delegate()	R	.delegate()										
+on die	R	.die()										
+on die()	R	.die()										
+on error	R	.error()										
+on error()	R	.error()										
+on event	R	.on()										
+on focus	R	.focus()										
+on focus()	R	.focus()										
+on focusin	R	.focusin()										
+on focusin()	R	.focusin()										
+on focusout	R	.focusout()										
+on focusout()	R	.focusout()										
+on hover	R	.hover()										
+on hover()	R	.hover()										
+on keydown	R	.keydown()										
+on keydown()	R	.keydown()										
+on keypress	R	.keypress()										
+on keypress()	R	.keypress()										
+on keyup	R	.keyup()										
+on keyup()	R	.keyup()										
+on live	R	.live()										
+on live()	R	.live()										
+on load	R	.load()										
+on load()	R	.load()										
+on mouse down	R	.mousedown()										
+on mouse enter	R	.mouseenter()										
+on mouse leave	R	.mouseleave()										
+on mouse move	R	.mousemove()										
+on mouse out	R	.mouseout()										
+on mouse over	R	.mouseover()										
+on mouse up	R	.mouseup()										
+on mousedown	R	.mousedown()										
+on mousedown()	R	.mousedown()										
+on mouseenter	R	.mouseenter()										
+on mouseenter()	R	.mouseenter()										
+on mouseleave	R	.mouseleave()										
+on mouseleave()	R	.mouseleave()										
+on mousemove	R	.mousemove()										
+on mousemove()	R	.mousemove()										
+on mouseout	R	.mouseout()										
+on mouseout()	R	.mouseout()										
+on mouseover	R	.mouseover()										
+on mouseover()	R	.mouseover()										
+on mouseup	R	.mouseup()										
+on mouseup()	R	.mouseup()										
+on off	R	.off()										
+on off()	R	.off()										
+on on	R	.on()										
+on on()	R	.on()										
+on one	R	.one()										
+on one()	R	.one()										
+on ready	R	.ready()										
+on ready()	R	.ready()										
+on resize	R	.resize()										
+on resize()	R	.resize()										
+on scroll	R	.scroll()										
+on scroll()	R	.scroll()										
+on select	R	.select()										
+on select()	R	.select()										
+on submit	R	.submit()										
+on submit()	R	.submit()										
+on toggle	R	.toggle()										
+on toggle()	R	.toggle()										
+on trigger	R	.trigger()										
+on trigger handler	R	.triggerHandler()										
+on trigger()	R	.trigger()										
+on triggerHandler	R	.triggerHandler()										
+on triggerHandler()	R	.triggerHandler()										
+on triggerhandler	R	.triggerHandler()										
+on unbind	R	.unbind()										
+on unbind()	R	.unbind()										
+on undelegate	R	.undelegate()										
+on undelegate()	R	.undelegate()										
 on unload	R	.unload()										
-.outerHeight()	A			jQuery methods							<section class="prog__container"><p>Get the current computed outer height (including padding, border, and optionally margin) for the first element in the set of matched elements.</p><pre><code>$(selector).outerHeight(includeMargin) → Number</code></pre>\n<p>Set the CSS outer height of each element in the set of matched elements.</p><pre><code>$(selector).outerHeight(value) → jQuery\n$(selector).outerHeight(function(index, height)) → jQuery</code></pre></section>	https://api.jquery.com/outerHeight/
+on unload()	R	.unload()										
+on()	R	.on()										
+on() event	R	.on()										
+one	R	.one()										
+one event	R	.one()										
+one()	R	.one()										
+one() event	R	.one()										
+only child selector	R	:only-child Selector										
+only of type selector	R	:only-of-type Selector										
 outer height	R	.outerHeight()										
-outerheight	R	.outerHeight()										
-.outerHeight	R	.outerHeight()										
-outerHeight()	R	.outerHeight()										
-outerHeight	R	.outerHeight()										
-.outerWidth()	A			jQuery methods							<section class="prog__container"><p>Get the current computed outer width (including padding, border, and optionally margin) for the first element in the set of matched elements.</p><pre><code>$(selector).outerWidth(includeMargin) → Number</code></pre>\n<p>Set the CSS outer width of each element in the set of matched elements.</p><pre><code>$(selector).outerWidth(value) → jQuery\n$(selector).outerWidth(function(index, width)) → jQuery</code></pre></section>	https://api.jquery.com/outerWidth/
 outer width	R	.outerWidth()										
-outerwidth	R	.outerWidth()										
-.outerWidth	R	.outerWidth()										
-outerWidth()	R	.outerWidth()										
+outerHeight	R	.outerHeight()										
+outerHeight()	R	.outerHeight()										
 outerWidth	R	.outerWidth()										
+outerWidth()	R	.outerWidth()										
+outerheight	R	.outerHeight()										
+outerwidth	R	.outerWidth()										
 page x	R	event.pageX										
-pagex	R	event.pageX										
-.pageX	R	event.pageX										
-pageX	R	event.pageX										
 page y	R	event.pageY										
-pagey	R	event.pageY										
-.pageY	R	event.pageY										
+pageX	R	event.pageX										
 pageY	R	event.pageY										
-.param()	R	jQuery.param()										
-.param	R	jQuery.param()										
-$.param()	R	jQuery.param()										
-$.param	R	jQuery.param()										
-param()	R	jQuery.param()										
+pagex	R	event.pageX										
+pagey	R	event.pageY										
 param	R	jQuery.param()										
-.parent()	A			jQuery methods							<section class="prog__container"><p>Get the parent of each element in the current set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).parent(selector) → jQuery</code></pre></section>	https://api.jquery.com/parent/
-.parent	R	.parent()										
-parent()	R	.parent()										
+param()	R	jQuery.param()										
 parent	R	.parent()										
-.parents()	A			jQuery methods							<section class="prog__container"><p>Get the ancestors of each element in the current set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).parents(selector) → jQuery</code></pre></section>	https://api.jquery.com/parents/
-:parent Selector	A			jQuery selectors							<section class="prog__container"><p>Select all elements that have at least one child node (either an element or text).</p><pre><code>$(":parent") → jQuery</code></pre></section>	https://api.jquery.com/parent-selector/
 parent selector	R	:parent Selector										
-.parents	R	.parents()										
-parents()	R	.parents()										
+parent()	R	.parent()										
 parents	R	.parents()										
-.parentsUntil()	A			jQuery methods							<section class="prog__container"><p>Get the ancestors of each element in the current set of matched elements, up to but not including the element matched by the selector, DOM node, or jQuery object.</p><pre><code>$(selector).parentsUntil(selector, filter) → jQuery\n$(selector).parentsUntil(element, filter) → jQuery</code></pre></section>	https://api.jquery.com/parentsUntil/
 parents until	R	.parentsUntil()										
-parentsuntil	R	.parentsUntil()										
-.parentsUntil	R	.parentsUntil()										
-parentsUntil()	R	.parentsUntil()										
+parents()	R	.parents()										
 parentsUntil	R	.parentsUntil()										
+parentsUntil()	R	.parentsUntil()										
+parentsuntil	R	.parentsUntil()										
 parse html	R	jQuery.parseHTML()										
-parsehtml	R	jQuery.parseHTML()										
-.parseHTML()	R	jQuery.parseHTML()										
-.parseHTML	R	jQuery.parseHTML()										
-$.parseHTML()	R	jQuery.parseHTML()										
-$.parseHTML	R	jQuery.parseHTML()										
-parseHTML()	R	jQuery.parseHTML()										
-parseHTML	R	jQuery.parseHTML()										
 parse json	R	jQuery.parseJSON()										
-parsejson	R	jQuery.parseJSON()										
-.parseJSON()	R	jQuery.parseJSON()										
-.parseJSON	R	jQuery.parseJSON()										
-$.parseJSON()	R	jQuery.parseJSON()										
-$.parseJSON	R	jQuery.parseJSON()										
-parseJSON()	R	jQuery.parseJSON()										
-parseJSON	R	jQuery.parseJSON()										
 parse xml	R	jQuery.parseXML()										
-parsexml	R	jQuery.parseXML()										
-.parseXML()	R	jQuery.parseXML()										
-.parseXML	R	jQuery.parseXML()										
-$.parseXML()	R	jQuery.parseXML()										
-$.parseXML	R	jQuery.parseXML()										
-parseXML()	R	jQuery.parseXML()										
+parseHTML	R	jQuery.parseHTML()										
+parseHTML()	R	jQuery.parseHTML()										
+parseJSON	R	jQuery.parseJSON()										
+parseJSON()	R	jQuery.parseJSON()										
 parseXML	R	jQuery.parseXML()										
-:password Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type password.</p><pre><code>$(":password") → jQuery</code></pre></section>	https://api.jquery.com/password-selector/
+parseXML()	R	jQuery.parseXML()										
+parsehtml	R	jQuery.parseHTML()										
+parsejson	R	jQuery.parseJSON()										
+parsexml	R	jQuery.parseXML()										
 password selector	R	:password Selector										
-.pipe()	R	deferred.pipe()										
-.pipe	R	deferred.pipe()										
-pipe()	R	deferred.pipe()										
 pipe	R	deferred.pipe()										
-.position()	A			jQuery methods							<section class="prog__container"><p>Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.</p><pre><code>$(selector).position() → Object</code></pre></section>	https://api.jquery.com/position/
-.position	R	.position()										
-position()	R	.position()										
+pipe()	R	deferred.pipe()										
 position	R	.position()										
-.post()	R	jQuery.post()										
-.post	R	jQuery.post()										
-$.post()	R	jQuery.post()										
-$.post	R	jQuery.post()										
-post()	R	jQuery.post()										
+position()	R	.position()										
 post	R	jQuery.post()										
-.prepend()	A			jQuery methods							<section class="prog__container"><p>Insert content, specified by the parameter, to the beginning of each element in the set of matched elements.</p><pre><code>$(selector).prepend(content, content) → jQuery\n$(selector).prepend(function) → jQuery</code></pre></section>	https://api.jquery.com/prepend/
-.prepend	R	.prepend()										
-prepend()	R	.prepend()										
+post()	R	jQuery.post()										
 prepend	R	.prepend()										
-.prependTo()	A			jQuery methods							<section class="prog__container"><p>Insert every element in the set of matched elements to the beginning of the target.</p><pre><code>$(selector).prependTo(target) → jQuery</code></pre></section>	https://api.jquery.com/prependTo/
 prepend to	R	.prependTo()										
-prependto	R	.prependTo()										
-.prependTo	R	.prependTo()										
-prependTo()	R	.prependTo()										
+prepend()	R	.prepend()										
 prependTo	R	.prependTo()										
-.prev()	A			jQuery methods							<section class="prog__container"><p>Get the immediately preceding sibling of each element in the set of matched elements. If a selector is provided, it retrieves the previous sibling only if it matches that selector.</p><pre><code>$(selector).prev(selector) → jQuery</code></pre></section>	https://api.jquery.com/prev/
-.prevAll()	A			jQuery methods							<section class="prog__container"><p>Get all preceding siblings of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).prevAll(selector) → jQuery</code></pre></section>	https://api.jquery.com/prevAll/
-prev all	R	.prevAll()										
-prevall	R	.prevAll()										
-.prevAll	R	.prevAll()										
-prevAll()	R	.prevAll()										
-prevAll	R	.prevAll()										
-prevent default	R	event.preventDefault()										
-preventdefault	R	event.preventDefault()										
-.preventDefault()	R	event.preventDefault()										
-.preventDefault	R	event.preventDefault()										
-preventDefault()	R	event.preventDefault()										
-preventDefault	R	event.preventDefault()										
-.prev	R	.prev()										
-prev()	R	.prev()										
+prependTo()	R	.prependTo()										
+prependto	R	.prependTo()										
 prev	R	.prev()										
-.prevUntil()	A			jQuery methods							<section class="prog__container"><p>Get all preceding siblings of each element up to but not including the element matched by the selector, DOM node, or jQuery object.</p><pre><code>$(selector).prevUntil(selector, filter) → jQuery\n$(selector).prevUntil(element, filter) → jQuery</code></pre></section>	https://api.jquery.com/prevUntil/
+prev all	R	.prevAll()										
 prev until	R	.prevUntil()										
-prevuntil	R	.prevUntil()										
-.prevUntil	R	.prevUntil()										
-prevUntil()	R	.prevUntil()										
+prev()	R	.prev()										
+prevAll	R	.prevAll()										
+prevAll()	R	.prevAll()										
 prevUntil	R	.prevUntil()										
-.progress()	R	deferred.progress()										
-.progress	R	deferred.progress()										
-progress()	R	deferred.progress()										
+prevUntil()	R	.prevUntil()										
+prevall	R	.prevAll()										
+prevent default	R	event.preventDefault()										
+preventDefault	R	event.preventDefault()										
+preventDefault()	R	event.preventDefault()										
+preventdefault	R	event.preventDefault()										
+prevuntil	R	.prevUntil()										
 progress	R	deferred.progress()										
-.promise()	A			jQuery methods							<section class="prog__container"><p> Return a Promise object to observe when all actions of a certain type bound to the collection, queued or not, have finished. </p><pre><code>$(selector).promise(type, target) → Promise</code></pre></section>	https://api.jquery.com/promise/
-.promise	R	.promise()										
-promise()	R	.promise()										
+progress()	R	deferred.progress()										
 promise	R	.promise()										
-.prop()	A			jQuery methods							<section class="prog__container"><p>Get the value of a property for the first element in the set of matched elements.</p><pre><code>$(selector).prop(propertyName) → Anything</code></pre>\n<p>Set one or more properties for the set of matched elements.</p><pre><code>$(selector).prop(propertyName, value) → jQuery\n$(selector).prop(properties) → jQuery\n$(selector).prop(propertyName, function) → jQuery</code></pre></section>	https://api.jquery.com/prop/
-.prop	R	.prop()										
-prop()	R	.prop()										
+promise()	R	.promise()										
 prop	R	.prop()										
-.proxy()	R	jQuery.proxy()										
-.proxy	R	jQuery.proxy()										
-$.proxy()	R	jQuery.proxy()										
-$.proxy	R	jQuery.proxy()										
-proxy()	R	jQuery.proxy()										
+prop()	R	.prop()										
 proxy	R	jQuery.proxy()										
-.pushStack()	A			jQuery methods							<section class="prog__container"><p>Add a collection of DOM elements onto the jQuery stack.</p><pre><code>$(selector).pushStack(elements) → jQuery\n$(selector).pushStack(elements, name, arguments) → jQuery</code></pre></section>	https://api.jquery.com/pushStack/
+proxy()	R	jQuery.proxy()										
 push stack	R	.pushStack()										
-pushstack	R	.pushStack()										
-.pushStack	R	.pushStack()										
-pushStack()	R	.pushStack()										
 pushStack	R	.pushStack()										
-.queue()	A			jQuery methods							<section class="prog__container"><p>Show the queue of functions to be executed on the matched elements.</p><pre><code>$(selector).queue(queueName) → Array</code></pre>\n<p>Manipulate the queue of functions to be executed, once for each matched element.</p><pre><code>$(selector).queue(queueName, newQueue) → jQuery\n$(selector).queue(queueName, callback) → jQuery</code></pre></section>	https://api.jquery.com/queue/
-$.queue()	R	jQuery.queue()										
-$.queue	R	jQuery.queue()										
-.queue	R	.queue()										
-queue()	R	.queue()										
+pushStack()	R	.pushStack()										
+pushstack	R	.pushStack()										
 queue	R	.queue()										
-:radio Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all  elements of type radio.</p><pre><code>$(":radio") → jQuery</code></pre></section>	https://api.jquery.com/radio-selector/
+queue()	R	.queue()										
 radio selector	R	:radio Selector										
-.ready()	A			jQuery methods							<section class="prog__container"><p>Specify a function to execute when the DOM is fully loaded.</p><pre><code>$(selector).ready(handler) → jQuery</code></pre></section>	https://api.jquery.com/ready/
-.ready event	R	.ready()										
-.ready() event	R	.ready()										
-ready event	R	.ready()										
-ready() event	R	.ready()										
-ready exception	R	jQuery.readyException()										
-readyexception	R	jQuery.readyException()										
-.readyException()	R	jQuery.readyException()										
-.readyException	R	jQuery.readyException()										
-$.readyException()	R	jQuery.readyException()										
-$.readyException	R	jQuery.readyException()										
-readyException()	R	jQuery.readyException()										
-readyException	R	jQuery.readyException()										
-.ready	R	.ready()										
-ready()	R	.ready()										
 ready	R	.ready()										
-.reject()	R	deferred.reject()										
-.reject	R	deferred.reject()										
-reject()	R	deferred.reject()										
+ready event	R	.ready()										
+ready exception	R	jQuery.readyException()										
+ready()	R	.ready()										
+ready() event	R	.ready()										
+readyException	R	jQuery.readyException()										
+readyException()	R	jQuery.readyException()										
+readyexception	R	jQuery.readyException()										
 reject	R	deferred.reject()										
 reject with	R	deferred.rejectWith()										
-rejectwith	R	deferred.rejectWith()										
-.rejectWith()	R	deferred.rejectWith()										
-.rejectWith	R	deferred.rejectWith()										
-rejectWith()	R	deferred.rejectWith()										
+reject()	R	deferred.reject()										
 rejectWith	R	deferred.rejectWith()										
+rejectWith()	R	deferred.rejectWith()										
+rejectwith	R	deferred.rejectWith()										
 related target	R	event.relatedTarget										
-relatedtarget	R	event.relatedTarget										
-.relatedTarget	R	event.relatedTarget										
 relatedTarget	R	event.relatedTarget										
-.remove()	A			jQuery methods							<section class="prog__container"><p>Remove the set of matched elements from the DOM.</p><pre><code>$(selector).remove(selector) → jQuery</code></pre></section>	https://api.jquery.com/remove/
-.removeAttr()	A			jQuery methods							<section class="prog__container"><p>Remove an attribute from each element in the set of matched elements.</p><pre><code>$(selector).removeAttr(attributeName) → jQuery</code></pre></section>	https://api.jquery.com/removeAttr/
-remove attr	R	.removeAttr()										
-removeattr	R	.removeAttr()										
-.removeAttr	R	.removeAttr()										
-removeAttr()	R	.removeAttr()										
-removeAttr	R	.removeAttr()										
-.removeClass()	A			jQuery methods							<section class="prog__container"><p>Remove a single class, multiple classes, or all classes from each element in the set of matched elements.</p><pre><code>$(selector).removeClass(className) → jQuery\n$(selector).removeClass(function) → jQuery</code></pre></section>	https://api.jquery.com/removeClass/
-remove class	R	.removeClass()										
-removeclass	R	.removeClass()										
-.removeClass	R	.removeClass()										
-removeClass()	R	.removeClass()										
-removeClass	R	.removeClass()										
-.removeData()	A			jQuery methods							<section class="prog__container"><p>Remove a previously-stored piece of data.</p><pre><code>$(selector).removeData(name) → jQuery\n$(selector).removeData(list) → jQuery</code></pre></section>	https://api.jquery.com/removeData/
-$.removeData()	R	jQuery.removeData()										
-$.removeData	R	jQuery.removeData()										
-remove data	R	.removeData()										
-removedata	R	.removeData()										
-.removeData	R	.removeData()										
-removeData()	R	.removeData()										
-removeData	R	.removeData()										
-.removeProp()	A			jQuery methods							<section class="prog__container"><p>Remove a property for the set of matched elements.</p><pre><code>$(selector).removeProp(propertyName) → jQuery</code></pre></section>	https://api.jquery.com/removeProp/
-remove prop	R	.removeProp()										
-removeprop	R	.removeProp()										
-.removeProp	R	.removeProp()										
-removeProp()	R	.removeProp()										
-removeProp	R	.removeProp()										
-.remove	R	.remove()										
-remove()	R	.remove()										
+relatedtarget	R	event.relatedTarget										
 remove	R	.remove()										
-.replaceAll()	A			jQuery methods							<section class="prog__container"><p>Replace each target element with the set of matched elements.</p><pre><code>$(selector).replaceAll(target) → jQuery</code></pre></section>	https://api.jquery.com/replaceAll/
+remove attr	R	.removeAttr()										
+remove class	R	.removeClass()										
+remove data	R	.removeData()										
+remove prop	R	.removeProp()										
+remove()	R	.remove()										
+removeAttr	R	.removeAttr()										
+removeAttr()	R	.removeAttr()										
+removeClass	R	.removeClass()										
+removeClass()	R	.removeClass()										
+removeData	R	.removeData()										
+removeData()	R	.removeData()										
+removeProp	R	.removeProp()										
+removeProp()	R	.removeProp()										
+removeattr	R	.removeAttr()										
+removeclass	R	.removeClass()										
+removedata	R	.removeData()										
+removeprop	R	.removeProp()										
 replace all	R	.replaceAll()										
-replaceall	R	.replaceAll()										
-.replaceAll	R	.replaceAll()										
-replaceAll()	R	.replaceAll()										
-replaceAll	R	.replaceAll()										
-.replaceWith()	A			jQuery methods							<section class="prog__container"><p>Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.</p><pre><code>$(selector).replaceWith(newContent) → jQuery\n$(selector).replaceWith(function) → jQuery</code></pre></section>	https://api.jquery.com/replaceWith/
 replace with	R	.replaceWith()										
-replacewith	R	.replaceWith()										
-.replaceWith	R	.replaceWith()										
-replaceWith()	R	.replaceWith()										
+replaceAll	R	.replaceAll()										
+replaceAll()	R	.replaceAll()										
 replaceWith	R	.replaceWith()										
-:reset Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type reset.</p><pre><code>$(":reset") → jQuery</code></pre></section>	https://api.jquery.com/reset-selector/
+replaceWith()	R	.replaceWith()										
+replaceall	R	.replaceAll()										
+replacewith	R	.replaceWith()										
 reset selector	R	:reset Selector										
-.resize()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).resize(handler) → jQuery\n$(selector).resize(eventData, handler) → jQuery\n$(selector).resize() → jQuery</code></pre></section>	https://api.jquery.com/resize/
-.resize event	R	.resize()										
-.resize() event	R	.resize()										
-resize event	R	.resize()										
-resize() event	R	.resize()										
-.resize	R	.resize()										
-resize()	R	.resize()										
 resize	R	.resize()										
-.resolve()	R	deferred.resolve()										
-.resolve	R	deferred.resolve()										
-resolve()	R	deferred.resolve()										
+resize event	R	.resize()										
+resize()	R	.resize()										
+resize() event	R	.resize()										
 resolve	R	deferred.resolve()										
 resolve with	R	deferred.resolveWith()										
-resolvewith	R	deferred.resolveWith()										
-.resolveWith()	R	deferred.resolveWith()										
-.resolveWith	R	deferred.resolveWith()										
-resolveWith()	R	deferred.resolveWith()										
+resolve()	R	deferred.resolve()										
 resolveWith	R	deferred.resolveWith()										
-.result	R	event.result										
+resolveWith()	R	deferred.resolveWith()										
+resolvewith	R	deferred.resolveWith()										
 result	R	event.result										
-$.)	R	jQuery()										
-	R	jQuery()										
-:root Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the element that is the root of the document.</p><pre><code>$(":root") → jQuery</code></pre></section>	https://api.jquery.com/root-selector/
 root selector	R	:root Selector										
-.scroll()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).scroll(handler) → jQuery\n$(selector).scroll(eventData, handler) → jQuery\n$(selector).scroll() → jQuery</code></pre></section>	https://api.jquery.com/scroll/
-.scroll event	R	.scroll()										
-.scroll() event	R	.scroll()										
-scroll event	R	.scroll()										
-scroll() event	R	.scroll()										
-.scrollLeft()	A			jQuery methods							<section class="prog__container"><p>Get the current horizontal position of the scroll bar for the first element in the set of matched elements.</p><pre><code>$(selector).scrollLeft() → Integer</code></pre>\n<p>Set the current horizontal position of the scroll bar for each of the set of matched elements.</p><pre><code>$(selector).scrollLeft(value) → jQuery</code></pre></section>	https://api.jquery.com/scrollLeft/
-scroll left	R	.scrollLeft()										
-scrollleft	R	.scrollLeft()										
-.scrollLeft	R	.scrollLeft()										
-scrollLeft()	R	.scrollLeft()										
-scrollLeft	R	.scrollLeft()										
-.scroll	R	.scroll()										
-scroll()	R	.scroll()										
 scroll	R	.scroll()										
-.scrollTop()	A			jQuery methods							<section class="prog__container"><p>Get the current vertical position of the scroll bar for the first element in the set of matched elements or set the vertical position of the scroll bar for every matched element.</p><pre><code>$(selector).scrollTop() → Number</code></pre>\n<p>Set the current vertical position of the scroll bar for each of the set of matched elements.</p><pre><code>$(selector).scrollTop(value) → jQuery</code></pre></section>	https://api.jquery.com/scrollTop/
+scroll event	R	.scroll()										
+scroll left	R	.scrollLeft()										
 scroll top	R	.scrollTop()										
-scrolltop	R	.scrollTop()										
-.scrollTop	R	.scrollTop()										
-scrollTop()	R	.scrollTop()										
+scroll()	R	.scroll()										
+scroll() event	R	.scroll()										
+scrollLeft	R	.scrollLeft()										
+scrollLeft()	R	.scrollLeft()										
 scrollTop	R	.scrollTop()										
-.select()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "select" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).select(handler) → jQuery\n$(selector).select(eventData, handler) → jQuery\n$(selector).select() → jQuery</code></pre></section>	https://api.jquery.com/select/
-:selected Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are selected.</p><pre><code>$(":selected") → jQuery</code></pre></section>	https://api.jquery.com/selected-selector/
-selected selector	R	:selected Selector										
-.select event	R	.select()										
-.select() event	R	.select()										
-select event	R	.select()										
-select() event	R	.select()										
-.selector	A			jQuery properties							<section class="prog__container"><p>A selector representing selector passed to jQuery(), if any, when creating the original set.</p><pre><code>$(selector).selector → String</code></pre></section>	https://api.jquery.com/selector/
-selector	R	.selector										
-.select	R	.select()										
-select()	R	.select()										
+scrollTop()	R	.scrollTop()										
+scrollleft	R	.scrollLeft()										
+scrolltop	R	.scrollTop()										
 select	R	.select()										
-.serialize()	A			jQuery methods							<section class="prog__container"><p>Encode a set of form elements as a string for submission.</p><pre><code>$(selector).serialize() → String</code></pre></section>	https://api.jquery.com/serialize/
-.serializeArray()	A			jQuery methods							<section class="prog__container"><p>Encode a set of form elements as an array of names and values.</p><pre><code>$(selector).serializeArray() → Array</code></pre></section>	https://api.jquery.com/serializeArray/
-serialize array	R	.serializeArray()										
-serializearray	R	.serializeArray()										
-.serializeArray	R	.serializeArray()										
-serializeArray()	R	.serializeArray()										
-serializeArray	R	.serializeArray()										
-.serialize	R	.serialize()										
-serialize()	R	.serialize()										
+select event	R	.select()										
+select()	R	.select()										
+select() event	R	.select()										
+selected selector	R	:selected Selector										
+selector	R	.selector										
 serialize	R	.serialize()										
-.show()	A			jQuery methods							<section class="prog__container"><p>Display the matched elements.</p><pre><code>$(selector).show() → jQuery\n$(selector).show(duration, complete) → jQuery\n$(selector).show(options) → jQuery\n$(selector).show(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/show/
-.show	R	.show()										
-show()	R	.show()										
+serialize array	R	.serializeArray()										
+serialize()	R	.serialize()										
+serializeArray	R	.serializeArray()										
+serializeArray()	R	.serializeArray()										
+serializearray	R	.serializeArray()										
 show	R	.show()										
-.siblings()	A			jQuery methods							<section class="prog__container"><p>Get the siblings of each element in the set of matched elements, optionally filtered by a selector.</p><pre><code>$(selector).siblings(selector) → jQuery</code></pre></section>	https://api.jquery.com/siblings/
-.siblings	R	.siblings()										
-siblings()	R	.siblings()										
+show()	R	.show()										
 siblings	R	.siblings()										
-.size()	A			jQuery methods							<section class="prog__container"><p>Return the number of elements in the jQuery object.</p><pre><code>$(selector).size() → Integer</code></pre></section>	https://api.jquery.com/size/
-.size	R	.size()										
-size()	R	.size()										
+siblings()	R	.siblings()										
 size	R	.size()										
-.slice()	A			jQuery methods							<section class="prog__container"><p>Reduce the set of matched elements to a subset specified by a range of indices.</p><pre><code>$(selector).slice(start, end) → jQuery</code></pre></section>	https://api.jquery.com/slice/
-.slice	R	.slice()										
-slice()	R	.slice()										
+size()	R	.size()										
 slice	R	.slice()										
-.slideDown()	A			jQuery methods							<section class="prog__container"><p>Display the matched elements with a sliding motion.</p><pre><code>$(selector).slideDown(duration, complete) → jQuery\n$(selector).slideDown(options) → jQuery\n$(selector).slideDown(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/slideDown/
+slice()	R	.slice()										
 slide down	R	.slideDown()										
-slidedown	R	.slideDown()										
-.slideDown	R	.slideDown()										
-slideDown()	R	.slideDown()										
-slideDown	R	.slideDown()										
-.slideToggle()	A			jQuery methods							<section class="prog__container"><p>Display or hide the matched elements with a sliding motion.</p><pre><code>$(selector).slideToggle(duration, complete) → jQuery\n$(selector).slideToggle(options) → jQuery\n$(selector).slideToggle(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/slideToggle/
 slide toggle	R	.slideToggle()										
-slidetoggle	R	.slideToggle()										
-.slideToggle	R	.slideToggle()										
-slideToggle()	R	.slideToggle()										
-slideToggle	R	.slideToggle()										
-.slideUp()	A			jQuery methods							<section class="prog__container"><p>Hide the matched elements with a sliding motion.</p><pre><code>$(selector).slideUp(duration, complete) → jQuery\n$(selector).slideUp(options) → jQuery\n$(selector).slideUp(duration, easing, complete) → jQuery</code></pre></section>	https://api.jquery.com/slideUp/
 slide up	R	.slideUp()										
-slideup	R	.slideUp()										
-.slideUp	R	.slideUp()										
-slideUp()	R	.slideUp()										
+slideDown	R	.slideDown()										
+slideDown()	R	.slideDown()										
+slideToggle	R	.slideToggle()										
+slideToggle()	R	.slideToggle()										
 slideUp	R	.slideUp()										
-.speed	R	jQuery.speed										
-$.speed	R	jQuery.speed										
+slideUp()	R	.slideUp()										
+slidedown	R	.slideDown()										
+slidetoggle	R	.slideToggle()										
+slideup	R	.slideUp()										
 speed	R	jQuery.speed										
-.state()	R	deferred.state()										
-.state	R	deferred.state()										
-state()	R	deferred.state()										
 state	R	deferred.state()										
-.stop()	A			jQuery methods							<section class="prog__container"><p>Stop the currently-running animation on the matched elements.</p><pre><code>$(selector).stop(clearQueue, jumpToEnd) → jQuery\n$(selector).stop(queue, clearQueue, jumpToEnd) → jQuery</code></pre></section>	https://api.jquery.com/stop/
-stop immediate propagation	R	event.stopImmediatePropagation()										
-stopimmediatepropagation	R	event.stopImmediatePropagation()										
-.stopImmediatePropagation()	R	event.stopImmediatePropagation()										
-.stopImmediatePropagation	R	event.stopImmediatePropagation()										
-stopImmediatePropagation()	R	event.stopImmediatePropagation()										
-stopImmediatePropagation	R	event.stopImmediatePropagation()										
-stop propagation	R	event.stopPropagation()										
-stoppropagation	R	event.stopPropagation()										
-.stopPropagation()	R	event.stopPropagation()										
-.stopPropagation	R	event.stopPropagation()										
-stopPropagation()	R	event.stopPropagation()										
-stopPropagation	R	event.stopPropagation()										
-.stop	R	.stop()										
-stop()	R	.stop()										
+state()	R	deferred.state()										
 stop	R	.stop()										
-.submit()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.</p><pre><code>$(selector).submit(handler) → jQuery\n$(selector).submit(eventData, handler) → jQuery\n$(selector).submit() → jQuery</code></pre></section>	https://api.jquery.com/submit/
-.submit event	R	.submit()										
-.submit() event	R	.submit()										
-submit event	R	.submit()										
-submit() event	R	.submit()										
-.submit	R	.submit()										
-submit()	R	.submit()										
-submit	R	.submit()										
-:submit Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements of type submit.</p><pre><code>$(":submit") → jQuery</code></pre></section>	https://api.jquery.com/submit-selector/
-submit selector	R	:submit Selector										
-.sub()	R	jQuery.sub()										
-.sub	R	jQuery.sub()										
-$.sub()	R	jQuery.sub()										
-$.sub	R	jQuery.sub()										
-sub()	R	jQuery.sub()										
+stop immediate propagation	R	event.stopImmediatePropagation()										
+stop propagation	R	event.stopPropagation()										
+stop()	R	.stop()										
+stopImmediatePropagation	R	event.stopImmediatePropagation()										
+stopImmediatePropagation()	R	event.stopImmediatePropagation()										
+stopPropagation	R	event.stopPropagation()										
+stopPropagation()	R	event.stopPropagation()										
+stopimmediatepropagation	R	event.stopImmediatePropagation()										
+stoppropagation	R	event.stopPropagation()										
 sub	R	jQuery.sub()										
-.support	R	jQuery.support										
-$.support	R	jQuery.support										
+sub()	R	jQuery.sub()										
+submit	R	.submit()										
+submit event	R	.submit()										
+submit selector	R	:submit Selector										
+submit()	R	.submit()										
+submit() event	R	.submit()										
 support	R	jQuery.support										
-.target	R	event.target										
 target	R	event.target										
-:target Selector	A			jQuery selectors							<section class="prog__container"><p>Selects the target element indicated by the fragment identifier of the document's URI.</p><pre><code>$(":target") → jQuery</code></pre></section>	https://api.jquery.com/target-selector/
 target selector	R	:target Selector										
-.text()	A			jQuery methods							<section class="prog__container"><p>Get the combined text contents of each element in the set of matched elements, including their descendants.</p><pre><code>$(selector).text() → String</code></pre>\n<p>Set the content of each element in the set of matched elements to the specified text.</p><pre><code>$(selector).text(text) → jQuery\n$(selector).text(function) → jQuery</code></pre></section>	https://api.jquery.com/text/
-.text	R	.text()										
-text()	R	.text()										
 text	R	.text()										
-:text Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all input elements of type text.</p><pre><code>$(":text") → jQuery</code></pre></section>	https://api.jquery.com/text-selector/
 text selector	R	:text Selector										
-.then()	R	deferred.then()										
-.then	R	deferred.then()										
-then()	R	deferred.then()										
+text()	R	.text()										
 then	R	deferred.then()										
+then()	R	deferred.then()										
 time stamp	R	event.timeStamp										
-timestamp	R	event.timeStamp										
-.timeStamp	R	event.timeStamp										
 timeStamp	R	event.timeStamp										
-.toArray()	A			jQuery methods							<section class="prog__container"><p>Retrieve all the elements contained in the jQuery set, as an array.</p><pre><code>$(selector).toArray() → Array</code></pre></section>	https://api.jquery.com/toArray/
+timestamp	R	event.timeStamp										
 to array	R	.toArray()										
-toarray	R	.toArray()										
-.toArray	R	.toArray()										
-toArray()	R	.toArray()										
 toArray	R	.toArray()										
-.toggle()	A			jQuery methods							<section class="prog__container"><p>Display or hide the matched elements.</p><pre><code>$(selector).toggle(duration, complete) → jQuery\n$(selector).toggle(options) → jQuery\n$(selector).toggle(duration, easing, complete) → jQuery\n$(selector).toggle(display) → jQuery</code></pre></section>	https://api.jquery.com/toggle/
-.toggleClass()	A			jQuery methods							<section class="prog__container"><p>Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the state argument.</p><pre><code>$(selector).toggleClass(className) → jQuery\n$(selector).toggleClass(className, state) → jQuery\n$(selector).toggleClass(function, state) → jQuery</code></pre>\n<p></p><pre><code>$(selector).toggleClass(state) → jQuery</code></pre></section>	https://api.jquery.com/toggleClass/
-toggle class	R	.toggleClass()										
-toggleclass	R	.toggleClass()										
-.toggleClass	R	.toggleClass()										
-toggleClass()	R	.toggleClass()										
-toggleClass	R	.toggleClass()										
-.toggle event	R	.toggle()										
-.toggle() event	R	.toggle()										
-toggle event	R	.toggle()										
-toggle() event	R	.toggle()										
-.toggle	R	.toggle()										
-toggle()	R	.toggle()										
+toArray()	R	.toArray()										
+toarray	R	.toArray()										
 toggle	R	.toggle()										
-.trigger()	A			jQuery methods							<section class="prog__container"><p>Execute all handlers and behaviors attached to the matched elements for the given event type.</p><pre><code>$(selector).trigger(eventType, extraParameters) → jQuery\n$(selector).trigger(event, extraParameters) → jQuery</code></pre></section>	https://api.jquery.com/trigger/
-.trigger event	R	.trigger()										
-.trigger() event	R	.trigger()										
-trigger event	R	.trigger()										
-trigger() event	R	.trigger()										
-.triggerHandler()	A			jQuery methods							<section class="prog__container"><p>Execute all handlers attached to an element for an event.</p><pre><code>$(selector).triggerHandler(eventType, extraParameters) → Object\n$(selector).triggerHandler(event, extraParameters) → Object</code></pre></section>	https://api.jquery.com/triggerHandler/
-trigger handler event	R	.triggerHandler()										
-triggerhandler event	R	.triggerHandler()										
-.triggerHandler event	R	.triggerHandler()										
-.triggerHandler() event	R	.triggerHandler()										
-triggerHandler event	R	.triggerHandler()										
-triggerHandler() event	R	.triggerHandler()										
-trigger handler	R	.triggerHandler()										
-triggerhandler	R	.triggerHandler()										
-.triggerHandler	R	.triggerHandler()										
-triggerHandler()	R	.triggerHandler()										
-triggerHandler	R	.triggerHandler()										
-.trigger	R	.trigger()										
-trigger()	R	.trigger()										
+toggle class	R	.toggleClass()										
+toggle event	R	.toggle()										
+toggle()	R	.toggle()										
+toggle() event	R	.toggle()										
+toggleClass	R	.toggleClass()										
+toggleClass()	R	.toggleClass()										
+toggleclass	R	.toggleClass()										
 trigger	R	.trigger()										
-.trim()	R	jQuery.trim()										
-.trim	R	jQuery.trim()										
-$.trim()	R	jQuery.trim()										
-$.trim	R	jQuery.trim()										
-trim()	R	jQuery.trim()										
+trigger event	R	.trigger()										
+trigger handler	R	.triggerHandler()										
+trigger handler event	R	.triggerHandler()										
+trigger()	R	.trigger()										
+trigger() event	R	.trigger()										
+triggerHandler	R	.triggerHandler()										
+triggerHandler event	R	.triggerHandler()										
+triggerHandler()	R	.triggerHandler()										
+triggerHandler() event	R	.triggerHandler()										
+triggerhandler	R	.triggerHandler()										
+triggerhandler event	R	.triggerHandler()										
 trim	R	jQuery.trim()										
-.type	R	event.type										
+trim()	R	jQuery.trim()										
 type	R	event.type										
-.type()	R	jQuery.type()										
-$.type()	R	jQuery.type()										
-$.type	R	jQuery.type()										
 type()	R	jQuery.type()										
-.unbind()	A			jQuery methods							<section class="prog__container"><p>Remove a previously-attached event handler from the elements.</p><pre><code>$(selector).unbind(eventType, handler) → jQuery\n$(selector).unbind(eventType, false) → jQuery\n$(selector).unbind(event) → jQuery\n$(selector).unbind() → jQuery</code></pre></section>	https://api.jquery.com/unbind/
-.unbind event	R	.unbind()										
-.unbind() event	R	.unbind()										
-unbind event	R	.unbind()										
-unbind() event	R	.unbind()										
-.unbind	R	.unbind()										
-unbind()	R	.unbind()										
 unbind	R	.unbind()										
-.undelegate()	A			jQuery methods							<section class="prog__container"><p>Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.</p><pre><code>$(selector).undelegate() → jQuery\n$(selector).undelegate(selector, eventType) → jQuery\n$(selector).undelegate(selector, eventType, handler) → jQuery\n$(selector).undelegate(selector, events) → jQuery\n$(selector).undelegate(namespace) → jQuery</code></pre></section>	https://api.jquery.com/undelegate/
-.undelegate event	R	.undelegate()										
-.undelegate() event	R	.undelegate()										
-undelegate event	R	.undelegate()										
-undelegate() event	R	.undelegate()										
-.undelegate	R	.undelegate()										
-undelegate()	R	.undelegate()										
+unbind event	R	.unbind()										
+unbind()	R	.unbind()										
+unbind() event	R	.unbind()										
 undelegate	R	.undelegate()										
-.unique()	R	jQuery.unique()										
-.unique	R	jQuery.unique()										
-$.unique()	R	jQuery.unique()										
-$.unique	R	jQuery.unique()										
-unique()	R	jQuery.unique()										
+undelegate event	R	.undelegate()										
+undelegate()	R	.undelegate()										
+undelegate() event	R	.undelegate()										
 unique	R	jQuery.unique()										
 unique sort	R	jQuery.uniqueSort()										
-uniquesort	R	jQuery.uniqueSort()										
-.uniqueSort()	R	jQuery.uniqueSort()										
-.uniqueSort	R	jQuery.uniqueSort()										
-$.uniqueSort()	R	jQuery.uniqueSort()										
-$.uniqueSort	R	jQuery.uniqueSort()										
-uniqueSort()	R	jQuery.uniqueSort()										
+unique()	R	jQuery.unique()										
 uniqueSort	R	jQuery.uniqueSort()										
-.unload()	A			jQuery methods							<section class="prog__container"><p>Bind an event handler to the "unload" JavaScript event.</p><pre><code>$(selector).unload(handler) → jQuery\n$(selector).unload(eventData, handler) → jQuery</code></pre></section>	https://api.jquery.com/unload/
-.unload event	R	.unload()										
-.unload() event	R	.unload()										
-unload event	R	.unload()										
-unload() event	R	.unload()										
-.unload	R	.unload()										
-unload()	R	.unload()										
+uniqueSort()	R	jQuery.uniqueSort()										
+uniquesort	R	jQuery.uniqueSort()										
 unload	R	.unload()										
-.unwrap()	A			jQuery methods							<section class="prog__container"><p>Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.</p><pre><code>$(selector).unwrap() → jQuery\n$(selector).unwrap(selector) → jQuery</code></pre></section>	https://api.jquery.com/unwrap/
-.unwrap	R	.unwrap()										
-unwrap()	R	.unwrap()										
+unload event	R	.unload()										
+unload()	R	.unload()										
+unload() event	R	.unload()										
 unwrap	R	.unwrap()										
-.val()	A			jQuery methods							<section class="prog__container"><p>Get the current value of the first element in the set of matched elements.</p><pre><code>$(selector).val() → String|Number|Array</code></pre>\n<p>Set the value of each element in the set of matched elements.</p><pre><code>$(selector).val(value) → jQuery\n$(selector).val(function) → jQuery</code></pre></section>	https://api.jquery.com/val/
-.val	R	.val()										
-val()	R	.val()										
+unwrap()	R	.unwrap()										
 val	R	.val()										
-:visible Selector	A			jQuery selectors							<section class="prog__container"><p>Selects all elements that are visible.</p><pre><code>$(":visible") → jQuery</code></pre></section>	https://api.jquery.com/visible-selector/
+val()	R	.val()										
 visible selector	R	:visible Selector										
-.when()	R	jQuery.when()										
-.when	R	jQuery.when()										
-$.when()	R	jQuery.when()										
-$.when	R	jQuery.when()										
-when()	R	jQuery.when()										
 when	R	jQuery.when()										
-.which	R	event.which										
+when()	R	jQuery.when()										
 which	R	event.which										
-.width()	A			jQuery methods							<section class="prog__container"><p>Get the current computed width for the first element in the set of matched elements.</p><pre><code>$(selector).width() → Number</code></pre>\n<p>Set the CSS width of each element in the set of matched elements.</p><pre><code>$(selector).width(value) → jQuery\n$(selector).width(function) → jQuery</code></pre></section>	https://api.jquery.com/width/
-.width	R	.width()										
-width()	R	.width()										
 width	R	.width()										
-.wrap()	A			jQuery methods							<section class="prog__container"><p>Wrap an HTML structure around each element in the set of matched elements.</p><pre><code>$(selector).wrap(wrappingElement) → jQuery\n$(selector).wrap(function) → jQuery</code></pre></section>	https://api.jquery.com/wrap/
-.wrapAll()	A			jQuery methods							<section class="prog__container"><p>Wrap an HTML structure around all elements in the set of matched elements.</p><pre><code>$(selector).wrapAll(wrappingElement) → jQuery\n$(selector).wrapAll(function) → jQuery</code></pre></section>	https://api.jquery.com/wrapAll/
-wrap all	R	.wrapAll()										
-wrapall	R	.wrapAll()										
-.wrapAll	R	.wrapAll()										
-wrapAll()	R	.wrapAll()										
-wrapAll	R	.wrapAll()										
-.wrapInner()	A			jQuery methods							<section class="prog__container"><p>Wrap an HTML structure around the content of each element in the set of matched elements.</p><pre><code>$(selector).wrapInner(wrappingElement) → jQuery\n$(selector).wrapInner(function) → jQuery</code></pre></section>	https://api.jquery.com/wrapInner/
-wrap inner	R	.wrapInner()										
-wrapinner	R	.wrapInner()										
-.wrapInner	R	.wrapInner()										
-wrapInner()	R	.wrapInner()										
-wrapInner	R	.wrapInner()										
-.wrap	R	.wrap()										
-wrap()	R	.wrap()										
+width()	R	.width()										
 wrap	R	.wrap()										
+wrap all	R	.wrapAll()										
+wrap inner	R	.wrapInner()										
+wrap()	R	.wrap()										
+wrapAll	R	.wrapAll()										
+wrapAll()	R	.wrapAll()										
+wrapInner	R	.wrapInner()										
+wrapInner()	R	.wrapInner()										
+wrapall	R	.wrapAll()										
+wrapinner	R	.wrapInner()										


### PR DESCRIPTION
## Description of new Instant Answer, or changes
This PR updates fetch.sh for jQuery to contain the download url for the fathead, which previously was loaded from data.url.

## Related Issues and Discussions
Fixes #636 

## People to notify
@bfmags @MariagraziaAlastra 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/jquery

