### PR TITLE
cppreference_doc: Commit parsing scripts to this repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ share/fathead/meta/metadata.json
 # Ignore plugin-generated files and directories.
 download
 zeroclickinfo-fathead.iml
+__pycache__

--- a/lib/fathead/cppreference_doc/README.md
+++ b/lib/fathead/cppreference_doc/README.md
@@ -1,7 +1,8 @@
 Cppreference Fathead
 ===========================
 
-This is a Fathead for C++ standard library reference manual hosted at http://en.cppreference.com.
+This is a Fathead for C++ standard library reference manual hosted at
+http://en.cppreference.com.
 
 Data Source
 -----------
@@ -19,9 +20,18 @@ is updated by linking to the most recent cppreference archive that someone
 actually tested to work, to ensure that the Fathead functionality does not
 accidentally break when new cppreference archives are released.
 
-The parsing script [index2ddg.py](https://github.com/p12tic/cppreference-doc/blob/master/index2ddg.py)
-as well as other required scripts are present in the [cppreference-doc repository](https://github.com/p12tic/cppreference-doc).
-Changes can be made by sending a pull request to this repository.
+Parse script
+--------------
+
+The parse scripts are located in cppreference-doc subdirectory. They were
+originally maintained in the [cppreference-doc repository](https://github.com/p12tic/cppreference-doc),
+but was copied here to simplify the process of the parse script development.
+
+The scripts still implicitly depend on the contents and the format of the
+archives that are uploaded to the cppreference.com website. Therefore, the
+scripts should be occasionally synchronized between the repositories. Please
+submit a PR to the cppreference-doc repository with any changes that land here
+first.
 
 Dependencies
 ------------

--- a/lib/fathead/cppreference_doc/cppreference-doc/build_link_map.py
+++ b/lib/fathead/cppreference_doc/cppreference-doc/build_link_map.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+#   Copyright (C) 2012  Povilas Kanapickas <povilas@radix.lt>
+#
+#   This file is part of cppreference-doc
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see http://www.gnu.org/licenses/.
+
+# This file examines all html files in the output directory and writes
+# filename -> title mapping to a xml file.
+
+import fnmatch
+import lxml.etree as e
+import re
+import os
+from link_map import LinkMap
+
+# returns a dict { title -> filename }.
+# directory - either 'output/reference' or 'reference'
+def build_link_map(directory):
+    # find all html files
+    html_files = []
+    for root, dirnames, filenames in os.walk(directory):
+        for filename in fnmatch.filter(filenames, '*.html'):
+            html_files.append(os.path.join(root, filename))
+
+    link_map = LinkMap()
+
+    for fn in sorted(html_files):
+        f = open(fn, "r", encoding='utf-8')
+        text = f.read()
+        f.close()
+
+        m = re.search('<script>[^<]*mw\.config\.set([^<]*wgPageName[^<]*)</script>', text)
+        if not m:
+            continue
+        text = m.group(1)
+        text = re.sub('\s*', '', text)
+        m = re.search('"wgPageName":"([^"]*)"', text)
+        if not m:
+            continue
+
+        title = m.group(1)
+
+        target = os.path.relpath(os.path.abspath(fn), os.path.abspath(directory))
+        link_map.add_link(title, target)
+    return link_map
+
+def main():
+    link_map = build_link_map('output/reference')
+
+    # create an xml file containing mapping between page title and actual location
+    link_map.write('output/link-map.xml')
+
+if __name__ == "__main__":
+    main()

--- a/lib/fathead/cppreference_doc/cppreference-doc/ddg_parse_html.py
+++ b/lib/fathead/cppreference_doc/cppreference-doc/ddg_parse_html.py
@@ -1,0 +1,390 @@
+ #!/usr/bin/env python3
+'''
+    Copyright (C) 2013  Povilas Kanapickas <povilas@radix.lt>
+
+    This file is part of cppreference-doc
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+'''
+
+import lxml.etree as e
+import re
+from copy import deepcopy
+
+class DdgException(Exception):
+    pass
+
+''' Returns the element in which the content is stored.
+'''
+def get_content_el(root_el):
+    try:
+        return root_el.xpath('''/html/body/div[@id="cpp-content-base"]
+                            /div[@id="content"]
+                            /div[@id="bodyContent"]
+                            /div[@class="mw-content-ltr"]''')[0]
+    except:
+        raise DdgException("Could not find content element")
+
+VERSION_C89 = 0
+VERSION_C99 = 1
+VERSION_C11 = 2
+VERSION_CXX98 = 100
+VERSION_CXX03 = 101
+VERSION_CXX11 = 102
+VERSION_CXX14 = 103
+
+''' Returns the declaration of the feature with name 'name'.
+    If several declarations with the same name are present, and entries
+    superseded in the later standards (as determined by the presence of until
+    XXX marker) are ignored. The rest of declarations are returned as a list of
+    tuples, each of which the two elements:
+        1) the code of the declaration
+        2) the version as defined by the 'num' dcl template parameter, or None
+           if no version was specified.
+
+    If no declaration is found, an exception of type DdgException is raised
+'''
+def get_declarations(root_el, name):
+    content_el = get_content_el(root_el)
+
+    dcl_tables = content_el.xpath('table[contains(@class, "t-dcl-begin")]')
+    if len(dcl_tables) == 0:
+        raise DdgException("dcl table not found")
+
+    dcl_table = dcl_tables[0]
+
+    dcls = []
+    ignored = False
+    for dcl in dcl_table.xpath('tbody/tr[contains(@class, "t-dcl")]'):
+        code_els = dcl.xpath('td[1]/div/span[contains(@class, "mw-geshi")]')
+        if len(code_els) == 0:
+            ignored = True
+            continue
+
+        code = code_els[0].text_content()
+        code = re.sub('\n+', '\n', code)
+
+        # skip entries that don't contain name
+        if re.search('[^a-zA-Z0-9_]' + re.escape(name) + '[^a-zA-Z0-9_]',
+                     code) == None:
+            ignored = True
+            continue
+
+        # skip deleted functions
+        if re.search('=\s*delete\s*;', code) != None:
+            ignored = True
+            continue
+
+        # ignore superseded entries
+        std_rev_els = dcl.xpath('td[3]/span[contains(@class, "t-mark")]')
+        if len(std_rev_els) != 0:
+            txt = std_rev_els[0].text_content().lower()
+            if txt.find('until') != -1:
+                ignored = True
+                continue
+
+        version = None
+        try:
+            version_str = dcl.xpath('td[2]')[0].text_content()
+            version_str = re.search('\((\d*)\)', version_str).group(1)
+            version = int(version_str)
+        except:
+            pass
+
+        dcls.append((code, version))
+
+    if len(dcls) == 0:
+        if not ignored:
+            raise DdgException("dcl table contains no declarations")
+        else:
+            raise DdgException("All entries in dcl table were ignored")
+
+    return dcls
+
+def del_all_attrs(el):
+    for key in el.attrib:
+        del el.attrib[key]
+
+def iterate_top_text(text, on_text=None):
+    last_close = 0
+    open_count = 0
+
+    for match in re.finditer('(<code>|</code>|<i>|</i>|<b>|</b>)', text):
+        if match.group(1)[1] != '/':
+            if open_count == 0:
+                on_text(last_close, text[last_close:match.start()])
+            open_count += 1
+
+        else:
+            open_count -= 1
+            if open_count == 0:
+                last_close = match.start() + len(match.group(1))
+
+    if open_count == 0:
+        on_text(last_close, text[last_close:])
+
+def remove_parentheses(desc, max_paren_text_size):
+
+    open_paren_count = 0
+    last_paren_open = 0
+
+    del_ranges = []
+
+    def on_text(pos, text):
+        nonlocal open_paren_count, last_paren_open, del_ranges
+        for match in re.finditer('(\(|\))', text):
+            gr = match.group(1)
+            if gr == '(':
+                if open_paren_count == 0:
+                    last_paren_open = pos + match.start()
+                open_paren_count += 1
+            else:
+                open_paren_count -= 1
+                if open_paren_count == 0:
+                    end = pos + match.start()+1
+
+                    if end - last_paren_open > max_paren_text_size:
+                        del_ranges.append((last_paren_open, end))
+
+                    if last_paren_open >= pos:
+                        if text.find('ᚃ') != -1 or text.find('ᚄ') != -1:
+                            del_ranges.append((last_paren_open, end))
+
+    for r in reversed(del_ranges):
+        begin,end = r
+        desc = desc[:begin] + desc[end:]
+    return desc
+
+def split_sentences(desc):
+
+    sentences = []
+
+    sentence_start_pos = 0
+
+    def on_text(pos, text):
+        nonlocal sentence_start_pos
+        dot_pos = text.find('.')
+        if dot_pos != -1:
+            dot_pos += pos
+            sentences.append(desc[sentence_start_pos:dot_pos+1])
+            sentence_start_pos = dot_pos+1
+
+    iterate_top_text(desc, on_text)
+
+    if len(desc[sentence_start_pos:].strip()) > 0:
+        sentences.append(desc[sentence_start_pos:])
+
+    return sentences
+
+def remove_punctuation_at_end(sentence):
+    return sentence.rstrip(' .,:;')
+
+def trim_single_sentence_at_word(sentence, max_chars):
+
+    last_valid_chunk = None
+    last_valid_chunk_pos = 0
+
+    def on_text(pos, text):
+        nonlocal last_valid_chunk, last_valid_chunk_pos
+        if pos <= max_chars:
+            last_valid_chunk = text
+            last_valid_chunk_pos = pos
+
+    iterate_top_text(sentence, on_text)
+
+    # split only single top-level chunk
+    words = last_valid_chunk.split(' ')
+    last_word = 0
+    curr_pos = last_valid_chunk_pos
+    for i, word in enumerate(words):
+        curr_pos += len(word) + 1
+        if curr_pos > max_chars:
+            break
+        last_word = i
+
+    last_valid_chunk = ' '.join(words[:last_word+1])
+
+    return sentence[:last_valid_chunk_pos] + last_valid_chunk
+
+def trim_single_sentence(text, max_chars):
+    if len(text) <= max_chars:
+        return text
+
+    # If the sentence is longer than the limit, then try to cut desc at "i.e."
+    # if present. Otherwise, cut desc in the middle of the sentence, preferably
+    # at the end of a word
+
+    #find the first match
+    ie_pos = None
+
+    def on_ie_text(pos, match_text):
+        nonlocal ie_pos
+        m = next(re.finditer('[ᚃᚄ]', match_text), None)
+        if m is not None and ie_pos is None:
+            ie_pos = pos + m.start()
+
+    iterate_top_text(text, on_ie_text)
+
+    if ie_pos is not None:
+        if ie_pos <= 2:
+            return ''
+
+        if ie_pos > max_chars:
+            text = trim_single_sentence_at_word(text, max_chars)
+        else:
+            text = text[:ie_pos]
+
+        return remove_punctuation_at_end(text) + '...'
+
+    text = trim_single_sentence_at_word(text, max_chars)
+    return remove_punctuation_at_end(text) + '...'
+
+''' Processes description text. Drops all tags except <code> and <i>. Replaces
+    <b> with <i>. Replaces span.mw-geshi with <code>. Returns the processed
+    description as str.
+
+    The description is limited to max_sentences number of sentences and
+    max_chars number of characters (each delimited by a dot).
+    If a single sentence is longer than max_chars characters, '...' is appended.
+
+    Setting max_paren_text_size to controls the maximum number of characters in
+    parenthesized text. If the size of parenthesized block exceeds that, it is
+    removed. Such blocks within <code>, <b> or <i> tag are ignored.
+'''
+def process_description(el, max_sentences, max_chars,
+                        max_paren_text_size, debug=False):
+
+    el = deepcopy(el)   # we'll modify the tree
+    el.tag = 'root'
+    del_all_attrs(el)
+
+    for t in el.xpath('.//span[contains(@class, "mw-geshi")]'):
+        t.tag = 'code'
+
+    for t in el.xpath('.//*'):
+        if t.tag in ['code', 'i', 'b']:
+            del_all_attrs(t)
+        else:
+            t.drop_tag()
+    desc = e.tostring(el, method='html', encoding=str, with_tail=False)
+    desc = desc.replace('<root>','').replace('</root>','')
+    if debug:
+        print("ROOT: " + desc)
+
+    # description must never contain newlines
+    desc = desc.replace('\n',' ')
+
+    # Handle 'i.e.' and 'that is' as a special case
+    desc = desc.replace('i.e.', 'ᚃ')
+    desc = desc.replace('that is,', 'ᚄ')
+
+    # process the description:
+    # remove text in parentheses (except when it's within some tag)
+    # get the position of the cut of the description
+
+    open_count = 0
+    open_paren_count = 0
+
+    desc = remove_parentheses(desc, max_paren_text_size)
+    sentences = split_sentences(desc)
+
+    # limit sentence count
+    if len(sentences) > max_sentences:
+        sentences = sentences[:max_sentences]
+
+    # coarse character limit
+    char_count = 0
+    last_sentence = len(sentences)
+    for i, s in enumerate(sentences):
+        char_count += len(s)
+        if char_count > max_chars:
+            last_sentence = i+1
+            break
+    sentences = sentences[:last_sentence]
+
+    # trim the single sentence if needed
+    if char_count > max_chars and len(sentences) == 1:
+        sentences[0] = trim_single_sentence(sentences[0], max_chars)
+    else:
+        if sentences[-1].rstrip()[-1] != '.':
+            sentences[-1] = remove_punctuation_at_end(sentences[-1]) + '...'
+
+    desc = '\n'.join(sentences)
+    desc = desc.replace('ᚃ', 'i.e.')
+    desc = desc.replace('ᚄ', 'that is,')
+
+    return desc
+
+''' Returns a short description of a feature. This is the first sentence after
+    the declaration (dcl template). If a list follows immediately, then the
+    description is picked from a list item identified by num
+
+    Raises DdgException on error
+'''
+def get_short_description(root_el, num, max_sentences=1, max_chars=200,
+                          max_paren_text_size=40, debug=False):
+
+    content_el = get_content_el(root_el)
+
+    dcl_tables = content_el.xpath('table[@class="t-dcl-begin"]')
+    if len(dcl_tables) == 0:
+        raise DdgException("No dcl table found")
+        #todo debug
+
+    dcl_table = dcl_tables[0]
+
+    desc_el = dcl_table.getnext()
+
+    if desc_el == None:
+        raise DdgException("No elements after dcl table")
+
+    if desc_el.tag == 'p':
+        return process_description(desc_el, max_sentences, max_chars,
+                                   max_paren_text_size, debug=debug)
+    elif desc_el.tag == 'div' and desc_el.get('class') == 't-li1':
+        if num == None:
+            raise DdgException("Versioned summary with no version supplied")
+
+        while (desc_el != None and desc_el.tag == 'div' and
+            desc_el.get('class') == 't-li1'):
+            index_els = desc_el.xpath('span[@class="t-li"]')
+            if len(index_els) == 0:
+                desc_el = desc_el.getnext()
+                continue
+            index_el = index_els[0]
+            index = e.tostring(index_el, encoding=str,
+                               method='text', with_tail=False)
+
+            m = re.match('^\s*(\d+)\)\s*$', index)
+            if m and int(m.group(1)) == num:
+                index_el.drop_tree()
+                return process_description(desc_el, max_sentences, max_chars,
+                                           max_paren_text_size, debug=debug)
+
+            m = re.match('^\s*(\d+)-(\d+)\)\s*$', index)
+            if m and int(m.group(1)) <= num and int(m.group(2)) >= num:
+                index_el.drop_tree()
+                return process_description(desc_el, max_sentences, max_chars,
+                                           max_paren_text_size, debug=debug)
+
+            m = re.match('^\s*(\d+),(\d+)\)\s*$', index)
+            if m and num in [int(m.group(1)), int(m.group(2))]:
+                index_el.drop_tree()
+                return process_description(desc_el, max_sentences, max_chars,
+                                           max_paren_text_size, debug=debug)
+
+            desc_el = desc_el.getnext()
+        raise DdgException("List items are not numbered")
+
+    raise DdgException("No description found")

--- a/lib/fathead/cppreference_doc/cppreference-doc/index2ddg.py
+++ b/lib/fathead/cppreference_doc/cppreference-doc/index2ddg.py
@@ -462,6 +462,9 @@ def main():
     parser = argparse.ArgumentParser(prog='index2ddg.py')
     parser.add_argument('index', type=str,
                         help='The path to the XML index containing identifier data')
+    parser.add_argument('reference', type=str,
+                        help=('The path to the downloaded reference (reference '
+                              'directory in the downloaded archive)'))
     parser.add_argument('output', type=str,
                         help='The path to destination output.txt file')
     parser.add_argument('--split_code_snippets', action='store_true', default=False,
@@ -503,11 +506,11 @@ def main():
     tr.transform(index_file)
 
     # get a list of existing pages
-    html_files = get_html_files('reference')
+    html_files = get_html_files(args.reference)
 
     # get a mapping between titles and pages
     # linkmap = dict { title -> filename }
-    link_map = build_link_map('reference')
+    link_map = build_link_map(args.reference)
 
     # create a list of processing instructions for each page
     proc_ins = get_processing_instructions(ident_map, link_map)
@@ -538,7 +541,7 @@ def main():
         #print(str(i) + '/' + str(len(proc_ins)) + ': ' + link)
         #i+=1
 
-        root = e.parse('reference/'+fn, parser=html.HTMLParser())
+        root = e.parse(os.path.join(args.reference, fn), parser=html.HTMLParser())
 
         for ident in idents:
 

--- a/lib/fathead/cppreference_doc/cppreference-doc/index2ddg.py
+++ b/lib/fathead/cppreference_doc/cppreference-doc/index2ddg.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+'''
+    Copyright (C) 2013  Povilas Kanapickas <povilas@radix.lt>
+
+    This file is part of cppreference-doc
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+'''
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+import re
+
+import lxml.etree as e
+import lxml.html as html
+
+from index_transform import IndexTransform
+from xml_utils import xml_escape
+from build_link_map import build_link_map
+from ddg_parse_html import get_declarations, get_short_description, DdgException
+
+# Entry types
+# a class or struct
+ITEM_TYPE_CLASS = 1
+
+# a member function or free function
+ITEM_TYPE_FUNCTION = 2
+
+# a constructor
+ITEM_TYPE_CONSTRUCTOR = 3
+
+# a constructor that is described in the same page as the class
+ITEM_TYPE_CONSTRUCTOR_INLINEMEM = 4
+
+# a destructor
+ITEM_TYPE_DESTRUCTOR = 5
+
+# a destructor that is described in the same page as the class
+ITEM_TYPE_DESTRUCTOR_INLINEMEM = 6
+
+# a member function that is described in the same page as the class
+ITEM_TYPE_FUNCTION_INLINEMEM = 7
+
+# an enum
+ITEM_TYPE_ENUM = 8
+
+# a value of an enum
+ITEM_TYPE_ENUM_CONST = 9
+
+# a variable
+ITEM_TYPE_VARIABLE = 10
+
+# a member variable that is described in the same page as the containing class
+ITEM_TYPE_VARIABLE_INLINEMEM = 11
+
+def get_item_type(el):
+    if (el.tag == 'const' and el.getparent().tag == 'enum' and
+        el.get('link') == '.'):
+        return ITEM_TYPE_ENUM_CONST
+    if el.tag == 'function':
+        if el.get('link') == '.':
+            return ITEM_TYPE_FUNCTION_INLINEMEM
+        else:
+            return ITEM_TYPE_FUNCTION
+        if el.tag == 'variable':
+            if el.get('link') == '.':
+                return ITEM_TYPE_VARIABLE_INLINEMEM
+            else:
+                return ITEM_TYPE_VARIABLE
+    if el.tag == 'constructor':
+        if el.get('link') == '.':
+            return ITEM_TYPE_CONSTRUCTOR_INLINEMEM
+        else:
+            return ITEM_TYPE_CONSTRUCTOR
+    if el.tag == 'destructor':
+        if el.get('link') == '.':
+            return ITEM_TYPE_DESTRUCTOR_INLINEMEM
+        else:
+            return ITEM_TYPE_DESTRUCTOR
+    if el.tag == 'class':
+        return ITEM_TYPE_CLASS
+    if el.tag == 'enum':
+        return ITEM_TYPE_ENUM
+    return None # not recognized
+
+class DDGDebug:
+
+    def __init__(self, enabled=False, ident_match=None, debug_abstracts_path=None):
+        self.enabled = enabled
+        self.ident_match = ident_match
+        self.stat_line_nums = []
+        self.debug_abstracts_file = sys.stdout
+        if debug_abstracts_path is not None:
+            self.debug_abstracts_file = open(debug_abstracts_path, 'w', encoding='utf-8')
+
+    # track the statistics of number of lines used by the entries
+    def submit_line_num(self, line_num):
+        while len(self.stat_line_nums) <= line_num:
+            self.stat_line_nums.append(0)
+        self.stat_line_nums[line_num] += 1
+
+    def should_skip_ident(self, ident):
+        if self.ident_match is None:
+            return False
+
+        if isinstance(ident, list):
+            for i in ident:
+                if self.ident_match in i:
+                    return False
+        else:
+            if self.ident_match in ident:
+                return False
+        return True
+
+class Index2DuckDuckGoList(IndexTransform):
+
+    def __init__(self, ident_map):
+        self.ident_map = ident_map
+        super(Index2DuckDuckGoList, self).__init__(ignore_typedefs=True)
+
+    def process_item_hook(self, el, full_name, full_link):
+
+        item_type = get_item_type(el)
+        if item_type:
+            if full_link in self.ident_map:
+                self.ident_map[full_link][full_name] = item_type
+            else:
+                self.ident_map[full_link] = { full_name : item_type }
+        IndexTransform.process_item_hook(self, el, full_name, full_link)
+
+def get_html_files(root):
+    files = []
+    for dir, dirnames, filenames in os.walk(root):
+        for filename in fnmatch.filter(filenames, '*.html'):
+            files.append(os.path.join(dir, filename))
+    return files
+
+def get_processing_instructions(ident_map, link_map):
+    proc_ins = {}
+
+    for link in ident_map:
+        if link in link_map.mapping:
+            fn = link_map.mapping[link]
+            if fn not in proc_ins:
+                proc_ins[fn] = { 'fn': fn, 'link': link, 'idents': {}}
+            for ident in ident_map[link]:
+                proc_ins[fn]['idents'][ident] = { 'ident' : ident,
+                                                  'type' : ident_map[link][ident] }
+    return proc_ins
+
+# process the files
+
+# returns the unqualified name of an identifier
+def get_unqualified_name(ident):
+    if ident.find('(') != -1:
+        ident = re.sub('\(.*?\)', '', ident)
+    if ident.find('<') != -1:
+        ident = re.sub('\<.*?\>', '', ident)
+    qpos = ident.rfind('::')
+    if qpos != -1:
+        ident = ident[qpos+2:]
+    return ident
+
+# returns the version number common to all declarations. Returns none if two
+# declarations have different version numbers or if no version number is
+# provided
+def get_version(decls):
+    rv = None
+    for code,v in decls:
+        if v:
+            if rv == None:
+                rv = v
+            elif v != rv:
+                return None
+    return rv
+
+def build_abstract(decls, desc, max_code_lines, split_code_lines, debug=DDGDebug()):
+
+    limited = False
+    code_snippets = []
+
+    for i,(code,ver) in enumerate(decls):
+        code = code.strip()
+        code = code.replace('<', '&lt;').replace('>', '&gt;')
+        code_num_lines = code.count('\n') + 1
+
+        # limit the number of code snippets to be included so that total number
+        # of lines is less than max_code_lines. The limit becomes active only
+        # for the second and subsequent snippets.
+        first = True if i == 0 else False;
+        last = True if i == len(decls)-1 else False;
+
+        if not first:
+            if last:
+                if code_num_lines > max_code_lines:
+                    limited = True
+                    break
+            else:
+                if code_num_lines > max_code_lines - 1:
+                    # -1 because we need to take into account
+                    # < omitted declarations > message
+                    limited = True
+                    break
+
+        code_snippets.append(code)
+        max_code_lines -= code_num_lines
+
+    if split_code_lines:
+        code_snippets = ['<pre><code>' + s + '</code></pre>' for s in code_snippets]
+        code_text = ''.join(code_snippets)
+    else:
+        code_text = '<pre><code>' + '\n\n'.join(code_snippets) + '</code></pre>'
+
+    if limited:
+        code_text += '\n<p><em>Additional declarations have been omitted</em></p>'
+
+    # count the number of lines used
+    num_lines = code_text.count('\n') + 1 # last line has no newline after it
+    if len(desc) > 110:
+        num_lines += 2
+    else:
+        num_lines += 1
+
+    debug.submit_line_num(num_lines)
+
+    result_lines = [
+        '<section class="prog__container">',
+        '<p>' + desc + '</p>',
+        code_text,
+        '</section>'
+    ]
+    result_text = '\n'.join(result_lines)
+
+    if debug.enabled and num_lines >= 10:
+        print("# error : large number of lines: ")
+        print("# BEGIN ======")
+        print(result_text)
+        print("# END ========")
+    return result_text
+
+''' Outputs additional redirects for an identifier.
+
+    Firstly, we replace '::' with spaces. Then we add two redirects: one with
+    unchanged text and another with '_' replaced with spaces. We strip one
+    level of namespace/class qualification and repeat the process with the
+    remaining text.
+
+    For constructors and destructors, we strip the function name and apply the
+    abovementioned algorithm, the only difference being that we append
+    (or prepend) 'constructor' or 'destructor' to the title of the redirect
+    respectively.
+
+    Each redirect has a 'priority', which is defined by the number of stripped
+    namespace/class qualifications from the entry that produced the redirect.
+    This is used to remove duplicate redirects. For each group of duplicate
+    redirects, we find the redirect with the highest priority (i.e. lowest
+    number of qualifications stripped) and remove all other redirects. If the
+    number of highest-priority redirects is more than one, then we remove all
+    redirects from the group altogether.
+
+    We don't add any redirects to specializations, overloads or operators.
+'''
+''' array of dict { 'title' -> redirect title,
+                    'target' -> redirect target,
+                    'priority' -> redirect priority as int
+                  }
+'''
+
+def build_redirects(redirects, item_ident, item_type):
+
+    for ch in [ '(', ')', '<', '>', 'operator' ]:
+        if ch in item_ident:
+            return
+
+    target = item_ident
+    parts = item_ident.split('::')
+
+    # -----
+    def do_parts(redirects, parts, prepend='', append=''):
+        if prepend != '':
+            prepend = prepend + ' '
+        if append != '':
+            append = ' ' + append
+
+        p = 0
+        while p < len(parts):
+            redir1 = prepend + ' '.join(parts[p:]) + append
+            redir2 = prepend + ' '.join(x.replace('_',' ') for x in parts[p:]) + append
+
+            redir1 = redir1.replace('  ', ' ').replace('  ', ' ')
+            redir2 = redir2.replace('  ', ' ').replace('  ', ' ')
+
+            redirects.append({'title' : redir1, 'target' : target,
+                              'priority' : p})
+            if redir1 != redir2:
+                redirects.append({'title' : redir2, 'target' : target,
+                                'priority' : p})
+            p += 1
+    # -----
+
+    if item_type in [ ITEM_TYPE_CLASS,
+                      ITEM_TYPE_FUNCTION,
+                      ITEM_TYPE_FUNCTION_INLINEMEM,
+                      ITEM_TYPE_VARIABLE,
+                      ITEM_TYPE_VARIABLE_INLINEMEM,
+                      ITEM_TYPE_ENUM,
+                      ITEM_TYPE_ENUM_CONST ]:
+        do_parts(redirects, parts)
+
+    elif item_type in [ ITEM_TYPE_CONSTRUCTOR,
+                        ITEM_TYPE_CONSTRUCTOR_INLINEMEM ]:
+        parts.pop()
+        do_parts(redirects, parts, prepend='constructor')
+        do_parts(redirects, parts, append='constructor')
+    elif item_type in [ ITEM_TYPE_DESTRUCTOR,
+                        ITEM_TYPE_DESTRUCTOR_INLINEMEM ]:
+        parts.pop()
+        do_parts(redirects, parts, prepend='destructor')
+        do_parts(redirects, parts, append='destructor')
+    else:
+        pass    # should not be here
+
+def output_redirects(out, redirects):
+
+    # convert to a convenient data structure
+    # dict { title -> dict { priority -> list ( targets ) } }
+    redir_map = {}
+
+    for r in redirects:
+        title = r['title']
+        target = r['target']
+        priority = r['priority']
+
+        if title not in redir_map:
+            redir_map[title] = {}
+        if priority not in redir_map[title]:
+            redir_map[title][priority] = []
+
+        redir_map[title][priority].append(target)
+
+    # get non-duplicate redirects
+    ok_redirects = [] # list ( dict { 'title' : title, 'target' : target  })
+
+    for title in redir_map:
+        # priority decreases with increasing values
+        highest_prio = min(redir_map[title])
+        if len(redir_map[title][highest_prio]) == 1:
+            # not duplicate
+            target = redir_map[title][highest_prio][0]
+            ok_redirects.append({ 'title' : title, 'target' : target })
+
+    # sort the redirects
+    ok_redirects = sorted(ok_redirects, key=lambda x: x['title'])
+
+    # output
+    for r in ok_redirects:
+        # title
+        line = r['title'] + '\t'
+        # type
+        line += 'R\t'
+        # redirect
+        line += r['target'] + '\t'
+        # otheruses, categories, references, see_also, further_reading,
+        # external links, disambiguation, images, abstract, source url
+        line += '\t\t\t\t\t\t\t\t\t\t\n'
+        out.write(line)
+
+def process_identifier(out, redirects, root, link, item_ident, item_type,
+                       opts, debug=DDGDebug()):
+    # get the name by extracting the unqualified identifier
+    name = get_unqualified_name(item_ident)
+    debug_verbose = True if debug.enabled and debug.ident_match is not None else False
+
+    try:
+        if item_type == ITEM_TYPE_CLASS:
+            decls = get_declarations(root, name)
+            desc = get_short_description(root, get_version(decls), opts.max_sentences, opts.max_characters,
+                                         opts.max_paren_chars, debug=debug_verbose)
+            abstract = build_abstract(decls, desc, opts.max_code_lines,
+                                      opts.split_code_snippets, debug=debug)
+
+        elif item_type in [ ITEM_TYPE_FUNCTION,
+                            ITEM_TYPE_CONSTRUCTOR,
+                            ITEM_TYPE_DESTRUCTOR ]:
+            decls = get_declarations(root, name)
+            desc = get_short_description(root, get_version(decls), opts.max_sentences, opts.max_characters,
+                                         opts.max_paren_chars, debug=debug_verbose)
+            abstract = build_abstract(decls, desc, opts.max_code_lines,
+                                      opts.split_code_snippets, debug=debug)
+
+        elif item_type in [ ITEM_TYPE_FUNCTION_INLINEMEM,
+                            ITEM_TYPE_CONSTRUCTOR_INLINEMEM,
+                            ITEM_TYPE_DESTRUCTOR_INLINEMEM ]:
+            raise DdgException("INLINEMEM") # not implemented
+            ''' Implementation notes:
+                * the declarations are possibly versioned
+                * declaration is selected from the member table
+                * the member table is found according to the identifier
+                  (last part after :: is enough, hopefully)
+            '''
+
+        elif item_type in [ ITEM_TYPE_VARIABLE,
+                            ITEM_TYPE_VARIABLE_INLINEMEM,
+                            ITEM_TYPE_ENUM ]:
+            raise DdgException("ENUM")      # not implemented
+            ''' Implementation notes:
+                * the declarations are possibly versioned
+            '''
+
+        elif item_type == ITEM_TYPE_ENUM_CONST:
+            raise DdgException("ENUM_CONST")    # not implemented
+            ''' Implementation notes:
+                * the abstract will come from the const -> definition table,
+                  which is always put before the first heading.
+                * the declaration will come from the dcl template. We need
+                  to split the content at ';' and ',', then search for the
+                  name of the enum. If we find duplicates, signal an error.
+            '''
+
+        if debug.enabled:
+            debug.debug_abstracts_file.write("--------------\n")
+            debug.debug_abstracts_file.write(item_ident + '\n')
+            debug.debug_abstracts_file.write(abstract + '\n')
+
+        # title
+        line = item_ident + '\t'
+        # type
+        line += 'A\t'
+        # redirect, otheruses, categories, references, see_also,
+        # further_reading, external links, disambiguation, images
+        line += '\t\t\t\t\t\t\t\t\t'
+        # abstract
+        abstract = abstract.replace('\n','\\n')
+        line += abstract + '\t'
+        # source url
+        line += 'http://en.cppreference.com/w/' + link + '\n'
+        out.write(line)
+
+        build_redirects(redirects, item_ident, item_type)
+
+    except DdgException as err:
+        if debug.enabled:
+            line = '# error (' + str(err) + "): " + link + ": " + item_ident + "\n"
+            out.write(line)
+
+def main():
+
+    parser = argparse.ArgumentParser(prog='index2ddg.py')
+    parser.add_argument('index', type=str,
+                        help='The path to the XML index containing identifier data')
+    parser.add_argument('output', type=str,
+                        help='The path to destination output.txt file')
+    parser.add_argument('--split_code_snippets', action='store_true', default=False,
+                        help='Puts each declaration into a separate code snippet.')
+    parser.add_argument('--max_code_lines', type=int, default=6,
+                        help='Maximum number of lines of code to show in abstract')
+    parser.add_argument('--max_sentences', type=int, default=1,
+                        help='Maximum number of sentences to use for the description')
+    parser.add_argument('--max_characters', type=int, default=200,
+                        help='Maximum number of characters to use for the description')
+    parser.add_argument('--max_paren_chars', type=int, default=40,
+                        help='Maximum size of parenthesized text in the description. '+
+                        'Parenthesized chunks longer than that is removed, unless '+
+                        'they are within <code>, <b> or <i> tags')
+    parser.add_argument('--debug', action='store_true', default=False,
+                        help='Enables debug mode.')
+    parser.add_argument('--debug_ident', type=str, default=None,
+                        help='Processes only the identifiers that match debug_ident')
+    parser.add_argument('--debug_abstracts_path', type=str, default=None,
+                        help='Path to print the abstracts before newline stripping occurs')
+    args = parser.parse_args()
+
+    # If a the second argument is 'debug', the program switches to debug mode and
+    # prints everything to stdout. If the third argument is provided, the program
+    # processes only the identifiers that match the provided string
+
+    debug = DDGDebug(args.debug, args.debug_ident, args.debug_abstracts_path)
+
+    index_file = args.index
+    output_file = args.output
+
+    # a map that stores information about location and type of identifiers
+    # it's two level map: full_link maps to a dict that has full_name map to
+    # ITEM_TYPE_* value
+    ident_map = {}
+
+    # get a list of pages to analyze
+    tr = Index2DuckDuckGoList(ident_map)
+    tr.transform(index_file)
+
+    # get a list of existing pages
+    html_files = get_html_files('reference')
+
+    # get a mapping between titles and pages
+    # linkmap = dict { title -> filename }
+    link_map = build_link_map('reference')
+
+    # create a list of processing instructions for each page
+    proc_ins = get_processing_instructions(ident_map, link_map)
+
+    # sort proc_ins to produce ordered output.txt
+    proc_ins = [ v for v in proc_ins.values() ]
+    proc_ins = sorted(proc_ins, key=lambda x: x['link'])
+
+    for page in proc_ins:
+        idents = page['idents']
+        idents = [ v for v in idents.values() ]
+        idents = sorted(idents, key=lambda x: x['ident'])
+        page['idents'] = idents
+
+    redirects = []
+
+    out = open(output_file, 'w', encoding='utf-8')
+
+    #i=1
+    for page in proc_ins:
+        idents = page['idents']
+        link = page['link']
+        fn = page['fn']
+
+        if debug.should_skip_ident([ i['ident'] for i in idents ]):
+            continue
+
+        #print(str(i) + '/' + str(len(proc_ins)) + ': ' + link)
+        #i+=1
+
+        root = e.parse('reference/'+fn, parser=html.HTMLParser())
+
+        for ident in idents:
+
+            item_ident = ident['ident']
+            item_type = ident['type']
+
+            process_identifier(out, redirects, root, link, item_ident, item_type,
+                               args, debug=debug)
+
+    output_redirects(out, redirects)
+
+    if debug.enabled:
+        print('=============================')
+        print('Numbers of lines used:')
+        for i,l in enumerate(debug.stat_line_nums):
+            print(str(i) + ': ' + str(l) + ' result(s)')
+
+if __name__ == "__main__":
+    main()

--- a/lib/fathead/cppreference_doc/cppreference-doc/index_transform.py
+++ b/lib/fathead/cppreference_doc/cppreference-doc/index_transform.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+'''
+    Copyright (C) 2011-2013  Povilas Kanapickas <povilas@radix.lt>
+
+    This file is part of cppreference-doc
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+'''
+
+'''
+    This is a python script for various transformations of the index.
+
+    Concrete transformations can be implemented by subclassing IndexTransform
+    and overriding the provided hooks.
+
+    process_item_hook:
+
+    Called to output information of a feature and continue the processing of the
+    children. By default just processes the children.
+'''
+
+import lxml.etree as e
+import re
+
+class IndexTransform:
+
+    def __init__(self, ignore_typedefs=False, ignore_inherits=False):
+        self.ignore_typedefs = ignore_typedefs
+        self.ignore_inherits = ignore_inherits
+
+    """ Returns the attribute 'attr' of 'el', raises exception on error
+    """
+    def get_attr(self, el, attr):
+        a = el.get(attr)
+        if not a:
+            nm = el.get('name')
+            if nm:
+                nm_str = '( name: ' + nm + ' )'
+            else:
+                nm_str = ''
+            raise Exception('Element \'' + el.tag + '\' does not have attribute \'' +
+                             attr + '\' ' + nm_str)
+        return str(a)
+
+    """ Returns the relative link of 'el' to its parent, if any
+    """
+    def get_link(self, el, default = None):
+        if not default:
+            default = self.get_name(el)
+
+        link = el.get('link')
+        if link == None:
+            return default
+        if link == '.':
+            return ''
+        return str(link)
+
+    """ Appends two possible empty relative links
+    """
+    def link_append(self, el, link, parent_link):
+        if parent_link != '' and link != '':
+            return parent_link + '/' + link
+        return parent_link + link
+
+    """ Returns the absolute link of el
+    """
+    def get_full_link(self, el, parent_link):
+
+        if el.tag == 'typedef':
+            alias_name = el.get('alias')
+            if alias_name:
+                return self.get_link(self.get_alias(el, alias_name))
+            else:
+                return self.link_append(el, self.get_link(el), parent_link)
+
+        elif el.tag == 'constructor':
+            d_link = parent_link.split('/')[-1]
+            return self.link_append(el, self.get_link(el, default=d_link), parent_link)
+
+        elif el.tag == 'destructor':
+            d_link = '~' + parent_link.split('/')[-1]
+            return self.link_append(el, self.get_link(el, default=d_link), parent_link)
+
+        else:
+            return self.link_append(el, self.get_link(el), parent_link)
+
+    """ Returns the name of el """
+    def get_name(self, el):
+        return self.get_attr(el, 'name')
+
+    """ Returns the full name (with the namespace qualification) of el """
+    def get_full_name(self, el, parent_name):
+        if not parent_name and el.tag in ['constructor', 'destructor',
+                                          'overload', 'specialization']:
+            raise Exception('element \'' + el.tag + '\' does not have a parent')
+
+        if el.tag == 'constructor':
+            return parent_name + '::' + parent_name.split('::')[-1]
+        if el.tag == 'destructor':
+            return parent_name + '::~' + parent_name.split('::')[-1]
+        elif el.tag == 'specialization':
+            return self.get_name(el) + '<' + parent_name + '>'
+        elif el.tag == 'overload':
+            return self.get_name(el) + '(' + parent_name + ')'
+        else:
+            name = ''
+            if parent_name:
+                name += parent_name + '::'
+            name += self.get_name(el)
+            return name
+
+    """ Returns the element within the document that has a name that matches
+        'name'
+    """
+    def get_alias(self, el, name):
+        aliases = el.xpath('/index/class[@name = \'' + name + '\'] |' +
+                            '/index/enum[@name = \'' + name + '\']')
+        if len(aliases) == 0:
+            raise Exception('No aliases found for \'' + name + '\'')
+        if len(aliases) > 1:
+            raise Exception('More than one alias found for \'' + name + '\'')
+        return aliases[0]
+
+    """ Processes one item """
+    def process_item(self, el, parent_name, parent_link):
+        if el.tag in ['const','function','class','enum','variable','typedef',
+                      'constructor','destructor','specialization','overload']:
+
+            full_name = self.get_full_name(el, parent_name)
+            full_link = self.get_full_link(el, parent_link)
+
+            self.process_item_hook(el, full_name, full_link)
+
+        elif el.tag == 'inherits' and el.getparent().xpath('child::inherits')[0] == el:
+            if self.ignore_inherits:
+                return
+            pending = el.getparent().xpath('child::inherits')
+            self.inherits_worker(parent_name, pending, list())
+
+    """ Processes children of an item """
+    def process_children(self, el, parent_name, parent_link):
+
+        if el.tag == 'class' or el.tag == 'enum':
+            for child in el:
+                self.process_item(child, parent_name, parent_link)
+        elif el.tag == 'typedef':
+            if self.ignore_typedefs:
+                return
+
+            alias_name = el.get('alias')
+            if alias_name:
+                target = self.get_alias(el, alias_name)
+            else:
+                return
+            link = self.get_link(target)
+            for target_ch in target:
+                self.process_item(target_ch, parent_name, link)
+
+    """ Pulls the contents of the inherited classes. Diamond inheritance is
+        handled properly
+    """
+    def inherits_worker(self, parent_name, pending, finished):
+        if len(pending) == 0:
+            return
+
+        current = pending.pop(0)
+
+        # find the source class/enum
+        source = self.get_alias(current, self.get_attr(current, 'name'))
+
+        if not source in finished:
+            finished.append(source)
+            parent_link = self.get_attr(source, 'link')
+            for source_ch in source:
+                ignore_tags =  ['constructor', 'destructor', 'inherits', 'specialization', 'overload']
+                if source_ch.tag in ignore_tags: pass
+                elif source_ch.tag == 'function' and source_ch.get('name') == 'operator=': pass
+                else:
+                    self.process_item(source_ch, parent_name, parent_link)
+
+        # append new elements
+        more_pending = source.xpath('child::inherits')
+        more_pending = [p for p in more_pending if not p is current]
+        pending.extend(more_pending)
+
+        self.inherits_worker(parent_name, pending, finished)
+
+    """ Transforms the index """
+    def transform(self, fn):
+        root = e.parse(fn)
+        elems = root.xpath('/index/*')
+        for el in elems:
+            self.process_item(el, '', '')
+
+    """ Hooks """
+    def process_item_hook(self, el, full_name, full_link):
+        self.process_children(el, full_name, full_link)

--- a/lib/fathead/cppreference_doc/cppreference-doc/link_map.py
+++ b/lib/fathead/cppreference_doc/cppreference-doc/link_map.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+'''
+    Copyright (C) 2012-2014  Povilas Kanapickas <povilas@radix.lt>
+
+    This file is part of cppreference-doc
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+'''
+
+import lxml.etree as e
+
+class LinkMap:
+    def __init__(self):
+        self.mapping = dict()
+
+    def read(self, fn):
+        root = e.parse(fn)
+        el_files = root.xpath('/files/*')
+
+        self.mapping = dict()
+
+        for el_file in el_files:
+            fn_from = el_file.get('from')
+            fn_to = el_file.get('to')
+            self.mapping[fn_from] = fn_to
+
+    def write(self, fn):
+        root = e.Element('files')
+
+        for key in self.mapping:
+            file_el = e.SubElement(root, 'file')
+            file_el.set('from', key)
+            file_el.set('to', self.mapping[key])
+
+        out = open(fn, 'w', encoding='utf-8')
+        out.write('<?xml version="1.0" encoding="UTF-8"?>')
+        out.write(e.tostring(root, encoding=str, pretty_print=True))
+        out.close()
+
+    # Returns None on failure
+    def get_dest(self, target):
+        if target in self.mapping:
+            return self.mapping[target]
+        return None
+
+    def add_link(self, title, target):
+        self.mapping[title] = target

--- a/lib/fathead/cppreference_doc/cppreference-doc/version.txt
+++ b/lib/fathead/cppreference_doc/cppreference-doc/version.txt
@@ -1,0 +1,1 @@
+https://github.com/p12tic/cppreference-doc ced2260ba95b338c7b37c26306a4e9de9bb855d3

--- a/lib/fathead/cppreference_doc/cppreference-doc/xml_utils.py
+++ b/lib/fathead/cppreference_doc/cppreference-doc/xml_utils.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+'''
+    Copyright (C) 2011-2014  Povilas Kanapickas <povilas@radix.lt>
+
+    This file is part of cppreference-doc
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+'''
+
+xml_escape_table = {
+    "&": "&amp;",
+    '"': "&quot;",
+    "'": "&apos;",
+    ">": "&gt;",
+    "<": "&lt;",
+    }
+
+def xml_escape(text):
+    return "".join(xml_escape_table.get(c,c) for c in text)
+
+def xml_unescape(text):
+    text = text.replace("&quot;", '"')
+    text = text.replace("&apos;", "'")
+    text = text.replace("&gt;", ">")
+    text = text.replace("&lt;", "<")
+    text = text.replace("&amp;", "&")
+    return text

--- a/lib/fathead/cppreference_doc/fetch.sh
+++ b/lib/fathead/cppreference_doc/fetch.sh
@@ -7,4 +7,5 @@ wget upload.cppreference.com/w/Cppreference:DDG-link?action=raw -O cppreference-
 
 wget -i cppreference-link -O cppreference-doc-ddg.tar.gz
 tar -xzf cppreference-doc-ddg.tar.gz
+mv cppreference-doc-20* cppreference-doc
 popd > /dev/null

--- a/lib/fathead/cppreference_doc/parse.sh
+++ b/lib/fathead/cppreference_doc/parse.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# we can use glob since the archive contains a single directory
-pushd download/*/ > /dev/null
-python3 index2ddg.py index-functions-cpp.xml ../../output.txt --split_code_snippets
+pushd cppreference-doc > /dev/null
+python3 index2ddg.py \
+    "../download/cppreference-doc/index-functions-cpp.xml" \
+    "../download/cppreference-doc/reference" \
+    ../output.txt --split_code_snippets
 
 # work around a DDG bug that strips empty parentheses
 # note that we can't just match '()', as that would change identifier names
-sed -e 's/()\([^\t]\)/(void)\1/g' -i ../../output.txt
+sed -e 's/()\([^\t]\)/(void)\1/g' -i ../output.txt
 
 popd > /dev/null


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The strange and inconvenient setup of cppreference_doc fathead parsing plugins has been discussed several times: https://github.com/duckduckgo/zeroclickinfo-fathead/issues/781, https://github.com/duckduckgo/zeroclickinfo-fathead/pull/539. To recap, the current setup is this:
 - create a mirror of cppreference.com using the scripts within cppreference-doc repository
 - upload the resulting archive to cppreference.com
 - download the archive from cppreference.com (fetch.sh)
 - run the parsing scripts within the downloaded archive (parse.sh)

The first two tasks are performed by the cppreference.com maintainers, the last two - by DDG staff or contributors. As a result of this process, any change is inconvenient to develop, as the developer needs to work with both repositories.

Previously I have argued that it makes sense to keep maintaining the parsing scripts in single repository. However, it occurred to me that this shouldn't necessarily mean that the repositories need to be as coupled as they are. The scripts can be kept in both places and as long as there's cooperation and PRs are made then there are no downsides.

This PR copies the DDG parsing scripts from the cppreference-doc repository as of 89745148178ff699a27d58e3972b62fbbe90dbf2 and updates the scripts to use the local copy. output.txt does not change.

## Related Issues and Discussions
(none)

## People to notify
@moollaza, @sahildua2305, @ManrajGrover, @pjhampton

## Testing & Review
To be completed by Language Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - One topic for the Search Space Language (Java, Python, Scala, Ruby, etc.)
    - One topic from: Reference, Help, Libraries, Tools
        - Documentation Fatheads are considered "Reference"
    - Description, Data source, and 2+ example queries
    - Perl Module (e.g. "DDG::Fathead::PerlDoc" -- we only need a name, not an actual file)
    - Source Name (for "More at <source_name>" link)
    - Source Domain (must contain http:// or https:// -- can be the same as Data Source)
    - Source Info (used as Subtitle for each Article -- usually matches the IA Name)
    - 'Skip Abstract' is checked off
    - Source ID (ping @moollaza to assign one, once Fathead is ready for Beta deploy)

**Code**
- [ ] Uniformly indented, well commented
- [ ] Fetch.sh and Parse.sh run without errors
- [ ] Output contains no blank lines, or multi-line entries
- [ ] Fathead Tests are passing (run `$ duckpan test <fathead_id>`)
    - Tester should report any failures

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/cppreference_doc
<!-- FILL THIS IN:                           ^^^^ -->
