### PR TITLE
Revert "Fatheads: Remove unused data.url and meta.txt files"

### DIFF
--- a/lib/fathead/abbreviations_com/meta.txt
+++ b/lib/fathead/abbreviations_com/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Abbreviations.com
+
+# This is the base domain where the source pages are located.
+Domain: www.abbreviations.com
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: Abbreviations.com
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: acronym, abbreviation, shorthand, stands for, stand for, short for, means

--- a/lib/fathead/airports/meta.txt
+++ b/lib/fathead/airports/meta.txt
@@ -1,0 +1,10 @@
+Name: Wikipedia
+
+Domain: wikipedia.org
+
+Type: Wikipedia
+
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: iata, icao

--- a/lib/fathead/arch_pkgs/meta.txt
+++ b/lib/fathead/arch_pkgs/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Arch Linux Packages
+
+# This is the base domain where the source pages are located.
+Domain: archlinux.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: ArchLinux Package
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: archlinux package, arch package

--- a/lib/fathead/bible/data.url
+++ b/lib/fathead/bible/data.url
@@ -1,0 +1,1 @@
+http://downloads.believersresource.com/bibles/rawdata/sql/sqlbible.zip

--- a/lib/fathead/bible/meta.txt
+++ b/lib/fathead/bible/meta.txt
@@ -1,0 +1,20 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: Blue Letter Bible
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: blueletterbible.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: Bible
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with,
+Keywords: bible

--- a/lib/fathead/cppreference_doc/data.url
+++ b/lib/fathead/cppreference_doc/data.url
@@ -1,0 +1,1 @@
+upload.cppreference.com/w/Cppreference:DDG-link?action=raw

--- a/lib/fathead/cve/data.url
+++ b/lib/fathead/cve/data.url
@@ -1,0 +1,1 @@
+https://cve.mitre.org/data/downloads/allitems.xml.gz

--- a/lib/fathead/file_formats/meta.txt
+++ b/lib/fathead/file_formats/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Wikipedia
+
+# This is the base domain where the source pages are located.
+Domain: en.wikipedia.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: File Format
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 1
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: file format, extension, file extension

--- a/lib/fathead/firefox_about_config/data.url
+++ b/lib/fathead/firefox_about_config/data.url
@@ -1,0 +1,1 @@
+http://kb.mozillazine.org/About:config_entries

--- a/lib/fathead/firefox_about_config/meta.txt
+++ b/lib/fathead/firefox_about_config/meta.txt
@@ -1,0 +1,5 @@
+Name: Firefox about:config
+Domain: http://kb.mozillazine.org/About:config_entries
+Type: Firefox configuration
+MediaWiki: 0
+Keywords: firefox config,firefox configuration,firefox about, firefox about config,firefox about:config,ff config, ff configuration, ff about, ff about config, ff about:config

--- a/lib/fathead/git_manual/data.url
+++ b/lib/fathead/git_manual/data.url
@@ -1,0 +1,1 @@
+https://git-scm.com/docs/

--- a/lib/fathead/hello_world/data.url
+++ b/lib/fathead/hello_world/data.url
@@ -1,0 +1,1 @@
+git://github.com/leachim6/hello-world.git

--- a/lib/fathead/hello_world/meta.txt
+++ b/lib/fathead/hello_world/meta.txt
@@ -1,0 +1,20 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: Hello World
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: www.github.com
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: Github
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with a comma - ','
+Keywords: hello world, source

--- a/lib/fathead/hgnc_gene_names/data.url
+++ b/lib/fathead/hgnc_gene_names/data.url
@@ -1,0 +1,1 @@
+http://www.genenames.org/cgi-bin/hgnc_downloads.cgi?title=HGNC+output+data&hgnc_dbtag=on&preset=all&status=Approved&status=Entry+Withdrawn&status_opt=2&level=pri&=on&where=&order_by=gd_app_sym_sort&limit=&format=text&submit=submit&.cgifields=&.cgifields=level&.cgifields=chr&.cgifields=status&.cgifields=hgnc_dbtag

--- a/lib/fathead/hgnc_gene_names/meta.txt
+++ b/lib/fathead/hgnc_gene_names/meta.txt
@@ -1,0 +1,5 @@
+Name: HGNC Gene Names
+Domain: www.genenames.org
+Type: Human Gene Name
+MediaWiki: 0
+Keywords: HGNC, human gene, gene

--- a/lib/fathead/htmlref/data.url
+++ b/lib/fathead/htmlref/data.url
@@ -1,0 +1,1 @@
+http://html5doctor.com/element-index/

--- a/lib/fathead/htmlref/meta.txt
+++ b/lib/fathead/htmlref/meta.txt
@@ -1,0 +1,5 @@
+Name: HTML Reference
+Domain: http://html5doctor.com
+Type: HTML5Doctor
+MediaWiki: 0
+Keywords: html,html tag,html5,html5 tag,tag

--- a/lib/fathead/iso_3166_codes/data.url
+++ b/lib/fathead/iso_3166_codes/data.url
@@ -1,0 +1,1 @@
+http://www.iso.org/iso/list-en1-semic-3.txt

--- a/lib/fathead/iso_3166_codes/meta.txt
+++ b/lib/fathead/iso_3166_codes/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: ISO 3166 code lists 
+
+# This is the base domain where the source pages are located.
+Domain: www.iso.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: ISO 3166
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: iso, 3166

--- a/lib/fathead/java/data.url
+++ b/lib/fathead/java/data.url
@@ -1,0 +1,1 @@
+http://download.oracle.com/otn-pub/java/jdk/8u25-b17/jdk-8u25-docs-all.zip

--- a/lib/fathead/java/meta.txt
+++ b/lib/fathead/java/meta.txt
@@ -1,0 +1,5 @@
+Name: JDK 8
+Domain: docs.oracle.com
+Type: Java
+MediaWiki: 0
+Keywords: Java

--- a/lib/fathead/jquery/data.url
+++ b/lib/fathead/jquery/data.url
@@ -1,0 +1,1 @@
+https://codeload.github.com/jquery/api.jquery.com/zip/master

--- a/lib/fathead/ldraw_org/meta.txt
+++ b/lib/fathead/ldraw_org/meta.txt
@@ -1,0 +1,21 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: LDraw Parts Tracker
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: ldraw.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: Lego
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with ,
+# (appropriate to include LDraw part file suffix, ".dat", as well?)
+Keywords: LDraw, LEGO

--- a/lib/fathead/legal_docs/data.url
+++ b/lib/fathead/legal_docs/data.url
@@ -1,0 +1,1 @@
+http://www.docracy.com/application/duckduckgo

--- a/lib/fathead/legal_docs/meta.txt
+++ b/lib/fathead/legal_docs/meta.txt
@@ -1,0 +1,20 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: Docracy
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: www.docracy.com
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: Docracy
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with,
+Keywords: legal document,contract,legal contract,legal,law

--- a/lib/fathead/lkddb/data.url
+++ b/lib/fathead/lkddb/data.url
@@ -1,0 +1,2 @@
+If you don't have the time or bandwith to fetch the pages, here is a recent compressed data dump (2.7MB) hosted on my server:
+http://ks384172.kimsufi.com/dl/lkddb-dump-2012-07-01.7z

--- a/lib/fathead/lkddb/meta.txt
+++ b/lib/fathead/lkddb/meta.txt
@@ -1,0 +1,20 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: Linux Kernel Driver DataBase
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: cateee.net
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: LKDDB
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with,
+Keywords: 

--- a/lib/fathead/mdnjs/meta.txt
+++ b/lib/fathead/mdnjs/meta.txt
@@ -1,0 +1,9 @@
+Name: Mozilla Developer Network
+
+Domain: developer.mozilla.org
+
+Type: JavaScript
+
+MediaWiki: 0
+
+Keywords: javascript js mdn

--- a/lib/fathead/mime_types/meta.txt
+++ b/lib/fathead/mime_types/meta.txt
@@ -1,0 +1,20 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: MIME media types
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: http://hg.python.org/cpython/file/2.7/Lib/mimetypes.py
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: 
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with,
+Keywords: mime type,mime,mimetype

--- a/lib/fathead/nginx/data.url
+++ b/lib/fathead/nginx/data.url
@@ -1,0 +1,1 @@
+http://hg.nginx.org/nginx.org/raw-file/default/xml/en/docs/http

--- a/lib/fathead/pci_ids/data.url
+++ b/lib/fathead/pci_ids/data.url
@@ -1,0 +1,1 @@
+http://pciids.sourceforge.net/v2.2/pci.ids

--- a/lib/fathead/pci_ids/meta.txt
+++ b/lib/fathead/pci_ids/meta.txt
@@ -1,0 +1,5 @@
+Name: PCI IDs
+Domain: http://pciids.sourceforge.net/
+Type: PCI
+MediaWiki: 0
+Keywords: pci, pcid, pci id

--- a/lib/fathead/perl6doc/meta.txt
+++ b/lib/fathead/perl6doc/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Perl 6 Documentation
+
+# This is the base domain where the source pages are located.
+Domain: doc.perl6.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: Perl 6 Documentation
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: perl 6, perl6

--- a/lib/fathead/php/data.url
+++ b/lib/fathead/php/data.url
@@ -1,0 +1,1 @@
+http://php.net/distributions/manual/php_manual_en.tar.gz

--- a/lib/fathead/pika/data.url
+++ b/lib/fathead/pika/data.url
@@ -1,0 +1,1 @@
+https://media.readthedocs.org/htmlzip/pika/latest/pika.zip

--- a/lib/fathead/plone_org/meta.txt
+++ b/lib/fathead/plone_org/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Plone
+
+# This is the base domain where the source pages are located.
+Domain: plone.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: Plone
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: plone

--- a/lib/fathead/plural/data.url
+++ b/lib/fathead/plural/data.url
@@ -1,0 +1,1 @@
+http://dumps.wikimedia.org/enwiktionary/latest/enwiktionary-latest-pages-articles.xml.bz2

--- a/lib/fathead/port_lookup/meta.txt
+++ b/lib/fathead/port_lookup/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Wikipedia
+
+# This is the base domain where the source pages are located.
+Domain: en.wikipedia.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: Port
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 1
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: port, tcp port, udp port, tcp, udp

--- a/lib/fathead/py_pi/meta.txt
+++ b/lib/fathead/py_pi/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Python Package Index
+
+# This is the base domain where the source pages are located.
+Domain: pypi.python.org 
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: Python
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: python, python package, pypi

--- a/lib/fathead/redis_commands/meta.txt
+++ b/lib/fathead/redis_commands/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: Redis
+
+# This is the base domain where the source pages are located.
+Domain: redis.io
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: Redis
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: redis

--- a/lib/fathead/rfc_lookup/meta.txt
+++ b/lib/fathead/rfc_lookup/meta.txt
@@ -1,0 +1,5 @@
+Name: RFC Documents
+Domain: www.rfc-editor.org
+Type: Internet Standards
+MediaWiki: 0
+Keywords: RFC, rfc

--- a/lib/fathead/ruby/data.url
+++ b/lib/fathead/ruby/data.url
@@ -1,0 +1,1 @@
+http://ruby-doc.org/downloads/ruby_2_3_1_core_rdocs.tgz

--- a/lib/fathead/scholrly/meta.txt
+++ b/lib/fathead/scholrly/meta.txt
@@ -1,0 +1,5 @@
+Name: Scholrly
+Domain: scholr.ly
+Type: Research
+MediaWiki: 0
+Keywords: scholrly, schol, sch,research,researcher

--- a/lib/fathead/spring_framework/data.url
+++ b/lib/fathead/spring_framework/data.url
@@ -1,0 +1,1 @@
+http://docs.spring.io/spring/docs/current/javadoc-api/overview-summary.html

--- a/lib/fathead/sysctl/meta.txt
+++ b/lib/fathead/sysctl/meta.txt
@@ -1,0 +1,10 @@
+Name: SysctlKernel
+
+Domain: kernel.org
+
+Type: Documentation
+
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: linux, linux kernel, linux /proc/sys/kernel, /proc/sys/kernel, linux proc sys kernel, proc sys kernel, sysctl

--- a/lib/fathead/tcl_ref/meta.txt
+++ b/lib/fathead/tcl_ref/meta.txt
@@ -1,0 +1,9 @@
+Name: Tcl/Tk 8.5 Manual
+
+Domain: www.tcl.tk
+
+Type: Tcl
+
+MediaWiki: 0
+
+Keywords: tcl

--- a/lib/fathead/unix_man/meta.txt
+++ b/lib/fathead/unix_man/meta.txt
@@ -1,0 +1,20 @@
+# This is the name of the source as people would refer to it,
+# e.g. Wikipedia or PerlDoc -- gets displayed on Web site.
+Name: LinuxCommand.org 
+
+# This is the base domain where the source pages are located.
+# Get used to get the favicon.
+Domain: http://www.linuxcommand.org/
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely 
+# general info spanning many types of topics like Facebook.
+Type: Unix command
+
+# Whether the source is from MediaWiki (1) or not (0).
+# Processing happens a bit differently on MediaWiki.
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+# Can seperate multiple keywords with,
+Keywords: unix man, manpage, man page

--- a/lib/fathead/xep/meta.txt
+++ b/lib/fathead/xep/meta.txt
@@ -1,0 +1,15 @@
+# This is the name of the source as people would refer to it, e.g. Wikipedia or PerlDoc
+Name: XMPP Standards Foundation
+
+# This is the base domain where the source pages are located.
+Domain: xmpp.org
+
+# This is what gets put in quotes next to the source
+# It can be blank if it is a source with completely general info spanning many types of topics like Facebook.
+Type: XEP
+
+# Whether the source is from MediaWiki (1) or not (0).
+MediaWiki: 0
+
+# Keywords uses to trigger (or prefer) the source over others.
+Keywords: xep

--- a/lib/fathead/yui3/meta.txt
+++ b/lib/fathead/yui3/meta.txt
@@ -1,0 +1,5 @@
+Name: YUI Library
+Domain: yuilibrary.com
+Type: YUI 3 Module
+MediaWiki: 0
+Keywords: yui, yui 3, yui3


### PR DESCRIPTION
Reverts duckduckgo/zeroclickinfo-fathead#633

## Reason

I didn't realize that a few of the Fatheads load the `data.url` in their `fetch.sh` and `parse.sh`scripts. 

I'll revert these changes, then remove the meta.txt in a new PR, and remove the unused `data.url` files in another.

/cc @jdorweiler @MariagraziaAlastra @bfmags