### PR TITLE
Fathead Tests: Suppress test output unless -v option passed

### DIFF
--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -188,7 +188,7 @@ sub report {
         my @slice = splice @$elements, $limit;
         my $remaining = scalar @slice;
         diag $_ for @$elements;
-        diag "...\nPLUS $remaining MORE. (Use `duckpan test -v` to see full output)";
+        diag UNDERSCORE BOLD MAGENTA "PLUS $remaining MORE!", RESET, " (Use `duckpan test -v` to see full output)";
     }
 }
 

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -16,6 +16,11 @@ use Term::ANSIColor qw(:constants);
 
 has fathead => ( is => 'ro' );
 
+has verbose => ( is => 'lazy' );
+sub _build_verbose {
+    $ENV{'DDG_VERBOSE_TEST'};
+}
+
 has project_root => ( is => 'lazy' );
 sub _build_project_root {
     my ( $self ) = @_;
@@ -171,6 +176,22 @@ sub _a_not_in_b {
     return wantarray ? @missing : \@missing;
 }
 
+sub report {
+    my ( $self, $elements, $limit ) = @_;
+
+    $limit ||= 20;
+
+    if ( scalar @$elements <= $limit || $self->verbose ) {
+        diag $_ for @$elements;
+    }
+    else {
+        my @slice = splice @$elements, $limit;
+        my $remaining = scalar @slice;
+        diag $_ for @$elements;
+        diag "...\nPLUS $remaining MORE. (Use `duckpan test -v` to see full output)";
+    }
+}
+
 sub duplicates {
     my ( $self ) = @_;
     my @dupes = grep { $self->titles->{$_}->{count} > 1 } keys %{ $self->titles };
@@ -194,7 +215,7 @@ sub coverage {
     if (@missing){
         my $count = scalar @missing;
         diag YELLOW "\n$count TITLES MISSING IN OUTPUT FILE";
-        diag $_ for @missing;
+        $self->report(\@missing);
     }
     return @missing ? 0 : 1;
 }
@@ -207,7 +228,7 @@ sub types {
     if (@invalid_types){
         my $count = scalar @invalid_types;
         diag YELLOW "$count INVALID ARTICLE TYPES FOUND";
-        diag $_ for @invalid_types;
+        $self->report(\@invalid_types);
     }
     return @invalid_types ? 0 : 1;
 }
@@ -241,7 +262,7 @@ sub escapes {
     if (@unescaped){
         my $count = scalar @unescaped;
         diag YELLOW "\n$count POSSIBLY UNESCAPED CHARACTERS FOUND:";
-        diag $_ for @unescaped;
+        $self->report(\@unescaped);
     }
     return $r;
 }
@@ -256,7 +277,7 @@ sub disambiguations_format {
     if (@invalid){
         my $count = scalar @invalid;
         diag YELLOW "\n$count INVALID DISMABIGUATIONS FOUND:";
-        diag $_ for @invalid;
+        $self->report(\@invalid, 5);
     }
 
     return @invalid ? 0 : 1;
@@ -275,7 +296,7 @@ sub disambiguations_missing {
     if (@missing){
         my $count = scalar @missing;
         diag YELLOW "\n$count DISAMBIGUATION TITLES MISSING FROM ARTICLES:";
-        diag $_ for @missing;
+        $self->report(\@missing);
     }
     return @missing ? 0 : 1;
 }
@@ -293,8 +314,9 @@ sub category_clash {
     if (@clash){
         my $count = scalar @clash;
         diag YELLOW "$count CATEGORIES NAMES MATCHING ARTICLE TITLES";
-        diag $_ for @clash;
+        $self->report(\@clash)
     }
     return @clash ? 0 : 1;
 }
+
 1;


### PR DESCRIPTION
## Background

Fathead output files can be tested with DuckPAN test, but sometimes they can dump thousands of lines of output if there are lots of errors for a big Fathead. This makes the test results very hard to read at a glance, and should be fixed.


## Description of new Instant Answer, or changes

This updates `TestUtils.pm` to enable verbose output depending on the value of a new ENV variable, which is set by DuckPAN when the `-v` flag is passed to the `duckpan test` command.

e.g. `duckpan test -v mdn_css`

## Related Issues and Discussions
Associated DuckPAN changes: https://github.com/duckduckgo/p5-app-duckpan/pull/386

## Testing

1. Checkout PR
2. Run `duckpan -I ../p5-app-duckpan/lib test mdn_css` in Fathead repo
3. You should see the "Missing Titles" section truncated, and it should read "PLUS 29 MORE"
4. Run `duckpan -I ../p5-app-duckpan/lib test -v mdn_css` to see full (current) output

## People to notify
@jbarrett