### PR TITLE
Django: Rework fathead to handle sub modules

### DIFF
--- a/lib/fathead/django/fetch.sh
+++ b/lib/fathead/django/fetch.sh
@@ -4,17 +4,4 @@ mkdir -p download
 cd download
 rm -f *.html
 
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/contrib/ -O contrib.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/django-admin/ -O django-admin.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/exceptions/ -O exceptions.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/forms/fields/ -O form_fields.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/forms/widgets/ -O widgets.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/templates/builtins/ -O builtins.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/settings/ -O settings.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/validators/ -O validators.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/views/ -O view.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/urlresolvers/ -O urlresolvers.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/urls/ -O urls.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/models/database-functions/ -O database-functions.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/models/fields/ -O fields.html
-wget --quiet https://docs.djangoproject.com/en/1.10/ref/migration-operations/ -O migration-operations.html
+wget --quiet -np -nc -r https://docs.djangoproject.com/en/1.10/ref/

--- a/lib/fathead/django/output_statistics.awk
+++ b/lib/fathead/django/output_statistics.awk
@@ -1,0 +1,10 @@
+#!/usr/bin/awk -f
+BEGIN { FS="\t"; nbrArticles=0; nbrRedirects=0; nbrDis=0 }
+$2=="A" { nbrArticles=nbrArticles+1 } 
+$2=="R" { nbrRedirects=nbrRedirects+1 } 
+$2=="D" { nbrDis=nbrDis+1 } 
+END { 
+	print "Output contains:"; 
+	print "Articles:" nbrArticles; 
+	print "Redirects:" nbrRedirects; 
+	print "Disambiguations:" nbrDis }

--- a/lib/fathead/django/parse.py
+++ b/lib/fathead/django/parse.py
@@ -1,192 +1,177 @@
-import argparse
+# -*- coding: utf-8 -*-
 import os
-
+import csv
 from bs4 import BeautifulSoup
 
-ARGUMENT_PARSER = argparse.ArgumentParser()
-ARGUMENT_PARSER.add_argument('--django-version')
-
 DJANGO_HOME = 'https://www.djangoproject.com/'
-DJANGO_DOC_URL = 'https://docs.djangoproject.com/en/{}'
+DJANGO_DOC_URL = 'https://docs.djangoproject.com/en/1.10/ref{}'
 
+INFO = {'download_path': 'download/docs.djangoproject.com/en/1.10/ref', 
+    'doc_base_url': 
+            DJANGO_DOC_URL,
+    'out_file': 'output.txt'}
+HOME_LINK= 'https://docs.djangoproject.com/en/1.10/'
+"""
+This design is based on the python fathead 
+(zeroclickinfo-fathead/lib/fathead/python)
 
-class DjangoData(object):
+"""
+class Data(object):
     """
-    Object responsible for loading raw HTML data for Django Docs
+    Object responsible for loading raw HTML docs:
     """
-
-    def __init__(self, page_name):
+    def __init__(self, file):
         """
-        Initialize DjangoData object. Load data from HTML.
+        Initialize Data object. Load data from HTML.
 
         """
-        self.DJANGO_HTML = ""
-        self.load_data(page_name)
+        self.HTML = ""
+        self.FILE = file
+        self.load_data()
 
-    def load_data(self, page_name):
+    def load_data(self):
         """
         Open the HTML file and load it into the object.
 
         """
-        with open('download/' + page_name, 'r') as data_file:
-            self.DJANGO_HTML = data_file.read()
+        with open(self.FILE, 'r') as data_file:
+            self.HTML = data_file.read()
 
     def get_raw_data(self):
         """
         Returns: The raw HTML that was loaded.
 
         """
-        return self.DJANGO_HTML
+        return self.HTML
 
-
-class DjangoDataParser(object):
-    """
-    Object responsible for parsing the raw HTML that contains Django Docs data
-    """
-
-    def __init__(self, raw_data, section_name, page_url):
+    def get_file_path(self):
         """
-        Given raw data, get the relevant sections
+        Returns: The file path of the file being used.
+
+        """
+        return self.FILE
+
+
+class DataParser(object):
+    """
+    Object responsible for parsing the raw HTML that contains data
+        
+    """
+    
+    """
         Args:
-            raw_data: HTML data
-        """
+            soup_data: BeautifulSoup data object.
+            file_name: file name of object being parsed.
+            info: Information about the document (url).
+            module_pre: If this is a submodule, this contains the parent module.
+    """
+    def __init__(self, soup_data, file_name, info, module_pre=''):
         self.parsed_data = None
-        self.url = page_url
+        self.class_sections = []
+        self.method_sections = []
+        self.intro_text = ''
+        self.module = module_pre
+        self.info = info
+        self.soup_data = soup_data
+        self.file_being_used = file_name
 
-        soup_data = BeautifulSoup(raw_data, 'html.parser')
-        doc_content = soup_data.find('div', {'id': 'docs-content'})
-
-        tags = doc_content.find(
-            'div', {'class': 'section', 'id': section_name})
-        self.tag_sections = tags.find_all('div', {'class': 'section'})
-
-    def parse_name_and_anchor_from_data(self, section, heading_style):
+    def _parse_for_element_name(self, section):
         """
-        Find the name and anchor for a given section
+        Returns the function name
         Args:
-            section: A section of parsed HTML that represents a section
+            section: A section of parsed HTML that represents a function 
+            definition
 
         Returns:
-            name: Name of the Element
-            anchor: Anchor tag to use when linking back to docs (ie #autoescape)
+            Name of function
 
         """
-        name = ''
-        anchor = ''
-        heading = section.find(heading_style)
-        if heading:
-            code = heading.find('code', {'class': 'docutils'})
-            if code:
-                name = code.find('span', {'class': 'pre'}).string
-            a_tag = heading.find('a', {'class': 'headerlink'})
-            if a_tag:
-                anchor = a_tag['href']
+        function_name = section.find('code', {'class': 'descname'}).text
+        return function_name
 
-        return name, anchor
-
-    def parse_first_paragraph_from_data(self, section, pstyle):
+    def _parse_for_first_paragraph(self, section):
         """
-        Get the first paragraph for display
+        Returns the first paragraph of text for a given function
+        Fixes up some weird double spacing and newlines.
         Args:
-            section: A section of parsed HTML that represents a Element
+            section: A section of parsed HTML that represents a function 
+            definition
 
         Returns:
-            First paragraph in the HTML
+            First paragraph found with text
 
         """
-
-        if pstyle == "p":
-            try:
-                return section.find('p').text.replace('\n', ' ')
-            except:
-                return ''
-
-        elif pstyle == "dt":
-            try:
-                dtname = section.find('dt').text.replace('\n', ' ')
-                if "source" in dtname:
-                    dtname = dtname[:-9]
-                elif "¶" in dtname:
-                    dtname = dtname[:-1]
-                return dtname
-
-            except:
-                return ''
-
-    def parse_second_paragraph_from_data(self, section, pstyle):
-        """
-        Get the second paragraph for display
-        Args:
-            section: A section of parsed HTML that represents a Element
-
-        Returns:
-            second paragraph in the HTML
-
-        """
-
-        if pstyle == "p":
-            try:
-                para = section.find_all('p')[1]
-                para = para.text.partition(". ")
-                return ''.join(para[:2]).replace('\n', ' ')
-            except:
-                return ''
-
-        elif pstyle == "dt":
-            para = section.find_all('p')[0]
-            if para:
-                para = para.text.partition(". ")
-                return ''.join(para[:2]).replace('\n', ' ')
-            else:
-                return ''
-
-    def parse_code_from_data(self, section):
-        """
-        Look for an example code block to output
-        Args:
-            section: A section of parsed HTML that represents a section
-
-        Returns:
-            Formatted code string
-        """
-        code = section.find('div', {'class': 'highlight'})
-        if code:
-            return '<pre><code>{}</code></pre>'.format(
-                code.text.replace('\n', '\\n'))
+        paragraphs = section.find_all('p')
+        for paragraph in paragraphs:
+            if paragraph.text:
+                return self._format_output(paragraph.text)
         return ''
 
-    def parse_for_data(self, code_or_second_para, hstyle, pstyle):
+    def _parse_for_anchor(self, section):
         """
-        Main gateway into parsing the data. Will retrieve all necessary data elements.
+        Returns the anchor link to specific function doc
+        Args:
+            section: A section of parsed HTML that represents a function 
+            definition
+
+        Returns:
+            The href value of the link to doc
+
         """
-        parsing_data = []
+        a_tag = section.find('a', {'class': 'headerlink'})
+        if a_tag:
+            return a_tag['href']
+        return ''
 
-        for section in (self.tag_sections):
-            name, anchor = self.parse_name_and_anchor_from_data(
-                section, hstyle)
-            first_paragraph = self.parse_first_paragraph_from_data(
-                section, pstyle)
+    def _parse_for_signature(self, section):
+        """
+        Returns the signature
+        Args:
+            section: A section of parsed HTML that represents a definition of 
+            a class, method or function
 
-            if code_or_second_para == "code":
-                code = self.parse_code_from_data(section)
-                second_paragraph = ''
-            elif code_or_second_para == "para":
-                second_paragraph = self.parse_second_paragraph_from_data(
-                    section, pstyle)
-                code = ''
+        Returns:
+            The signature
+        """
+        contents=[]
+        for e in section.dt.strings:
+            contents.append(e)
+        if contents:
+            del contents[-1]
+            if '[source]' in contents:
+                del contents[-1]
+            signature=''
+            for el in contents:
+                signature+=el
+            return '<pre><code>{}</code></pre>'.format(
+                    self._format_output(signature))
+        return ''
 
-            data_elements = {
-                'name': name,
-                'anchor': anchor,
-                'first_paragraph': first_paragraph,
-                'second_paragraph': second_paragraph,
-                'code': code,
-                'url': self.url
-            }
+    def _create_url(self, anchor):
+        """
+        Helper method to create URL back to document
+        Args:
+            anchor: #anchor
 
-            parsing_data.append(data_elements)
+        Returns:
+            Full URL to function on the doc
 
-        self.parsed_data = parsing_data
+        """
+        file_path = self.file_being_used.replace(
+                    self.info['download_path'], '').replace('/index.html', '')
+        return self.info['doc_base_url'].format('{}/{}'.format(file_path, anchor))
+
+    def parse_for_data(self):
+        """
+        Main gateway into parsing the data. Will retrieve all neccessary data
+        elements.
+        """
+        self.parsed_data = []
+        # Extract intro text
+        first_paragraph=''
+        div_section=soup_data.find('div', {'class': 'section'})
+        if div_section:
+            self._parse_section(div_section, self.module)
 
     def get_data(self):
         """
@@ -196,144 +181,234 @@ class DjangoDataParser(object):
         """
         return self.parsed_data
 
+    def _format_output(self, text):
+        """
+            Helper method to format the output appropriately.
+        """
+        return text.replace('  ', ' ').replace('\n', ' ').replace('\\n', r'\\n')
+    
 
-class DjangoDataOutput(object):
-    """
-    Object responsible for outputting data into the output1.txt file
-    """
+    def _parse_section(self, div_section, module_name):
+        """
+        Helper method to parse section, and recursively go through sub sections
+            Args:
+                div_section: The section div of the module
+                module_name: The name of the module
+            Returns:
+                Nothing - but stores data in the self.parsed_data list.
+        """
+        title_id=div_section.get('id')
+        title_split=title_id.split('-')
+        module_titles=title_split[-1].split('.')
+        # The last item in module_titles is the module for this section
+        # Require that there is a dot in the module title, else, it is
+        # not a sub module - only a sub section in the html document
+        if len(module_titles) > 1:
+            if module_name:
+                module_name=module_name+'.'+module_titles[-1]
+            else:
+                module_name=module_titles[-1]
+        
+        first_paragraph=div_section.find_next('p')
+        intro_text=''
+        if first_paragraph:
+            intro_text = self._format_output(first_paragraph.text)
+            
+        section_anchor=self._parse_for_anchor(div_section)
+        if intro_text and module_name:
+            data_elements = {
+                'module': module_name,
+                'function': '',
+                'method_signature': '',
+                'first_paragraph': intro_text,
+                'url': self._create_url(section_anchor)
+            }
+            self.parsed_data.append(data_elements)   
+        sub_sections = div_section.find_all('div', {'class': 'section'})
+        if sub_sections:
+            for sub_section in sub_sections:
+                # Parse each sub section
+                self._parse_section(sub_section, module_name)
+        # Now, replace all sub sections, that have already been parsed
+        sub_sections = div_section.find_all('div', {'class': 'section'})
+        [ sub_section.replaceWith('') for sub_section in sub_sections ]
+        
 
+        self._parse_section_for_elements(div_section, module_name)
+
+    def _parse_section_for_elements(self, section, module_name):
+        # Extract classes, methods and functions.
+        class_sections=section.find_all('dl', {'class': 'class'})
+        if class_sections: 
+            self._parse_for_elements(class_sections, module_name)           
+        method_sections=section.find_all('dl', {'class': 'method'})
+        if method_sections:
+            self._parse_for_elements(method_sections, module_name)            
+        function_sections=section.find_all('dl', {'class': 'function'})
+        if function_sections:
+            self._parse_for_elements(function_sections, module_name)
+        
+        # Parse for attributes
+        attribute_sections=section.find_all('dl', {'class': 'attribute'})
+        if attribute_sections:
+            self._parse_for_attributes(attribute_sections)
+        
+    def _parse_for_elements(self, sections, module_name):
+        """
+        Method for parsing out classes, methods or function elements from a
+            section. The data will be stored to self.parsed_data
+        Args:  
+            function_sections: The sections to be parsed
+            module_name: The name of the module
+        Returns:
+            nothing, but stores data in self.parsed_data
+        
+        """
+        for section in sections:
+            name=self._parse_for_element_name(section)
+            signature=self._parse_for_signature(section)
+            first_paragraph=self._parse_for_first_paragraph(section)
+            anchor=self._parse_for_anchor(section)
+            data_element = {
+                    'module': module_name,
+                    'function': name,
+                    'method_signature': signature,
+                    'first_paragraph': first_paragraph,
+                    'url': self._create_url(anchor),
+            }
+            self.parsed_data.append(data_element)
+    
+    def _parse_for_attributes(self, attribute_sections):
+        for section in attribute_sections:            
+            name=self._parse_for_element_name(section)        
+            full_class_name = section.dt.get('id')
+            if full_class_name is None:
+                return
+            parts=full_class_name.split('.')
+            del parts[0]
+            del parts[-1]
+            class_name = '.'.join(parts)
+            signature=self._parse_for_signature(section)
+            first_paragraph=self._parse_for_first_paragraph(section)
+            anchor=self._parse_for_anchor(section)
+            data_element = {
+                    'module': class_name,
+                    'function': name,
+                    'method_signature': signature,
+                    'first_paragraph': first_paragraph,
+                    'url': self._create_url(anchor),
+            }
+            self.parsed_data.append(data_element)
+        
+class DataOutput(object):
+    """
+    Object responsible for outputting data into the output.txt file
+    """
     def __init__(self, data):
         self.data = data
+        self.output = INFO['out_file']
+
+    def create_names_from_data(self, data_element):
+        """
+        Figure out the name of the function. Will contain the module name if 
+        one exists.
+        Args:
+            data_element: Incoming data dict
+
+        Returns:
+            Name, with whitespace stripped out
+
+        """
+        module = data_element.get('module')
+        function = data_element.get('function')
+
+        dotted_name = '{}{}{}'.format(module, '.' 
+                                      if module and function  else '', function)
+        spaced_name = '{} {}'.format(module, function)
+        
+
+        return dotted_name.strip(), spaced_name.strip()
 
     def create_file(self):
         """
-        Iterate through the data and create the needed output1.txt file.
+        Iterate through the data and create the needed output.txt file, 
+        appending to file as necessary.
 
         """
-        with open('output1.txt', 'a+') as output_file:
+        with open(self.output, 'a') as output_file:
             for data_element in self.data:
-                if data_element.get('name'):
-                    name = data_element.get('name')
-                    if "()" in name:
-                        name = name[:-2]
-                    code = data_element.get('code')
-                    first_paragraph = '<p>' + \
-                        data_element.get('first_paragraph') + '</p>'
-                    second_paragraph = '<p>' + \
-                        data_element.get('second_paragraph') + '</p>'
-                    abstract = '{}{}{}'.format(
-                        first_paragraph + second_paragraph, '', code)
-                    abstract = '<section class="prog__container">' + abstract + '</section>'
-                    url = '{}{}'.format(data_element.get(
-                        'url'), data_element.get('anchor'))
+                if data_element.get('module') or data_element.get('function'):
+                    method_signature = data_element.get('method_signature')
+                    first_paragraph_text=data_element.get('first_paragraph')
+                    first_paragraph=''
+                    if (first_paragraph_text):
+                        first_paragraph='<p>'
+                        first_paragraph+=first_paragraph_text
+                        first_paragraph+='</p>'
+
+                    name, redirect = self.create_names_from_data(data_element)
+
+                    abstract='<section class="prog__container">'
+                    abstract+='{}{}{}'.format(first_paragraph,
+                                                '' , 
+                                                method_signature)
+                    abstract+='</section>'
+                    url = data_element.get('url')
                     list_of_data = [
-                        name,       # unique name will be the name of the element
-                        'A',        # type is article
-                        '',         # no redirect data
-                        '',         # ignore
-                        '',         # no categories
-                        '',         # ignore
-                        '',         # no related topics
-                        '',         # ignore
-                        DJANGO_HOME,  # add an external link back to Django home
-                        '',         # no disambiguation
-                        '',         # images
-                        abstract,   # abstract
-                        url         # url to doc
+                        name,                       # unique name
+                        'A',                        # type is article
+                        '',                         # no redirect data
+                        '',                         # ignore
+                        '',                         # no categories
+                        '',                         # ignore
+                        '',                         # no related topics
+                        '',                         # ignore
+                        HOME_LINK,                  # add an external link back to react native home
+                        '',                         # no disambiguation
+                        '',                         # images
+                        abstract,                   # abstract
+                        url                         # url to doc
                     ]
                     output_file.write('{}\n'.format('\t'.join(list_of_data)))
 
+                    # Add redirect if we got a redirect name that is different from the original name
+                    if redirect != name:
+                        list_of_data = [
+                            redirect,                   # unique name
+                            'R',                        # type is redirect
+                            name,                       # redirect alias, to the original data
+                            '',                         # ignore
+                            '',                         # no categories
+                            '',                         # ignore
+                            '',                         # no related topics
+                            '',                         # ignore
+                            '',                         # no external link
+                            '',                         # no disambiguation
+                            '',                         # images
+                            '',                         # no abstract
+                            ''                          # no url
+                        ]
+                        output_file.write('{}\n'.format('\t'.join(list_of_data)))
+
+
+def cleanup(out_file):
+    """
+    Cleanup output.txt's files.  Mostly for use during local dev/testing.
+    """
+    if os.path.isfile(out_file):
+        os.remove(out_file)
+
 
 if __name__ == "__main__":
-    args = ARGUMENT_PARSER.parse_args()
-    if args.django_version:
-        DJANGO_DOC_URL = DJANGO_DOC_URL.format(args.django_version)
-    else:
-        DJANGO_DOC_URL = DJANGO_DOC_URL.format('1.10')
-
-    """
-    The Complete Page Structure to be scrapped
-        name: Downloaded file name
-        sections: Sections in page
-        code_or_second_para: Whether to get code or second_paragraph
-        hstyle: heading attribute for the element
-        pstyle: para attribute for the description
-    """
-    page_structure = [
-        {"Name": 'contrib.html', "Sections": ['s-contrib-packages'],
-         "Url": '/ref/contrib/', "code_or_second_para": "para", "hstyle": "h2", "pstyle": "p"},
-
-        {"Name": 'django-admin.html', "Sections": ['s-available-commands'],
-         "Url": '/ref/django-admin/', "code_or_second_para": "para", "hstyle": "h3", "pstyle": "dt"},
-
-        {"Name": 'django-admin.html', "Sections": ['s-commands-provided-by-applications'],
-         "Url": '/ref/django-admin/', "code_or_second_para": "para", "hstyle": "h4", "pstyle": "dt"},
-
-        {"Name": 'exceptions.html', "Sections": ['s-module-django.core.exceptions', 's-url-resolver-exceptions', 's-http-exceptions', 's-transaction-exceptions'],
-         "Url": '/ref/exceptions/', "code_or_second_para": "para", "hstyle": "h3", "pstyle": "dt"},
-
-        {"Name": 'form_fields.html', "Sections": ['s-core-field-arguments'],
-         "Url": '/ref/forms/fields/', "code_or_second_para": "para", "hstyle": "h3", "pstyle": "p"},
-
-        {"Name": 'widgets.html', "Sections": ['s-built-in-widgets'],
-         "Url": '/ref/forms/widgets/', "code_or_second_para": "para", "hstyle": "h4", "pstyle": "p"},
-
-        {"Name": 'builtins.html', "Sections": ['s-built-in-tag-reference', 's-built-in-filter-reference'],
-         "Url": '/ref/templates/builtins/', "code_or_second_para": "code", "hstyle": "h3", "pstyle": "p"},
-
-        {"Name": 'settings.html', "Sections": ['s-core-settings', 's-auth', 's-messages', 's-sessions', 's-sites', 's-static-files'],
-            "Url":'/ref/settings/', "code_or_second_para":"para", "hstyle":"h3", "pstyle":"p"},
-
-        {"Name": 'validators.html', "Sections": ['s-built-in-validators'],
-         "Url":'/ref/validators/', "code_or_second_para":"para", "hstyle":"h3", "pstyle":"p"},
-
-        {"Name": 'urlresolvers.html', "Sections": ['s-module-django.urls'],
-         "Url":'/ref/urlresolvers/', "code_or_second_para":"para", "hstyle":"h2", "pstyle":"p"},
-
-        {"Name": 'urls.html', "Sections": ['s-module-django.conf.urls'],
-         "Url":'/ref/urls/', "code_or_second_para":"para", "hstyle":"h2", "pstyle":"p"},
-
-        {"Name": 'database-functions.html', "Sections": ['s-module-django.db.models.functions'],
-         "Url":'/ref/models/database-functions/', "code_or_second_para":"para", "hstyle":"h2", "pstyle":"p"},
-
-        {"Name": 'fields.html', "Sections": ['s-module-django.db.models.fields'],
-         "Url":'/ref/models/fields/', "code_or_second_para":"para", "hstyle":"h3", "pstyle":"p"},
-
-        {"Name": 'migration-operations.html', "Sections": ['s-schema-operations', 's-special-operations'],
-         "Url":'/ref/migration-operations/', "code_or_second_para":"para", "hstyle":"h3", "pstyle":"dt"},
-
-    ]
-
-    for page in page_structure:
-        data = DjangoData(page["Name"])
-
-        page_url = '{}{}'.format(DJANGO_DOC_URL, page["Url"])
-
-        parser = []
-        for section_name in page["Sections"]:
-            parser.append(DjangoDataParser(
-                data.get_raw_data(), section_name, page_url))
-
-            for parsed in parser:
-                parsed.parse_for_data(page["code_or_second_para"], page[
-                                      "hstyle"], page["pstyle"])
-                output = DjangoDataOutput(parsed.get_data())
+    cleanup('output.txt')
+    for dir_path, dir_name, file_names in os.walk(INFO['download_path']):
+        for file_name in file_names:
+            if '.html' in file_name:
+                print("Processing %s/%s " % (dir_path, file_name))
+                file_path = '/'.join((dir_path, file_name))
+                data = Data(file_path)
+                soup_data = BeautifulSoup(data.get_raw_data(), 'html.parser')
+                parser = DataParser(soup_data, data.get_file_path(), INFO)
+                parser.parse_for_data()
+                output = DataOutput(parser.get_data())
                 output.create_file()
-
-
-
-    # Removing duplicate entries...
-    Dat = []
-    with open('output1.txt', 'r') as file:
-        for line in file:
-            Dat.append(line)
-
-    with open("output.txt", 'w') as file:
-        for i in range(len(Dat)-1):
-            l = Dat[i].split('\t', 1)[0]
-            l2 = Dat[i+1].split('\t', 1)[0]
-            if l != l2:
-                file.write(Dat[i])
-        file.write(Dat[len(Dat)-1])
-
-    os.remove("output1.txt")

--- a/lib/fathead/django/parse.py
+++ b/lib/fathead/django/parse.py
@@ -91,11 +91,10 @@ class DataParser(object):
 
     def _parse_for_first_paragraph(self, section):
         """
-        Returns the first paragraph of text for a given function
+        Returns the first paragraph of text for a given section
         Fixes up some weird double spacing and newlines.
         Args:
-            section: A section of parsed HTML that represents a function 
-            definition
+            section: A section of parsed HTML that represents a section
 
         Returns:
             First paragraph found with text
@@ -105,6 +104,25 @@ class DataParser(object):
         for paragraph in paragraphs:
             if paragraph.text:
                 return self._format_output(paragraph.text)
+        return ''
+    
+    def _parse_for_first_element_paragraph(self, section):
+        """
+        Returns the first paragraph of text for a given element section
+        Fixes up some weird double spacing and newlines.
+        Args:
+            section: A section of parsed HTML that represents an element 
+            definition
+
+        Returns:
+            First paragraph found with text
+
+        """
+        id=section.dt.get('id')
+        # The first paragraph is outside of the section for elements
+        paragraph=section.parent.find('dt', {'id': id}).find_next('p')
+        if paragraph and paragraph.text:
+            return self._format_output(paragraph.text)
         return ''
 
     def _parse_for_anchor(self, section):
@@ -213,7 +231,6 @@ class DataParser(object):
         intro_text=''
         if first_paragraph:
             intro_text = self._format_output(first_paragraph.text)
-            
         section_anchor=self._parse_for_anchor(div_section)
         if intro_text and module_name:
             data_elements = {
@@ -267,7 +284,8 @@ class DataParser(object):
         for section in sections:
             name=self._parse_for_element_name(section)
             signature=self._parse_for_signature(section)
-            first_paragraph=self._parse_for_first_paragraph(section)
+            first_paragraph=self._parse_for_first_element_paragraph(section)
+            
             anchor=self._parse_for_anchor(section)
             data_element = {
                     'module': module_name,

--- a/lib/fathead/django/parse.sh
+++ b/lib/fathead/django/parse.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 rm -f output.txt
-python3 parse.py --django-version 1.10
+python3 parse.py
+python3 redirect.py
+
+sort -u -t$'\t' -k1,1 < output2.txt > output_sorted.txt
+mv output_sorted.txt output.txt
+cat output.txt | ./output_statistics.awk

--- a/lib/fathead/django/redirect.py
+++ b/lib/fathead/django/redirect.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import copy
+import itertools
+import re
+
+bad_strings = ['\\000', '\\xe0']
+
+class BadEntryException(Exception):
+    """
+    Thrown when entry data is invalid
+    """
+    pass
+
+
+class Entry(object):
+    """
+    Represents a single entry in fathead output.txt datafile
+    """
+    def __init__(self, obj):
+        # Type of entry. R = Redirect, A = Article, D = Disambiguation
+        self.entry_type = ''
+
+        # Unique key
+        self.key = ''
+
+        # Referenced entry key (only for redirects)
+        # i.e. the redirect target
+        self.reference = ''
+        self.abstract = ''
+        self.anchor = ''
+
+        self.category = ''
+        self.related = ''
+
+        # Alternative keys used for redirects
+        self.alternative_keys = []
+        self.parse(obj)
+
+    def __str__(self, obj):
+        return self.alternative_keys
+
+    def parse(self, input_obj):
+        """
+        Try to parse given input into a valid entry.
+        Args:
+            input_obj: TSV string or list of data.
+
+        Returns:
+            List of data
+        Raises:
+            Throws BadEntryException if data is invalid.
+        """
+        if isinstance(input_obj, str):
+            processed = input_obj.split('\t')
+            self.data = processed
+        elif isinstance(input_obj, list):
+            self.data = input_obj
+        try:
+            self.key = self.data[0].strip()
+            self.entry_type = self.data[1].strip()
+            self.reference = self.data[2].strip()
+            if len(self.data) > 3:
+                self.category = self.data[4].strip()
+                self.related = self.data[6].strip()
+                self.abstract = self.data[11].strip()
+                self.anchor = self.data[12].strip()
+        except Exception as e:
+            raise BadEntryException('Article had invalid number of elements.')
+
+        if self.entry_type == 'A':
+            self.parse_alternative_keys()
+
+        return self.data
+
+    def parse_alternative_keys(self):
+        """
+        Find alternative keys to use in generated redirects
+
+        Returns:
+            Set of possible redirect entries
+        """
+        self.alternative_keys = set()
+
+        if '.' in self.key and self.entry_type == 'A':
+            key_arr = self.key.split('.')
+            method_name = key_arr[-1]
+            key_arr_len = len(key_arr)
+
+            # always add method name as a key
+            self.alternative_keys.add(method_name)
+
+            # add all permutations of package and class
+            if key_arr_len >= 3:
+
+                for l in range(key_arr_len-1):
+                    permutations = itertools.permutations(key_arr[:key_arr_len-1], l+1)
+
+                    for k in permutations:
+                        new_key = "{} {}".format(' '.join(k), method_name)
+                        self.alternative_keys.add(new_key)
+            else:
+                package_name = key_arr[0]
+                new_key = "{} {}".format(package_name, method_name)
+                self.alternative_keys.add(new_key)
+
+        return self.alternative_keys
+
+    def get_data(self):
+        return self.data
+
+    def get_key(self):
+        return self.key
+
+    def set_entry_type(self, new_type):
+        self.entry_type = new_type
+        
+    def get_related(self):
+        return self.related
+    
+    def set_related(self, new_related):
+        self.related = new_related
+
+    def get_type(self):
+        return self.entry_type
+
+    def get_redirects(self):
+        redirs = []
+        for alt_key in list(self.alternative_keys):
+            entry = Entry([
+                    alt_key,
+                    'R',
+                    self.key
+                ])
+            redirs.append(entry)
+
+        return redirs
+
+    def get_alternatives(self):
+        return self.alternative_keys
+
+    def get_abstract(self):
+        return self.abstract
+    
+    def get_reference(self):
+        return self.reference
+
+    def get_entry(self):
+        return '\t'.join([
+            self.key,             # title / key
+            self.entry_type,      # entry type
+            self.reference,       # no redirect data
+            '',                   # ignore
+            self.category,        # categories
+            '',                   # ignore
+            self.related,         # related topics
+            '',                   # ignore
+            '',                   # add an external link back to page
+            '',                   # no disambiguation
+            '',                   # images
+            self.abstract,        # abstract
+            self.anchor           # anchor to specific section
+        ])
+
+    def __str__(self):
+        return self.get_entry()
+
+def generate_redirects(f):
+    output = dict()
+
+    # For debugging purposes
+    duplicate_count = 0
+    nbr_of_disambiguations = 0
+    # First, add all articles to output, so that package names are 
+    # already in output to be able to correctly generate related articles
+    for line in f.readlines():
+        try:
+            # Parse entry
+            entry = Entry(line)
+            key = entry.get_key()
+                
+            # Ignore redirects from parse.py, generate them in 
+            # get_redirects instead.
+            if entry.get_type() == 'R':
+                continue               
+
+            # Do we have the entry yet?
+            if key not in output:
+                output[key] = str(entry)
+                
+        except BadEntryException as e:
+            pass  # Continue execution entry data is invalid.
+    
+    # Now, go through all articles we have in output, and generate related 
+    # fields, redirects etc. Store them in sets, so that any 
+    # redirect/disambiguation only appear once in the field
+    related_fields = dict()
+    disambiguations = dict()
+    # Need to deepcopy the iterator items, because output will change in 
+    # the loop
+    iterator_items = copy.deepcopy(output).keys()
+    for key in iterator_items:
+        entry = Entry(output[key])
+        split_key = key.split('.')
+        package_name = '.'.join(split_key[0:len(split_key)-1])
+
+        if package_name in output \
+            and output[package_name].startswith(package_name + '\t' + 'A'):
+            #Add related links to this entry to the package entry
+            if package_name not in related_fields:
+                related_fields_for_article = set()
+                related_fields_for_article.add(key)
+                related_fields[package_name] = related_fields_for_article
+            else:
+                related_fields[package_name].add(key)
+
+        # Get all possible redirect entries
+        key_length = len((re.findall(r"[\w']+", key)))
+        if key_length > 1:
+            redirects = entry.get_redirects()
+            for redirect in redirects:
+                redirect_key = redirect.get_key()
+                redirect_entry = redirect.get_entry()
+                if redirect_key not in output:
+                    output[redirect_key] = str(redirect_entry)
+                elif str(output[redirect_key]) != str(redirect_entry):
+                    #Create a disambiguation
+                    if output[redirect_key].startswith(redirect_key + '\tR'):
+                        current_entry = Entry(output[redirect_key])
+                        #Replace the existing redirect with a disambiguation
+                        output[redirect_key] = str(redirect_key) + '\t' + 'D' +'\t\t\t\t\t\t\t\t'
+                        # Add the redirect currently in output to the disambigutions
+                        current_entry_article_redirect_target = Entry(output[current_entry.get_reference()])
+                        disambiguation_for_this_key = set()
+                        disambiguation_for_this_key.add((str(current_entry.get_reference()),
+                                                         str(current_entry_article_redirect_target.get_abstract())))
+                        # Add the redirect this line wanted to add to the disambigutions
+                        article_redirect_target = Entry(output[redirect.get_reference()])
+                        disambiguation_for_this_key.add((str(redirect.get_reference()),
+                                                        str(article_redirect_target.get_abstract())))
+                        disambiguations[redirect_key] = disambiguation_for_this_key
+                        duplicate_count += 1
+                        nbr_of_disambiguations += 1
+                    elif output[redirect_key].startswith(redirect_key + '\tD'):
+                        # Another disambiguation detected, append it to the entry
+                        disambiguations[redirect_key].add((str(redirect.get_reference()),
+                                                        str(article_redirect_target.get_abstract())))
+                        duplicate_count += 1
+
+    # Now, we add the related fields and disambiguations to output
+    for key, related_fields_set in related_fields.items():
+        output_entry = Entry(output[key])
+        related = ''
+        for r in related_fields_set:
+            if related != '':
+                related += '\\\\n'
+            related += '[[' + str(r) + ']]'
+        output_entry.set_related(related)
+        output[key] = output_entry.get_entry()
+        
+    for key, disambiguations_set in disambiguations.items():
+        disambiguation_str = ''
+        for disambiguation_key, abstract in disambiguations_set:
+            disambiguation_entry_str = ''
+            if disambiguation_str != '':
+                disambiguation_entry_str += '\\n'
+            disambiguation_entry_str += '*' + '[['+disambiguation_key+']] '
+            disambiguation_entry_str += abstract
+            disambiguation_str += disambiguation_entry_str
+        # Disambiguation field is third last, need to add tabs to the end to
+        # get a valid entry
+        output[key] += disambiguation_str + "\t\t\t"
+        
+    print("Duplicates: %s" % duplicate_count)
+    print("Disambiguations: %s" % nbr_of_disambiguations)
+
+    with open('output2.txt', 'w') as output_file:
+        for key, line in output.items():
+            if line.endswith('\\n'):
+                line = line[:-2]
+                line += '\t\t\t'
+            line = bad_string_check(line)
+            tsv = '{}\n'.format(line)
+            output_file.write(tsv)
+
+def bad_string_check(line):
+    for string in bad_strings:
+        if string in line:
+            replacement = '\\' + string
+            line = line.replace(string, replacement)
+    return line
+
+if __name__ == "__main__":
+    # Open output file for reading and writing.
+    with open('output.txt', 'r+') as output_file:
+        generate_redirects(output_file)


### PR DESCRIPTION
    * Sort output uniquely.
        The original output had 1101 lines. Now the unique output shows that
        only 359 entries were actually unique.

    * Download all sources, not specific pages.

    * Parsing module names, functions, methods and attributes.

    * Add redirect.py and sort properly and uniquely.

    * Add output_statistics.awk

    * Add output.txt.

<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
This is a complete rework of the fathead, and adds a lot of articles and a huge amount of redirects.

One con is that the [django allowed_hosts](https://duckduckgo.com/?q=Django+allowed_hosts&ia=about) query and other queries for settings will not work. I could look into that, if it is necessary.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #766 


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@pjhampton 

## Testing & Review
To be completed by Language Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [x] Title follows correct format (Specifies Instant Answer + Purpose)
- [x] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [x] Instant Answer page is correctly filled out and contains:
    - One topic for the Search Space Language (Java, Python, Scala, Ruby, etc.)
    - One topic from: Reference, Help, Libraries, Tools
        - Documentation Fatheads are considered "Reference"
    - Description, Data source, and 2+ example queries
    - Perl Module (e.g. "DDG::Fathead::PerlDoc" -- we only need a name, not an actual file)
    - Source Name (for "More at <source_name>" link)
    - Source Domain (must contain http:// or https:// -- can be the same as Data Source)
    - Source Info (used as Subtitle for each Article -- usually matches the IA Name)
    - 'Skip Abstract' is checked off
    - Source ID (ping @moollaza to assign one, once Fathead is ready for Beta deploy)

**Code**
- [ ] Uniformly indented, well commented
- [ ] Fetch.sh and Parse.sh run without errors
- [ ] Output contains no blank lines, or multi-line entries
- [ ] Fathead Tests are passing (run `$ duckpan test <fathead_id>`)
    - Tester should report any failures

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/django
<!-- FILL THIS IN:                           ^^^^ -->
