### PR TITLE
MDN CSS: Add aliases for background-*

### DIFF
--- a/lib/fathead/mdn_css/redirect.txt
+++ b/lib/fathead/mdn_css/redirect.txt
@@ -1,9 +1,13 @@
+align background,background-position
 attachment background,background-attachment
 blend background,background-blend-mode
+center background,background-position
 clip background,background-clip
 color background,background-color
+height background,background-size
 image background,background-image
 origin background,background-origin
 position background,background-position
 repeat background,background-repeat
 size background,background-size
+width background,background-size

--- a/lib/fathead/mdn_css/redirect.txt
+++ b/lib/fathead/mdn_css/redirect.txt
@@ -1,0 +1,9 @@
+attachment background,background-attachment
+blend background,background-blend-mode
+clip background,background-clip
+color background,background-color
+image background,background-image
+origin background,background-origin
+position background,background-position
+repeat background,background-repeat
+size background,background-size


### PR DESCRIPTION
Fixes #637. MDN CSS entries like "background-color" weren't being triggered by searches like "color background". Added redirects.txt aliases to specify these cases explicitly.


Instant Answer Page: https://duck.co/ia/view/mdn_css