### PR TITLE
Apple Docs (macOS): Nuke redirects

### DIFF
--- a/lib/fathead/apple_docs_macos/parse.py
+++ b/lib/fathead/apple_docs_macos/parse.py
@@ -66,18 +66,18 @@ def create_fathead(database):
     # This long SQL query just gets the details about each class and method.
     # ZLANGUAGE = 2 means Swift
     # Note: The SQL query is different between different docsets.
-    for row in c.execute('''SELECT ZTOKENNAME, ZABSTRACT, ZTOKENMETAINFORMATION.ZANCHOR, ZDECLARATION, ZNODEURL.ZPATH, ZTOKENUSR, ZTOKEN.ZTOKENTYPE 
-                            FROM ZTOKEN, ZTOKENMETAINFORMATION, ZNODEURL 
-                            WHERE ZLANGUAGE=2 
-                            AND ZTOKENTYPE IN (2, 3, 7, 8, 15, 16, 17, 19) 
-                            AND ZTOKENMETAINFORMATION.ZTOKEN=ZTOKEN.Z_PK 
-                            AND ZTOKENNAME IS NOT NULL 
-                            AND ZABSTRACT IS NOT NULL 
-                            AND ZTOKENMETAINFORMATION.ZANCHOR IS NOT NULL 
-                            AND ZDECLARATION IS NOT NULL 
-                            AND ZTOKENUSR IS NOT NULL 
-                            AND ZNODEURL.ZNODE=ZTOKEN.ZPARENTNODE 
-                            AND ZNODEURL.ZPATH IS NOT NULL 
+    for row in c.execute('''SELECT ZTOKENNAME, ZABSTRACT, ZTOKENMETAINFORMATION.ZANCHOR, ZDECLARATION, ZNODEURL.ZPATH, ZTOKENUSR, ZTOKEN.ZTOKENTYPE
+                            FROM ZTOKEN, ZTOKENMETAINFORMATION, ZNODEURL
+                            WHERE ZLANGUAGE=2
+                            AND ZTOKENTYPE IN (2, 3, 7, 8, 15, 16, 17, 19)
+                            AND ZTOKENMETAINFORMATION.ZTOKEN=ZTOKEN.Z_PK
+                            AND ZTOKENNAME IS NOT NULL
+                            AND ZABSTRACT IS NOT NULL
+                            AND ZTOKENMETAINFORMATION.ZANCHOR IS NOT NULL
+                            AND ZDECLARATION IS NOT NULL
+                            AND ZTOKENUSR IS NOT NULL
+                            AND ZNODEURL.ZNODE=ZTOKEN.ZPARENTNODE
+                            AND ZNODEURL.ZPATH IS NOT NULL
                             ORDER BY ZTOKENNAME'''):
         name, abstract, anchor, snippet, path, usr, tokentype = row
 
@@ -90,7 +90,7 @@ def create_fathead(database):
             "platform": "Mac",
             "snippet": snippet or "",
         }
-        
+
         # Remove all the tags inside the pre tags.
         snippet = re.sub(r'<[^>]*>', '', snippet)
         pack['snippet'] = "<pre><code>" + snippet + "</code></pre>"
@@ -110,25 +110,6 @@ def create_fathead(database):
             seen_list[pack['name']] = True
         else:
             continue
-
-        # ----------------
-        # Create redirects
-        # ----------------
-        # 
-        # This is where the variable `usr` will come in handy. It has information on whether a certain 
-        # method or variable belongs to a class which makes it useful for queries like "length nsstring",
-        # "nsstring length", or "nsstring.length" 
-
-        p = re.compile('c:objc\(..\)([a-zA-Z]+)\(..\)([a-zA-Z]+)')
-        if p.match(usr):
-            pack['redirect'] = p.findall(usr)
-            cl = pack['redirect'][0][0]
-            prop = pack['redirect'][0][1]
-            pack['name'] = cl + "." + prop
-
-            pack['alt_names'] = [cl + " " + prop, prop + " " + cl, prop]
-        else:
-            pack['redirect'] = None
 
         # Log
         print pack['name']


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->

This IA has quite bad overtriggering. See examples below:

![screen shot 2017-08-16 at 6 51 07 pm](https://user-images.githubusercontent.com/8960296/29377865-07d4425c-82b5-11e7-9a30-a89def01b2ae.png)
![screen shot 2017-08-16 at 6 54 07 pm](https://user-images.githubusercontent.com/8960296/29377866-07d81f26-82b5-11e7-82d4-dedb1c6e73b2.png)
![screen shot 2017-08-16 at 6 51 22 pm](https://user-images.githubusercontent.com/8960296/29377867-07dbe64c-82b5-11e7-86d7-8e210e35dee7.png)

Upon investigating the code and the output it seems to me that the redirects are too liberal and ambigious. See grep output:

![screen shot 2017-08-16 at 7 01 42 pm](https://user-images.githubusercontent.com/8960296/29378017-7a6dfdbc-82b5-11e7-8a08-978620b152a1.png)

As this isn't a popular IA and causing a lot of trouble, it makes sense to just purge the redirects from the output.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 

## Testing & Review
To be completed by Language Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - One topic for the Search Space Language (Java, Python, Scala, Ruby, etc.)
    - One topic from: Reference, Help, Libraries, Tools
        - Documentation Fatheads are considered "Reference"
    - Description, Data source, and 2+ example queries
    - Perl Module (e.g. "DDG::Fathead::PerlDoc" -- we only need a name, not an actual file)
    - Source Name (for "More at <source_name>" link)
    - Source Domain (must contain http:// or https:// -- can be the same as Data Source)
    - Source Info (used as Subtitle for each Article -- usually matches the IA Name)
    - 'Skip Abstract' is checked off
    - Source ID (ping @moollaza to assign one, once Fathead is ready for Beta deploy)

**Code**
- [ ] Uniformly indented, well commented
- [ ] Fetch.sh and Parse.sh run without errors
- [ ] Output contains no blank lines, or multi-line entries
- [ ] Fathead Tests are passing (run `$ duckpan test <fathead_id>`)
    - Tester should report any failures

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/apple_docs_macos
<!-- FILL THIS IN:                           ^^^^ -->
